### PR TITLE
feat: add deployment-registry spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/deployment-registry/.config.kiro
+++ b/.kiro/specs/deployment-registry/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "344d5054-0317-41bf-ad88-2d9c8e0a2ca5", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/deployment-registry/design.md
+++ b/.kiro/specs/deployment-registry/design.md
@@ -1,0 +1,500 @@
+# Design Document: Deployment Registry
+
+## Overview
+
+The Deployment Registry replaces static `.env` files as the authoritative source of truth for Soroban contract addresses across environments. It consists of:
+
+- A PostgreSQL schema with two tables: `deployment_records` and `admin_audit_log`
+- An Express/Node.js HTTP API with four route groups: POST `/deployments`, PATCH `/deployments/:id`, GET `/deployments`, GET `/manifest`
+- An admin authentication middleware (bearer token / API key via `Authorization` header)
+- An in-process read cache with 30-second TTL, invalidated on mutations
+- A Next.js manifest loader that fetches `/manifest` at build time or runtime
+
+The registry is append-friendly: records are created and patched but never hard-deleted. The audit log is strictly append-only at the database permission level.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    FE["Next.js Frontend\n(Manifest Loader)"]
+    BE["Express API Server\n(Node.js / TypeScript)"]
+    DB["PostgreSQL\n(deployment_records\nadmin_audit_log)"]
+    CACHE["In-Process Cache\n(Map + TTL 30s)"]
+    ADMIN["Admin Client\n(curl / CI script)"]
+
+    FE -- "GET /manifest?network=..." --> BE
+    ADMIN -- "POST /deployments\nPATCH /deployments/:id" --> BE
+    BE -- "reads (cache miss)" --> DB
+    BE -- "writes (transaction)" --> DB
+    BE -- "reads (cache hit)" --> CACHE
+    BE -- "invalidate on mutation" --> CACHE
+```
+
+**Request lifecycle for mutations:**
+1. Admin auth middleware validates `Authorization` header
+2. Request body validator checks field formats (Strkey, SemVer, hex hash, network enum)
+3. DB transaction: upsert `deployment_records` row + insert `admin_audit_log` row
+4. On commit: invalidate in-process cache for the affected network
+5. Return 201/200 with the updated record
+
+**Request lifecycle for reads:**
+1. No auth required
+2. Check in-process cache; return cached response if fresh (< 30s)
+3. On cache miss: query DB for `is_active = true` records for the requested network
+4. Populate cache, set `Cache-Control: max-age=30`, return response
+
+---
+
+## Components and Interfaces
+
+### Admin Auth Middleware
+
+```typescript
+// src/middleware/adminAuth.ts
+export function adminAuth(req: Request, res: Response, next: NextFunction): void
+```
+
+- Reads `Authorization: Bearer <token>` header
+- Compares token against `process.env.ADMIN_API_KEY` using a constant-time comparison
+- Returns 401 if header is absent or malformed
+- Returns 403 if token does not match (present but invalid)
+- Applied only to `POST /deployments` and `PATCH /deployments/:id`
+
+### TLS Enforcement Middleware
+
+```typescript
+// src/middleware/requireHttps.ts
+export function requireHttps(req: Request, res: Response, next: NextFunction): void
+```
+
+- Active only when `NODE_ENV === 'production'`
+- Checks `req.secure` or `X-Forwarded-Proto: https`
+- Redirects plaintext requests with HTTP 301 to the HTTPS equivalent URL
+
+### Input Validator
+
+```typescript
+// src/validators/deployment.ts
+export function validateContractAddress(value: string): boolean
+export function validateSemVer(value: string): boolean
+export function validateWasmHash(value: string): boolean
+export function validateNetwork(value: string): value is Network
+export function validateCreateBody(body: unknown): CreateDeploymentDto
+export function validatePatchBody(body: unknown): PatchDeploymentDto
+```
+
+- `validateContractAddress`: checks 56-char length, `C` prefix, and Strkey checksum via `@stellar/stellar-base`
+- `validateSemVer`: uses the `semver` package's `valid()` function
+- `validateWasmHash`: regex `/^[0-9a-f]{64}$/`
+- `validateNetwork`: checks membership in `['mainnet', 'testnet', 'local']`
+- Throws a typed `ValidationError` with field name and expected format on failure; route handlers catch and return HTTP 422
+
+### Route Handlers
+
+```typescript
+// src/routes/deployments.ts
+router.post('/', adminAuth, createDeployment)
+router.patch('/:id', adminAuth, updateDeployment)
+router.get('/', listActiveDeployments)
+
+// src/routes/manifest.ts
+router.get('/', getManifest)
+```
+
+### In-Process Cache
+
+```typescript
+// src/cache/deploymentCache.ts
+interface CacheEntry { data: DeploymentRecord[]; expiresAt: number }
+const store = new Map<Network, CacheEntry>()
+
+export function getCached(network: Network): DeploymentRecord[] | null
+export function setCached(network: Network, data: DeploymentRecord[]): void
+export function invalidate(network: Network): void
+```
+
+- TTL is 30 seconds (`Date.now() + 30_000`)
+- `invalidate` is called inside the mutation handler after the DB transaction commits
+- No external dependency; suitable for single-process deployments
+
+### Manifest Loader (Next.js)
+
+```typescript
+// frontend/src/lib/manifestLoader.ts
+export interface ContractManifest {
+  network: string
+  contracts: Array<{
+    contract_address: string
+    semantic_version: string
+    wasm_hash: string
+    activated_at: string
+  }>
+}
+
+export async function loadManifest(network: string): Promise<ContractManifest>
+```
+
+- Fetches `${NEXT_PUBLIC_REGISTRY_URL}/manifest?network=${network}`
+- Used in Next.js Server Components or `getServerSideProps` for runtime fetching
+- Can also be called in `next.config.mjs` for build-time embedding
+- Throws on non-200 responses; caller handles fallback
+
+---
+
+## Data Models
+
+### PostgreSQL Schema
+
+```sql
+-- Migration: 001_create_deployment_records.sql
+CREATE TYPE network_enum AS ENUM ('mainnet', 'testnet', 'local');
+
+CREATE TABLE deployment_records (
+    id               SERIAL PRIMARY KEY,
+    network          network_enum        NOT NULL,
+    contract_address VARCHAR(56)         NOT NULL,
+    semantic_version VARCHAR(64)         NOT NULL,
+    wasm_hash        CHAR(64)            NOT NULL,
+    activated_at     TIMESTAMPTZ         NOT NULL,
+    is_active        BOOLEAN             NOT NULL DEFAULT true,
+    created_at       TIMESTAMPTZ         NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ         NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uq_network_address
+    ON deployment_records (network, contract_address);
+
+CREATE INDEX idx_network_active
+    ON deployment_records (network, is_active);
+
+-- Auto-update updated_at on row change
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_deployment_records_updated_at
+    BEFORE UPDATE ON deployment_records
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+```
+
+```sql
+-- Migration: 002_create_admin_audit_log.sql
+CREATE TABLE admin_audit_log (
+    id                   SERIAL PRIMARY KEY,
+    actor                VARCHAR(256)  NOT NULL,
+    action               VARCHAR(16)   NOT NULL CHECK (action IN ('create', 'update')),
+    target_id            INTEGER       NOT NULL REFERENCES deployment_records(id),
+    change_payload_hash  CHAR(64)      NOT NULL,
+    source_ip            VARCHAR(45)   NOT NULL,
+    occurred_at          TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- Revoke mutation privileges to enforce append-only semantics
+REVOKE UPDATE, DELETE ON admin_audit_log FROM PUBLIC;
+REVOKE UPDATE, DELETE ON admin_audit_log FROM app_user; -- replace with actual role
+```
+
+### TypeScript Types
+
+```typescript
+// src/types.ts
+export type Network = 'mainnet' | 'testnet' | 'local'
+
+export interface DeploymentRecord {
+  id: number
+  network: Network
+  contract_address: string
+  semantic_version: string
+  wasm_hash: string
+  activated_at: string   // ISO 8601 UTC
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface AuditLogRow {
+  id: number
+  actor: string
+  action: 'create' | 'update'
+  target_id: number
+  change_payload_hash: string
+  source_ip: string
+  occurred_at: string
+}
+
+export interface CreateDeploymentDto {
+  network: Network
+  contract_address: string
+  semantic_version: string
+  wasm_hash: string
+  activated_at: string
+  is_active?: boolean
+}
+
+export interface PatchDeploymentDto {
+  contract_address?: string
+  semantic_version?: string
+  wasm_hash?: string
+  activated_at?: string
+  is_active?: boolean
+}
+```
+
+### Seed Migration
+
+```sql
+-- Migration: 003_seed_dev_data.sql
+-- Skipped automatically when NODE_ENV=production (enforced in migration runner)
+DO $$
+BEGIN
+  IF current_setting('app.environment', true) = 'production' THEN
+    RAISE WARNING 'Seed migration skipped in production environment';
+    RETURN;
+  END IF;
+
+  INSERT INTO deployment_records
+    (network, contract_address, semantic_version, wasm_hash, activated_at, is_active)
+  VALUES
+    ('local',   'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                '0.1.0', 'aabbcc' || repeat('0', 58), NOW(), true),
+    ('testnet', 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+                '0.1.0', 'ddeeff' || repeat('0', 58), NOW(), true)
+  ON CONFLICT (network, contract_address) DO NOTHING;
+END;
+$$;
+```
+
+The migration runner checks `NODE_ENV` before executing file `003_seed_dev_data.sql` and skips it with a logged warning when `NODE_ENV === 'production'`.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Unique constraint prevents duplicate (network, contract_address) pairs
+
+*For any* two POST requests that share the same `network` and `contract_address`, the second request SHALL be rejected with HTTP 409, regardless of the other field values.
+
+**Validates: Requirements 1.2, 3.6, 4.6**
+
+---
+
+### Property 2: Timestamps are set automatically on insert and update
+
+*For any* inserted Deployment_Record, `created_at` and `updated_at` SHALL be set to the current UTC time. *For any* subsequent update to that record, `updated_at` SHALL be greater than or equal to its previous value and `created_at` SHALL remain unchanged.
+
+**Validates: Requirements 1.4, 1.5**
+
+---
+
+### Property 3: Auth middleware rejects requests without valid admin credentials
+
+*For any* request to a mutation endpoint (`POST /deployments`, `PATCH /deployments/:id`), if the `Authorization` header is absent the response SHALL be HTTP 401; if the header is present but the token does not match the configured admin key the response SHALL be HTTP 403.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+---
+
+### Property 4: Strkey contract address validation
+
+*For any* string submitted as `contract_address`, the validator SHALL accept it if and only if it is exactly 56 characters, begins with `C`, and passes Stellar Strkey checksum validation. Strings beginning with `G` (valid account addresses) SHALL be rejected even if otherwise well-formed.
+
+**Validates: Requirements 3.2, 4.2, 8.1, 8.3**
+
+---
+
+### Property 5: SemVer validation rejects non-conforming version strings
+
+*For any* string submitted as `semantic_version` that does not conform to SemVer 2.0, the validator SHALL reject the request with HTTP 422.
+
+**Validates: Requirements 3.3, 4.3**
+
+---
+
+### Property 6: WASM hash validation rejects non-hex or wrong-length strings
+
+*For any* string submitted as `wasm_hash` that is not exactly 64 lowercase hexadecimal characters, the validator SHALL reject the request with HTTP 422.
+
+**Validates: Requirements 3.4, 4.4**
+
+---
+
+### Property 7: Network enum validation rejects unknown network values
+
+*For any* string submitted as the `network` field or query parameter that is not one of `mainnet`, `testnet`, or `local`, the API SHALL return HTTP 422.
+
+**Validates: Requirements 3.5, 6.2, 7.2**
+
+---
+
+### Property 8: POST creates a record and returns it
+
+*For any* valid `CreateDeploymentDto`, a POST to `/deployments` SHALL return HTTP 201 and a response body whose fields match the submitted values (modulo server-assigned `id`, `created_at`, `updated_at`).
+
+**Validates: Requirements 3.1**
+
+---
+
+### Property 9: PATCH applies only supplied fields
+
+*For any* existing Deployment_Record and any valid `PatchDeploymentDto`, a PATCH to `/deployments/:id` SHALL return HTTP 200 and a response body where only the supplied fields differ from the pre-patch record; all other fields SHALL remain unchanged.
+
+**Validates: Requirements 4.1**
+
+---
+
+### Property 10: Mutation atomically writes audit log row with all required fields
+
+*For any* successful mutation (POST or PATCH), exactly one row SHALL be inserted into `admin_audit_log` within the same transaction, containing non-null values for `actor`, `action`, `target_id`, `change_payload_hash`, `source_ip`, and `occurred_at`. If the transaction rolls back, no audit row SHALL be persisted.
+
+**Validates: Requirements 5.1, 5.2, 5.4**
+
+---
+
+### Property 11: Source IP recorded from X-Forwarded-For with fallback
+
+*For any* mutation request, the `source_ip` stored in the audit log SHALL equal the first value in the `X-Forwarded-For` header when that header is present, and SHALL equal the TCP remote address when the header is absent.
+
+**Validates: Requirements 5.5**
+
+---
+
+### Property 12: GET /deployments returns only active records for the requested network
+
+*For any* network value in `{mainnet, testnet, local}`, a GET to `/deployments?network=<network>` SHALL return a JSON array containing exactly the Deployment_Records where `is_active = true` and `network` matches the query parameter — no records from other networks and no inactive records.
+
+**Validates: Requirements 6.1**
+
+---
+
+### Property 13: Cache-Control header is present on read responses
+
+*For any* successful GET `/deployments` or GET `/manifest` response, the `Cache-Control` header SHALL be present and SHALL include `max-age=30`.
+
+**Validates: Requirements 6.4, 7.4**
+
+---
+
+### Property 14: Cache invalidation ensures post-mutation reads are fresh
+
+*For any* network, after a successful mutation affecting that network, the next GET `/deployments?network=<network>` response SHALL reflect the mutated state (i.e., the in-process cache entry for that network SHALL have been invalidated).
+
+**Validates: Requirements 6.5**
+
+---
+
+### Property 15: Manifest response shape is correct for all networks
+
+*For any* valid network, a GET to `/manifest?network=<network>` SHALL return a JSON object with a `network` string field equal to the query parameter and a `contracts` array where each element contains `contract_address`, `semantic_version`, `wasm_hash`, and `activated_at`. When no active records exist, `contracts` SHALL be an empty array and the status SHALL be HTTP 200.
+
+**Validates: Requirements 7.1, 7.5**
+
+---
+
+### Property 16: Seed migration is idempotent
+
+*For any* number of times the seed migration is run in a non-production environment, the resulting `deployment_records` table SHALL contain exactly one row for `network = local` and one for `network = testnet` with the seed addresses — no duplicates.
+
+**Validates: Requirements 9.3**
+
+---
+
+## Error Handling
+
+| Scenario | HTTP Status | Response body |
+|---|---|---|
+| Missing/malformed `Authorization` header | 401 | `{ "error": "Unauthorized" }` |
+| Valid header, wrong token | 403 | `{ "error": "Forbidden" }` |
+| Invalid field value (address, version, hash, network) | 422 | `{ "error": "Validation failed", "field": "<name>", "message": "<detail>" }` |
+| `(network, contract_address)` already exists | 409 | `{ "error": "Conflict", "message": "Deployment record already exists for this network and address" }` |
+| Record `id` not found on PATCH | 404 | `{ "error": "Not found" }` |
+| DB connection failure | 500 | `{ "error": "Internal server error" }` |
+| Plaintext HTTP in production | 301 | Redirect to HTTPS equivalent |
+
+All error responses set `Content-Type: application/json`.
+
+The mutation handler wraps the DB transaction in a try/catch. On any DB error the transaction is rolled back (both the `deployment_records` write and the `admin_audit_log` write are undone). The route handler then maps the error to the appropriate HTTP status.
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are required. They are complementary:
+
+- **Unit tests** cover specific examples, integration points, and edge cases (e.g., the G-address rejection, the empty-contracts manifest, the production seed skip, the 301 redirect).
+- **Property-based tests** verify universal invariants across randomly generated inputs (e.g., any invalid address is rejected, any valid POST round-trips correctly).
+
+### Property-Based Testing Library
+
+Use **`fast-check`** (TypeScript-native, works with Jest):
+
+```bash
+npm install --save-dev fast-check
+```
+
+Each property test runs a minimum of **100 iterations** (`{ numRuns: 100 }`).
+
+Each test is tagged with a comment referencing the design property:
+
+```typescript
+// Feature: deployment-registry, Property 4: Strkey contract address validation
+it('rejects non-C-prefix addresses', () => {
+  fc.assert(
+    fc.property(fc.string(), (addr) => {
+      fc.pre(!isValidContractAddress(addr))
+      expect(validateContractAddress(addr)).toBe(false)
+    }),
+    { numRuns: 100 }
+  )
+})
+```
+
+### Property Test Coverage
+
+Each correctness property (1–16) SHALL be implemented by exactly one property-based test:
+
+| Property | Test description |
+|---|---|
+| P1 | Duplicate (network, address) POST returns 409 |
+| P2 | Inserted record has correct timestamps; update advances updated_at |
+| P3 | Mutation endpoints return 401/403 for missing/invalid tokens |
+| P4 | Strkey validator accepts only valid C-addresses, rejects G-addresses |
+| P5 | SemVer validator rejects non-conforming version strings |
+| P6 | Hash validator rejects non-64-char or non-lowercase-hex strings |
+| P7 | Network validator rejects strings outside the enum |
+| P8 | Valid POST returns 201 with matching record fields |
+| P9 | PATCH only mutates supplied fields |
+| P10 | Successful mutation always produces an audit row; rollback removes both |
+| P11 | Audit log records correct source IP from header or fallback |
+| P12 | GET /deployments returns only active records for the queried network |
+| P13 | Cache-Control: max-age=30 present on all read responses |
+| P14 | Post-mutation read reflects updated state |
+| P15 | Manifest shape is correct; empty network returns empty contracts array |
+| P16 | Seed migration is idempotent across multiple runs |
+
+### Unit Test Coverage
+
+- Admin auth middleware: missing header → 401, wrong token → 403, correct token → passes through
+- TLS middleware: plaintext in production → 301, HTTPS in production → passes through, any in non-production → passes through
+- G-address rejection (edge case of P4)
+- Empty manifest response (edge case of P15)
+- Seed skip in production (Requirement 9.2)
+- Audit log DELETE/UPDATE rejection (Requirement 5.3)
+- PATCH on non-existent ID → 404
+
+### Integration Tests
+
+A test PostgreSQL instance (via `pg` + Docker Compose or `testcontainers`) is used for:
+- Transaction rollback atomicity (P10)
+- Cache invalidation after mutation (P14)
+- Seed idempotency (P16)
+- Unique constraint enforcement (P1)

--- a/.kiro/specs/deployment-registry/requirements.md
+++ b/.kiro/specs/deployment-registry/requirements.md
@@ -1,0 +1,160 @@
+# Requirements Document
+
+## Introduction
+
+The Deployment Registry is a backend service that persists authoritative mappings from environment/network to deployed Soroban contract addresses, semantic versions, activation timestamps, and expected WASM content hashes. It replaces static `.env` files as the source of truth when operating multiple environments (testnet, mainnet, local) or rotating deployments. The registry exposes admin-protected mutation endpoints, an append-only audit log mirroring on-chain admin events, and a read API consumed by the Next.js manifest loader.
+
+## Glossary
+
+- **Registry**: The backend subsystem (database tables + HTTP API) that stores and serves deployment records.
+- **Deployment_Record**: A single row representing one contract deployment on one network, containing address, version, activation timestamp, and WASM hash.
+- **Network**: A Stellar network identifier string, one of `mainnet`, `testnet`, or `local`.
+- **Contract_Address**: A Stellar Strkey-encoded contract address (56-character `C…` string).
+- **Wasm_Hash**: A lowercase hex-encoded SHA-256 hash of the deployed WASM binary (64 characters).
+- **Semantic_Version**: A version string conforming to SemVer 2.0 (e.g. `1.2.3`).
+- **Admin**: An authenticated operator holding a valid admin credential (API key or JWT) permitted to mutate deployment records.
+- **Audit_Log**: An append-only table (`admin_audit_log`) recording every mutation with actor identity, timestamp, source IP, and a hash of the change payload.
+- **Manifest**: A JSON document returned by the read API describing the active deployment(s) for a given network, consumed by the Next.js frontend.
+- **Manifest_Loader**: The Next.js module that fetches the Manifest from the Registry read API at build time or runtime.
+- **TTL**: Time-to-live duration for a cached read response.
+- **API_Server**: The Express/Node.js backend process hosting the Registry HTTP endpoints.
+- **DB**: The relational database (PostgreSQL) storing `deployment_records` and `admin_audit_log` tables.
+- **Validator**: The request-validation layer inside the API_Server that checks input shapes and Stellar address formats before persistence.
+
+---
+
+## Requirements
+
+### Requirement 1: Deployment Record Storage
+
+**User Story:** As an operator, I want deployment records stored in a relational database with indexes on network and active flag, so that queries for active deployments on a given network are fast and consistent.
+
+#### Acceptance Criteria
+
+1. THE DB SHALL store each Deployment_Record with the fields: `id` (surrogate primary key), `network` (Network enum), `contract_address` (Contract_Address), `semantic_version` (Semantic_Version), `wasm_hash` (Wasm_Hash), `activated_at` (UTC timestamp), `is_active` (boolean), `created_at` (UTC timestamp), and `updated_at` (UTC timestamp).
+2. THE DB SHALL enforce a unique constraint on `(network, contract_address)` to prevent duplicate address registrations per network.
+3. THE DB SHALL maintain an index on `(network, is_active)` to support efficient active-deployment lookups.
+4. WHEN a new Deployment_Record is inserted, THE DB SHALL set `created_at` and `updated_at` to the current UTC time automatically.
+5. WHEN a Deployment_Record is updated, THE DB SHALL set `updated_at` to the current UTC time automatically.
+
+---
+
+### Requirement 2: Admin Authentication and Authorization
+
+**User Story:** As a security engineer, I want all mutation endpoints protected by strong authentication, so that unauthorized clients cannot alter deployment records.
+
+#### Acceptance Criteria
+
+1. WHEN a request arrives at a mutation endpoint without a valid admin credential, THE API_Server SHALL reject the request with HTTP 401.
+2. WHEN a request arrives at a mutation endpoint with a credential that is valid but lacks admin privileges, THE API_Server SHALL reject the request with HTTP 403.
+3. THE API_Server SHALL accept admin credentials as a bearer token (JWT or opaque API key) supplied in the `Authorization` header.
+4. WHERE the environment is `production`, THE API_Server SHALL require TLS on all inbound connections and SHALL reject plaintext HTTP requests with HTTP 301 redirect to HTTPS.
+5. THE API_Server SHALL validate admin credentials against a secret stored in environment variables, not in source code or the DB.
+
+---
+
+### Requirement 3: Create Deployment Record (POST)
+
+**User Story:** As an admin, I want to register a new deployment via a POST endpoint, so that the registry reflects newly deployed contracts.
+
+#### Acceptance Criteria
+
+1. WHEN an Admin submits a POST request to `/deployments` with a valid body, THE API_Server SHALL create a new Deployment_Record and return HTTP 201 with the created record.
+2. WHEN the request body contains a `contract_address` that is not a valid Stellar Strkey contract address, THE Validator SHALL reject the request with HTTP 422 and a descriptive error message identifying the invalid field.
+3. WHEN the request body contains a `semantic_version` that does not conform to SemVer 2.0, THE Validator SHALL reject the request with HTTP 422 and a descriptive error message.
+4. WHEN the request body contains a `wasm_hash` that is not a 64-character lowercase hex string, THE Validator SHALL reject the request with HTTP 422 and a descriptive error message.
+5. WHEN the request body contains a `network` value outside the set `{mainnet, testnet, local}`, THE Validator SHALL reject the request with HTTP 422 and a descriptive error message.
+6. WHEN a POST request would violate the unique constraint on `(network, contract_address)`, THE API_Server SHALL return HTTP 409 with a descriptive conflict message.
+
+---
+
+### Requirement 4: Update Deployment Record (PATCH)
+
+**User Story:** As an admin, I want to update an existing deployment record via a PATCH endpoint, so that I can rotate addresses, bump versions, or toggle the active flag without replacing the full record.
+
+#### Acceptance Criteria
+
+1. WHEN an Admin submits a PATCH request to `/deployments/:id` with a valid partial body, THE API_Server SHALL apply only the supplied fields to the Deployment_Record and return HTTP 200 with the updated record.
+2. WHEN the PATCH body includes `contract_address`, THE Validator SHALL validate it as a Stellar Strkey contract address before applying the update.
+3. WHEN the PATCH body includes `semantic_version`, THE Validator SHALL validate it against SemVer 2.0 before applying the update.
+4. WHEN the PATCH body includes `wasm_hash`, THE Validator SHALL validate it as a 64-character lowercase hex string before applying the update.
+5. WHEN a PATCH request targets a Deployment_Record `id` that does not exist, THE API_Server SHALL return HTTP 404.
+6. WHEN a PATCH request would violate the unique constraint on `(network, contract_address)`, THE API_Server SHALL return HTTP 409.
+
+---
+
+### Requirement 5: Audit Logging
+
+**User Story:** As a compliance officer, I want every admin mutation recorded in an append-only audit log, so that the audit trail can reconstruct who changed what and when.
+
+#### Acceptance Criteria
+
+1. WHEN an Admin mutation (POST or PATCH) succeeds, THE API_Server SHALL insert a row into `admin_audit_log` within the same database transaction as the Deployment_Record change.
+2. THE DB SHALL store each audit row with: `id` (surrogate primary key), `actor` (the authenticated admin identity string), `action` (one of `create` or `update`), `target_id` (the affected Deployment_Record id), `change_payload_hash` (SHA-256 hex of the serialized change payload), `source_ip` (the client IP address string), and `occurred_at` (UTC timestamp).
+3. THE DB SHALL prohibit DELETE and UPDATE operations on `admin_audit_log` rows via database-level permissions, enforcing append-only semantics.
+4. WHEN the database transaction for a mutation fails, THE API_Server SHALL roll back both the Deployment_Record change and the audit row atomically, so no partial audit entries are persisted.
+5. THE API_Server SHALL record the `source_ip` from the `X-Forwarded-For` header when present, falling back to the direct connection remote address.
+
+---
+
+### Requirement 6: Read API — Active Deployments
+
+**User Story:** As a frontend developer, I want a read endpoint that returns active deployment records for a given network, so that the Next.js Manifest_Loader can fetch the correct contract addresses at runtime.
+
+#### Acceptance Criteria
+
+1. WHEN a GET request is made to `/deployments?network=<Network>`, THE API_Server SHALL return HTTP 200 with a JSON array of all Deployment_Records where `is_active = true` for the specified network.
+2. WHEN the `network` query parameter is absent or invalid, THE API_Server SHALL return HTTP 422 with a descriptive error.
+3. THE API_Server SHALL serve the GET `/deployments` endpoint without requiring admin credentials, permitting unauthenticated read access.
+4. THE API_Server SHALL include a `Cache-Control` header with a TTL of 30 seconds on successful GET `/deployments` responses.
+5. WHEN an Admin mutation succeeds, THE API_Server SHALL invalidate any in-process cache entries for the affected network so subsequent reads reflect the updated state within one TTL cycle.
+
+---
+
+### Requirement 7: Manifest Endpoint
+
+**User Story:** As a frontend developer, I want a dedicated manifest endpoint that returns a structured JSON document, so that the Next.js Manifest_Loader can consume a stable, typed contract for building frontend configuration.
+
+#### Acceptance Criteria
+
+1. WHEN a GET request is made to `/manifest?network=<Network>`, THE API_Server SHALL return HTTP 200 with a JSON object containing a `network` field and a `contracts` array, where each element includes `contract_address`, `semantic_version`, `wasm_hash`, and `activated_at`.
+2. WHEN the `network` query parameter is absent or invalid, THE API_Server SHALL return HTTP 422 with a descriptive error.
+3. THE API_Server SHALL serve GET `/manifest` without requiring admin credentials.
+4. THE API_Server SHALL set `Content-Type: application/json` on all `/manifest` responses.
+5. WHEN no active Deployment_Records exist for the requested network, THE API_Server SHALL return HTTP 200 with a JSON object containing an empty `contracts` array, not HTTP 404.
+
+---
+
+### Requirement 8: Input Validation — Stellar Address Format
+
+**User Story:** As a developer, I want the API to validate Stellar contract addresses strictly, so that malformed addresses are never persisted and on-chain lookups always succeed.
+
+#### Acceptance Criteria
+
+1. THE Validator SHALL accept a `contract_address` only if it is a 56-character string beginning with `C` and passing Stellar Strkey checksum validation.
+2. WHEN a `contract_address` fails Strkey checksum validation, THE Validator SHALL return a descriptive error message that identifies the field and states the expected format.
+3. THE Validator SHALL reject `contract_address` values that are valid Strkey account addresses (beginning with `G`) rather than contract addresses (beginning with `C`).
+
+---
+
+### Requirement 9: Development Seed Data
+
+**User Story:** As a developer, I want seed data for local and testnet environments applied via migration scripts, so that the development environment is immediately usable without manual database setup.
+
+#### Acceptance Criteria
+
+1. THE DB SHALL include a seed migration that inserts at least one Deployment_Record for `network = local` and one for `network = testnet` with placeholder `contract_address`, `semantic_version`, `wasm_hash`, and `activated_at` values.
+2. WHEN the seed migration is run in a `production` environment, THE API_Server SHALL skip the seed insertion and log a warning, leaving production data unmodified.
+3. THE DB seed migration SHALL be idempotent: running it multiple times SHALL NOT create duplicate Deployment_Records.
+
+---
+
+### Requirement 10: Release Runbook Integration
+
+**User Story:** As a DevOps engineer, I want documented procedures for updating the registry as part of a contract release, so that deployments are consistently recorded and the registry stays in sync with on-chain state.
+
+#### Acceptance Criteria
+
+1. THE Registry documentation SHALL describe the sequence of steps an operator must follow after deploying a new contract version: obtain the new `contract_address` and `wasm_hash`, call the POST endpoint, verify the response, and deactivate the previous record via PATCH.
+2. THE Registry documentation SHALL specify the environment variables required for admin authentication in each environment (`local`, `testnet`, `mainnet`).
+3. THE Registry documentation SHALL include an example `curl` command for each mutation endpoint showing required headers and a valid request body.

--- a/.kiro/specs/deployment-registry/tasks.md
+++ b/.kiro/specs/deployment-registry/tasks.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Deployment Registry
+
+## Overview
+
+Implement the Deployment Registry as a TypeScript/Express backend service with PostgreSQL persistence, an in-process cache, admin auth middleware, input validators, and a Next.js manifest loader. Tasks are ordered so each step builds on the previous and nothing is left unwired.
+
+## Tasks
+
+- [ ] 1. PostgreSQL migrations
+  - [ ] 1.1 Create `001_create_deployment_records.sql`
+    - Define `network_enum` type and `deployment_records` table with all columns from the data model
+    - Add unique index `uq_network_address` on `(network, contract_address)`
+    - Add index `idx_network_active` on `(network, is_active)`
+    - Add `set_updated_at()` trigger function and `trg_deployment_records_updated_at` trigger
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+  - [ ] 1.2 Create `002_create_admin_audit_log.sql`
+    - Define `admin_audit_log` table with all columns from the data model
+    - Add `CHECK (action IN ('create', 'update'))` constraint
+    - Add `REVOKE UPDATE, DELETE` statements to enforce append-only semantics
+    - _Requirements: 5.2, 5.3_
+  - [ ] 1.3 Create `003_seed_dev_data.sql`
+    - Insert one `local` and one `testnet` placeholder record using `ON CONFLICT DO NOTHING`
+    - Wrap in a `DO $$ BEGIN IF ... THEN RAISE WARNING ... RETURN; END IF; ... END; $$` block that checks `app.environment`
+    - _Requirements: 9.1, 9.2, 9.3_
+
+- [ ] 2. TypeScript types and DTOs
+  - [ ] 2.1 Create `backend/src/types.ts`
+    - Define `Network` union type, `DeploymentRecord`, `AuditLogRow`, `CreateDeploymentDto`, `PatchDeploymentDto` interfaces
+    - Define `ValidationError` class with `field` and `message` properties
+    - _Requirements: 1.1, 3.1, 4.1_
+
+- [ ] 3. Input validators
+  - [ ] 3.1 Create `backend/src/validators/deployment.ts`
+    - Implement `validateContractAddress` using `@stellar/stellar-base` Strkey checksum (56-char, `C` prefix, rejects `G` prefix)
+    - Implement `validateSemVer` using `semver` package's `valid()` function
+    - Implement `validateWasmHash` using regex `/^[0-9a-f]{64}$/`
+    - Implement `validateNetwork` as a type guard against `['mainnet', 'testnet', 'local']`
+    - Implement `validateCreateBody` and `validatePatchBody` that throw `ValidationError` on failure
+    - _Requirements: 3.2, 3.3, 3.4, 3.5, 4.2, 4.3, 4.4, 8.1, 8.2, 8.3_
+  - [ ] 3.2 Write property tests for validators
+    - **Property 4: Strkey contract address validation** — `fc.string()` inputs; assert accept iff 56-char `C`-prefix valid Strkey, reject `G`-prefix
+    - **Property 5: SemVer validation rejects non-conforming version strings**
+    - **Property 6: WASM hash validation rejects non-hex or wrong-length strings**
+    - **Property 7: Network enum validation rejects unknown network values**
+    - **Validates: Requirements 3.2, 3.3, 3.4, 3.5, 4.2, 4.3, 4.4, 8.1, 8.3**
+    - Tag each test with `// Feature: deployment-registry, Property N: ...`
+    - Use `{ numRuns: 100 }` for all `fc.assert` calls
+
+- [ ] 4. Admin auth and TLS middleware
+  - [ ] 4.1 Create `backend/src/middleware/adminAuth.ts`
+    - Read `Authorization: Bearer <token>` header; return 401 if absent/malformed
+    - Compare token against `process.env.ADMIN_API_KEY` using `crypto.timingSafeEqual`; return 403 on mismatch
+    - _Requirements: 2.1, 2.2, 2.3, 2.5_
+  - [ ] 4.2 Create `backend/src/middleware/requireHttps.ts`
+    - No-op when `NODE_ENV !== 'production'`
+    - Check `req.secure` or `X-Forwarded-Proto: https`; issue HTTP 301 redirect to HTTPS equivalent otherwise
+    - _Requirements: 2.4_
+  - [ ] 4.3 Write unit tests for auth and TLS middleware
+    - `adminAuth`: missing header → 401, wrong token → 403, correct token → `next()` called
+    - `requireHttps`: plaintext in production → 301, HTTPS in production → `next()`, any in non-production → `next()`
+    - **Property 3: Auth middleware rejects requests without valid admin credentials**
+    - **Validates: Requirements 2.1, 2.2, 2.3, 2.4**
+
+- [ ] 5. In-process cache module
+  - [ ] 5.1 Create `backend/src/cache/deploymentCache.ts`
+    - Implement `Map<Network, CacheEntry>` store with `{ data, expiresAt }` entries
+    - Implement `getCached(network)` returning `null` when entry is absent or `Date.now() > expiresAt`
+    - Implement `setCached(network, data)` setting `expiresAt = Date.now() + 30_000`
+    - Implement `invalidate(network)` deleting the entry for that network
+    - _Requirements: 6.4, 6.5_
+
+- [ ] 6. Database client and migration runner
+  - [ ] 6.1 Create `backend/src/db/client.ts`
+    - Export a `pg.Pool` instance configured from `DATABASE_URL` environment variable
+    - _Requirements: 1.1_
+  - [ ] 6.2 Create `backend/src/db/migrate.ts`
+    - Read SQL files from `migrations/` directory in order
+    - Skip `003_seed_dev_data.sql` when `NODE_ENV === 'production'` and log a warning
+    - Execute each migration in a transaction; track applied migrations in a `schema_migrations` table
+    - _Requirements: 9.2_
+
+- [ ] 7. POST /deployments route handler
+  - [ ] 7.1 Create `backend/src/routes/deployments.ts` with `createDeployment` handler
+    - Call `validateCreateBody`; catch `ValidationError` and return 422
+    - Open a `pg` transaction: INSERT into `deployment_records`, INSERT into `admin_audit_log`
+    - Compute `change_payload_hash` as SHA-256 hex of the serialized request body
+    - Extract `source_ip` from `X-Forwarded-For` header with fallback to `req.socket.remoteAddress`
+    - On unique constraint violation (`23505`) return 409; on other DB errors return 500
+    - On commit: call `invalidate(network)`, return 201 with the created record
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 5.1, 5.2, 5.4, 5.5_
+  - [ ] 7.2 Write property tests for POST /deployments
+    - **Property 1: Unique constraint prevents duplicate (network, contract_address) pairs** — generate valid DTOs with same network+address, assert second POST returns 409
+    - **Property 8: POST creates a record and returns it** — generate valid `CreateDeploymentDto`, assert 201 and response fields match submitted values
+    - **Property 10: Mutation atomically writes audit log row** — assert audit row exists after success; assert no audit row after forced rollback
+    - **Property 11: Source IP recorded from X-Forwarded-For with fallback**
+    - **Validates: Requirements 3.1, 3.6, 5.1, 5.2, 5.4, 5.5**
+
+- [ ] 8. PATCH /deployments/:id route handler
+  - [ ] 8.1 Add `updateDeployment` handler to `backend/src/routes/deployments.ts`
+    - Call `validatePatchBody`; catch `ValidationError` and return 422
+    - Open a `pg` transaction: UPDATE `deployment_records` for the given `id`, INSERT into `admin_audit_log`
+    - Return 404 when UPDATE affects 0 rows; return 409 on unique constraint violation
+    - On commit: call `invalidate(network)`, return 200 with the updated record
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.4_
+  - [ ] 8.2 Write property tests for PATCH /deployments/:id
+    - **Property 9: PATCH applies only supplied fields** — generate existing record + partial DTO, assert only supplied fields changed
+    - **Validates: Requirements 4.1**
+
+- [ ] 9. GET /deployments route handler
+  - [ ] 9.1 Add `listActiveDeployments` handler to `backend/src/routes/deployments.ts`
+    - Validate `network` query param; return 422 if absent or invalid
+    - Check `getCached(network)`; on hit return cached data with `Cache-Control: max-age=30`
+    - On miss: query `deployment_records WHERE is_active = true AND network = $1`, call `setCached`, return with `Cache-Control: max-age=30`
+    - No auth required
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+  - [ ] 9.2 Write property tests for GET /deployments
+    - **Property 12: GET /deployments returns only active records for the requested network** — seed mixed records, assert response contains only `is_active=true` rows for queried network
+    - **Property 13: Cache-Control header is present on read responses** — assert `Cache-Control: max-age=30` on every successful GET
+    - **Property 14: Cache invalidation ensures post-mutation reads are fresh** — mutate then GET, assert response reflects mutation
+    - **Validates: Requirements 6.1, 6.4, 6.5**
+
+- [ ] 10. GET /manifest route handler
+  - [ ] 10.1 Create `backend/src/routes/manifest.ts` with `getManifest` handler
+    - Validate `network` query param; return 422 if absent or invalid
+    - Check cache; on miss query active records for network
+    - Shape response as `{ network, contracts: [{ contract_address, semantic_version, wasm_hash, activated_at }] }`
+    - Return 200 with empty `contracts` array when no active records exist
+    - Set `Content-Type: application/json` and `Cache-Control: max-age=30`
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+  - [ ] 10.2 Write property tests for GET /manifest
+    - **Property 15: Manifest response shape is correct for all networks** — for each valid network assert shape; assert empty-contracts 200 when no active records
+    - **Validates: Requirements 7.1, 7.5**
+
+- [ ] 11. Wire routes into Express app
+  - [ ] 11.1 Update `backend/src/index.ts`
+    - Register `requireHttps` as global middleware
+    - Mount `deployments` router at `/deployments` (with `adminAuth` on POST and PATCH)
+    - Mount `manifest` router at `/manifest`
+    - Add global error handler that maps `ValidationError` → 422, unknown errors → 500 with `{ "error": "Internal server error" }`
+    - _Requirements: 2.4, 3.1, 4.1, 6.1, 7.1_
+
+- [ ] 12. Next.js manifest loader
+  - [ ] 12.1 Create `frontend/src/lib/manifestLoader.ts`
+    - Implement `loadManifest(network: string): Promise<ContractManifest>` fetching `${NEXT_PUBLIC_REGISTRY_URL}/manifest?network=${network}`
+    - Export `ContractManifest` interface matching the manifest response shape
+    - Throw on non-200 responses with a descriptive error message
+    - _Requirements: 7.1_
+
+- [ ] 13. Seed migration runner with production guard
+  - [ ] 13.1 Add `backend/src/db/seed.ts` script entry point
+    - Call `migrate.ts` runner; verify `NODE_ENV` guard skips seed file in production
+    - Log applied migrations and any skipped files
+    - _Requirements: 9.2_
+  - [ ] 13.2 Write property test for seed idempotency
+    - **Property 16: Seed migration is idempotent** — run seed migration N times against test DB, assert exactly one `local` and one `testnet` row with seed addresses
+    - **Validates: Requirements 9.3**
+
+- [ ] 14. Checkpoint — ensure all unit and property tests pass
+  - Run `npm test` in `backend/`; ensure all tests pass. Ask the user if any questions arise.
+
+- [ ] 15. Integration tests
+  - [ ] 15.1 Write integration tests for DB transaction atomicity (Property 10)
+    - Use `testcontainers` or a local Docker Compose PostgreSQL instance
+    - Force a mid-transaction error; assert both `deployment_records` and `admin_audit_log` rows are absent
+    - _Requirements: 5.4_
+  - [ ] 15.2 Write integration tests for cache invalidation (Property 14)
+    - POST a record, GET `/deployments`, mutate via PATCH, GET again; assert second response reflects the patch
+    - _Requirements: 6.5_
+  - [ ] 15.3 Write integration tests for unique constraint (Property 1)
+    - POST same `(network, contract_address)` twice; assert second returns 409 and only one row exists in DB
+    - _Requirements: 1.2, 3.6_
+  - [ ] 15.4 Write integration test for seed idempotency (Property 16)
+    - Run seed runner twice; assert row counts remain at 1 per seed address
+    - _Requirements: 9.3_
+  - [ ] 15.5 Write unit test for audit log append-only enforcement
+    - Attempt UPDATE and DELETE on `admin_audit_log` as `app_user`; assert both are rejected by the DB
+    - _Requirements: 5.3_
+
+- [ ] 16. Release runbook
+  - [ ] 16.1 Create `backend/docs/runbook.md`
+    - Document the post-deployment sequence: obtain `contract_address` and `wasm_hash`, call POST `/deployments`, verify 201 response, deactivate previous record via PATCH `{ "is_active": false }`
+    - List required environment variables (`ADMIN_API_KEY`, `DATABASE_URL`, `NODE_ENV`) per environment
+    - Include example `curl` commands for POST and PATCH with required headers and valid request bodies
+    - _Requirements: 10.1, 10.2, 10.3_
+
+- [ ] 17. Final checkpoint — ensure all tests pass
+  - Run `npm test` in `backend/`; ensure all unit, property, and integration tests pass. Ask the user if any questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP (none in this plan — all tests are required per the design)
+- Property tests use `fast-check` with `{ numRuns: 100 }` and are tagged with `// Feature: deployment-registry, Property N: ...`
+- Integration tests require a PostgreSQL instance; use `testcontainers` or Docker Compose
+- The seed migration runner must check `NODE_ENV` before executing `003_seed_dev_data.sql`
+- All error responses set `Content-Type: application/json`


### PR DESCRIPTION
closes #37
Define Deployment entity/table with indexes on network and active flag.
Implement admin-guarded mutation endpoints with validation of Stellar addresses.
Log actor, timestamp, IP (if appropriate), and change payload hashes to admin_audit_log.
Seed development values via migrations or scripts.
Document how releases update this table as part of the runbook.
