### PR TITLE
feat: add delegate-authorization spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/delegate-authorization/.config.kiro
+++ b/.kiro/specs/delegate-authorization/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "8f6c3ff0-d4da-4c80-8bc6-c973775fdbc1", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/delegate-authorization/design.md
+++ b/.kiro/specs/delegate-authorization/design.md
@@ -1,0 +1,648 @@
+# Design Document: Delegate Authorization
+
+## Overview
+
+The delegate authorization feature adds a scoped, time-bounded delegation layer to the NiffyInsure
+Soroban smart contract. A policyholder (the "Holder") can register a trusted address (the
+"Delegate") to perform a restricted set of actions — renewing coverage and filing claims — on one
+or more of their policies without exposing the Holder's cold key for routine operations.
+
+The feature spans four layers:
+
+| Layer | Scope |
+|---|---|
+| Soroban contract (`contracts/niffyinsure/src/`) | New `delegate.rs` module; additions to `storage.rs`, `types.rs`, `validate.rs`, `lib.rs` |
+| Integration tests (`contracts/niffyinsure/tests/`) | New `delegate.rs` test file using `soroban-sdk` test harness |
+| Node/TypeScript backend (`backend/src/`) | New `/delegates/:holder` endpoint; `DelegateUpdated` event indexer |
+| Next.js frontend (`frontend/src/`) | Delegate management panel with risk disclosure and revocation UI |
+
+Key design constraints:
+- Delegates can never vote, redirect payouts, or modify delegate assignments.
+- All authorization checks happen before any storage write (fail-fast).
+- `require_auth` is called on the actual transaction signer in every entrypoint.
+- Multisig Holders are supported transparently via Soroban's native auth resolution.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Contract["Soroban Contract"]
+        direction TB
+        LIB["lib.rs\nset_delegate\nrevoke_delegate\nrenew_policy\nfile_claim\nvote_on_claim"]
+        DEL["delegate.rs\ncheck_delegate_auth()\nemit_delegate_updated()"]
+        STOR["storage.rs\nDelegate(holder,policy_id,delegate)\nDataKey additions"]
+        TYPES["types.rs\nDelegateRecord\nDelegateScope\nDelegateAction"]
+        VAL["validate.rs\nError additions"]
+        LIB --> DEL
+        DEL --> STOR
+        DEL --> TYPES
+        DEL --> VAL
+    end
+
+    subgraph Backend["Node/TypeScript Backend"]
+        IDX["Event Indexer\nDelegateUpdated listener"]
+        API["GET /delegates/:holder"]
+        IDX --> API
+    end
+
+    subgraph Frontend["Next.js Frontend"]
+        PANEL["DelegatePanel\nlist / set / revoke"]
+        DISC["RiskDisclosure modal"]
+        PANEL --> DISC
+    end
+
+    Contract -- "DelegateUpdated events" --> IDX
+    Frontend -- "Soroban RPC calls" --> Contract
+    Frontend -- "REST" --> API
+```
+
+### Authorization Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Contract
+    participant DelegateRegistry
+
+    Caller->>Contract: renew_policy(holder, policy_id, caller)
+    Contract->>Contract: require_auth(caller)
+    alt caller == holder
+        Contract->>Contract: proceed with holder checks
+    else caller != holder
+        Contract->>DelegateRegistry: check_delegate_auth(holder, policy_id, caller, Renew)
+        DelegateRegistry-->>Contract: Ok / Err::DelegateExpired / Err::UnauthorizedDelegate / Err::DelegateScopeViolation
+        Contract->>Contract: proceed or revert
+    end
+    Contract->>Contract: renew logic (holder remains owner)
+```
+
+---
+
+## Components and Interfaces
+
+### 1. `types.rs` additions
+
+```rust
+/// Bitmask of permitted delegate actions.
+/// Stored as a u32 to remain XDR-serialisable.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum DelegateScope {
+    None,       // no permissions (used in Revoked events)
+    Renew,      // may call renew_policy
+    FileClaim,  // may call file_claim
+    RenewAndFileClaim, // both
+}
+
+/// Discriminant carried in DelegateUpdated events.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum DelegateAction {
+    Set,
+    Revoked,
+}
+
+/// Stored on-chain per (holder, policy_id, delegate) triple.
+#[contracttype]
+#[derive(Clone)]
+pub struct DelegateRecord {
+    pub expiry_ledger: u32,
+    pub scope: DelegateScope,
+}
+```
+
+### 2. `storage.rs` additions
+
+New `DataKey` variants:
+
+```rust
+/// Delegate_Record keyed by (holder, policy_id, delegate).
+Delegate(Address, u32, Address),
+```
+
+New helper functions:
+
+```rust
+pub fn set_delegate(env: &Env, holder: &Address, policy_id: u32, delegate: &Address, record: &DelegateRecord);
+pub fn get_delegate(env: &Env, holder: &Address, policy_id: u32, delegate: &Address) -> Option<DelegateRecord>;
+pub fn remove_delegate(env: &Env, holder: &Address, policy_id: u32, delegate: &Address);
+```
+
+Storage tier: `persistent()` — delegate records must survive ledger archival windows.
+
+### 3. `delegate.rs` (new module)
+
+```rust
+/// Verifies that `caller` is authorised to perform `action` on `(holder, policy_id)`.
+/// Returns Ok(()) if caller == holder (bypasses delegate lookup).
+/// Otherwise looks up the DelegateRecord and checks expiry and scope.
+pub fn check_delegate_auth(
+    env: &Env,
+    holder: &Address,
+    policy_id: u32,
+    caller: &Address,
+    required_scope: DelegateScope,
+) -> Result<(), Error>;
+
+/// Emits a `DelegateUpdated` contract event.
+pub fn emit_delegate_updated(
+    env: &Env,
+    holder: &Address,
+    policy_id: u32,
+    delegate: &Address,
+    expiry_ledger: u32,
+    scope: DelegateScope,
+    action: DelegateAction,
+);
+```
+
+`check_delegate_auth` logic (ordered, fail-fast):
+1. If `caller == holder` → return `Ok(())`.
+2. Load `DelegateRecord` for `(holder, policy_id, caller)`. If absent → `Err(UnauthorizedDelegate)`.
+3. If `env.ledger().sequence() >= record.expiry_ledger` → `Err(DelegateExpired)`.
+4. If `record.scope` does not cover `required_scope` → `Err(DelegateScopeViolation)`.
+5. Return `Ok(())`.
+
+### 4. `validate.rs` additions
+
+```rust
+// New error variants
+pub enum Error {
+    // ... existing variants ...
+    DelegateExpiredWindow,   // set_delegate called with expiry_ledger <= current_ledger
+    DelegateExpired,         // caller's record exists but is past expiry
+    UnauthorizedDelegate,    // no record found for caller
+    DelegateScopeViolation,  // record exists but scope doesn't cover the action
+    NotAVoter,               // vote_on_claim caller holds no active policy as direct holder
+    InvalidPayoutAddress,    // file_claim payout address != policy.holder
+}
+```
+
+### 5. `lib.rs` new entrypoints
+
+```rust
+/// Register or update a delegate for a specific policy.
+pub fn set_delegate(
+    env: Env,
+    holder: Address,
+    policy_id: u32,
+    delegate: Address,
+    expiry_ledger: u32,
+    scope: DelegateScope,
+) -> Result<(), Error>;
+
+/// Remove a delegate record for a specific policy.
+pub fn revoke_delegate(
+    env: Env,
+    holder: Address,
+    policy_id: u32,
+    delegate: Address,
+) -> Result<(), Error>;
+```
+
+Modifications to existing entrypoints:
+
+- `renew_policy(env, holder, policy_id, caller)` — adds `caller: Address` parameter; calls
+  `require_auth(&caller)` then `check_delegate_auth(holder, policy_id, caller, Renew)`.
+- `file_claim(env, holder, policy_id, caller, amount, details, image_urls)` — adds `caller:
+  Address`; calls `require_auth(&caller)` then `check_delegate_auth(holder, policy_id, caller,
+  FileClaim)`; derives payout recipient from `policy.holder` only.
+- `vote_on_claim(env, voter, claim_id, vote)` — adds check that `voter` is a direct Holder of an
+  active policy; rejects with `Error::NotAVoter` otherwise.
+
+### 6. Backend: event indexer and REST endpoint
+
+```typescript
+// In-memory delegate index (replace with DB in production)
+type DelegateIndex = Map<string, DelegateRecord[]>; // key: holder address
+
+interface DelegateRecord {
+  policyId: number;
+  delegate: string;
+  expiryLedger: number;
+  scope: string;
+}
+
+// New route
+app.get("/delegates/:holder", (req, res) => { ... });
+
+// Event listener (Soroban RPC subscription or polling)
+function handleDelegateUpdated(event: DelegateUpdatedEvent): void { ... }
+```
+
+### 7. Frontend: DelegatePanel component
+
+New files:
+- `frontend/src/app/components/DelegatePanel.tsx` — lists active delegates, expiry warnings,
+  revoke button.
+- `frontend/src/app/components/RiskDisclosure.tsx` — modal shown before `set_delegate` submission.
+
+---
+
+## Data Models
+
+### On-chain storage layout
+
+| DataKey | Storage tier | Value type | Notes |
+|---|---|---|---|
+| `Delegate(holder, policy_id, delegate)` | `persistent` | `DelegateRecord` | Removed on revoke |
+| Existing keys unchanged | — | — | — |
+
+### `DelegateRecord`
+
+| Field | Type | Constraints |
+|---|---|---|
+| `expiry_ledger` | `u32` | Must be > `current_ledger` at write time |
+| `scope` | `DelegateScope` | Must not be `None` at write time |
+
+### `DelegateUpdated` event schema
+
+| Field | Type | Set value | Revoked value |
+|---|---|---|---|
+| `holder` | `Address` | holder | holder |
+| `policy_id` | `u32` | policy_id | policy_id |
+| `delegate` | `Address` | delegate | delegate |
+| `expiry_ledger` | `u32` | expiry_ledger | `0` |
+| `scope` | `DelegateScope` | scope | `DelegateScope::None` |
+| `action` | `DelegateAction` | `Set` | `Revoked` |
+
+### Backend delegate index entry
+
+```typescript
+interface DelegateIndexEntry {
+  holder: string;       // Stellar address
+  policyId: number;
+  delegate: string;     // Stellar address
+  expiryLedger: number;
+  scope: "Renew" | "FileClaim" | "RenewAndFileClaim";
+}
+```
+
+---
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a
+system — essentially, a formal statement about what the system should do. Properties serve as the
+bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: set_delegate round-trip
+
+*For any* valid `(holder, policy_id, delegate, expiry_ledger, scope)` tuple where `expiry_ledger >
+current_ledger`, calling `set_delegate` and then reading back the stored `DelegateRecord` should
+return a record with the same `expiry_ledger` and `scope` that was written.
+
+**Validates: Requirements 1.1**
+
+---
+
+### Property 2: set_delegate rejects past or current expiry_ledger
+
+*For any* `set_delegate` call where `expiry_ledger <= current_ledger`, the contract SHALL reject
+the call with `Error::DelegateExpiredWindow` and leave storage unchanged.
+
+**Validates: Requirements 1.3**
+
+---
+
+### Property 3: revoke_delegate removes the record
+
+*For any* `(holder, policy_id, delegate)` triple for which a `DelegateRecord` exists, calling
+`revoke_delegate` should result in the record being absent from storage, such that a subsequent
+authorization check returns `Error::UnauthorizedDelegate`.
+
+**Validates: Requirements 1.4**
+
+---
+
+### Property 4: DelegateUpdated event is emitted with correct fields
+
+*For any* valid `set_delegate` call, the emitted `DelegateUpdated` event should contain exactly the
+`holder`, `policy_id`, `delegate`, `expiry_ledger`, and `scope` passed in, with `action = Set`.
+*For any* valid `revoke_delegate` call, the emitted event should contain the same `holder`,
+`policy_id`, and `delegate`, with `expiry_ledger = 0`, `scope = DelegateScope::None`, and `action
+= Revoked`.
+
+**Validates: Requirements 1.6, 8.1, 8.2**
+
+---
+
+### Property 5: Delegate with Renew scope can renew_policy
+
+*For any* `(holder, policy_id, delegate)` triple where a non-expired `DelegateRecord` with
+`DelegateScope::Renew` (or `RenewAndFileClaim`) exists, calling `renew_policy` with `caller =
+delegate` should succeed.
+
+**Validates: Requirements 2.1**
+
+---
+
+### Property 6: Delegate with FileClaim scope can file_claim
+
+*For any* `(holder, policy_id, delegate)` triple where a non-expired `DelegateRecord` with
+`DelegateScope::FileClaim` (or `RenewAndFileClaim`) exists, calling `file_claim` with `caller =
+delegate` should succeed.
+
+**Validates: Requirements 2.2**
+
+---
+
+### Property 7: Expired delegate is rejected before any state change
+
+*For any* `(holder, policy_id, delegate)` triple where a `DelegateRecord` exists but
+`current_ledger >= expiry_ledger`, calling `renew_policy` or `file_claim` as that delegate should
+revert with `Error::DelegateExpired` and leave all storage unchanged.
+
+**Validates: Requirements 2.4, 5.1**
+
+---
+
+### Property 8: Unknown delegate is rejected before any state change
+
+*For any* caller address that is not the Holder and for which no `DelegateRecord` exists on the
+target `(holder, policy_id)`, calling `renew_policy` or `file_claim` should revert with
+`Error::UnauthorizedDelegate` and leave all storage unchanged.
+
+**Validates: Requirements 2.5, 5.2**
+
+---
+
+### Property 9: Holder remains policy owner after delegate renew
+
+*For any* `renew_policy` call where `caller` is a valid Delegate, the `policy.holder` field read
+back after the call should equal the original Holder address, not the Delegate address.
+
+**Validates: Requirements 2.6**
+
+---
+
+### Property 10: Claimant is always the Holder after delegate file_claim
+
+*For any* `file_claim` call where `caller` is a valid Delegate, the `claim.claimant` field stored
+on-chain should equal `policy.holder`, not the Delegate address.
+
+**Validates: Requirements 2.7**
+
+---
+
+### Property 11: Payout recipient is always policy.holder
+
+*For any* approved claim, the address receiving the token transfer should equal `policy.holder` for
+that claim's policy, regardless of who filed the claim.
+
+**Validates: Requirements 3.1**
+
+---
+
+### Property 12: file_claim rejects mismatched payout address
+
+*For any* `file_claim` call that includes an explicit payout address field that differs from
+`policy.holder`, the contract should reject the call with `Error::InvalidPayoutAddress` before
+writing any state.
+
+**Validates: Requirements 3.2**
+
+---
+
+### Property 13: vote_on_claim is restricted to direct Holders of active policies
+
+*For any* address that does not hold at least one active policy as a direct Holder (including
+Delegate addresses regardless of their scope), calling `vote_on_claim` should revert with
+`Error::NotAVoter`.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+---
+
+### Property 14: Scope violation is rejected before any state change
+
+*For any* `(holder, policy_id, delegate)` triple where a valid non-expired `DelegateRecord` exists
+but the `DelegateScope` does not cover the requested action (e.g., a `Renew`-only delegate calling
+`file_claim`), the contract should revert with `Error::DelegateScopeViolation` before writing any
+state.
+
+**Validates: Requirements 5.3**
+
+---
+
+### Property 15: Holder always bypasses delegate lookup
+
+*For any* `renew_policy` or `file_claim` call where `caller == holder`, the contract should
+proceed with only Holder-level authorization checks and never consult the delegate registry, even
+when no `DelegateRecord` exists.
+
+**Validates: Requirements 5.4**
+
+---
+
+### Property 16: Delegate cannot modify delegate assignments
+
+*For any* address that holds a `DelegateRecord` (regardless of scope), calling `set_delegate` or
+`revoke_delegate` on any policy should fail because `require_auth` on the Holder will not be
+satisfied by the Delegate's signature.
+
+**Validates: Requirements 5.5**
+
+---
+
+### Property 17: Expiry warning threshold
+
+*For any* `(current_ledger, expiry_ledger)` pair where `expiry_ledger - current_ledger < 1000`,
+the frontend helper function `isNearExpiry` should return `true`; for pairs where the difference is
+≥ 1000 it should return `false`.
+
+**Validates: Requirements 7.5**
+
+---
+
+### Property 18: Backend removes revoked delegate from index
+
+*For any* delegate entry present in the backend index, processing a `DelegateUpdated` event with
+`action = Revoked` for that `(holder, policy_id, delegate)` triple should result in the entry
+being absent from the index returned by `GET /delegates/:holder`.
+
+**Validates: Requirements 8.4**
+
+---
+
+## Error Handling
+
+### Contract errors
+
+| Error | Trigger | State change |
+|---|---|---|
+| `DelegateExpiredWindow` | `set_delegate` called with `expiry_ledger <= current_ledger` | None |
+| `DelegateExpired` | Caller's record exists but `current_ledger >= expiry_ledger` | None |
+| `UnauthorizedDelegate` | No `DelegateRecord` found for `(holder, policy_id, caller)` | None |
+| `DelegateScopeViolation` | Record exists but scope doesn't cover the requested action | None |
+| `NotAVoter` | `vote_on_claim` caller holds no active policy as direct Holder | None |
+| `InvalidPayoutAddress` | `file_claim` payout address field != `policy.holder` | None |
+
+All new errors follow the existing pattern in `validate.rs`: they are returned as `Err(Error::X)`
+and the contract panics via `unwrap()` or `expect()` at the call site in `lib.rs`, which causes
+Soroban to revert the entire transaction. No partial writes occur.
+
+### Backend errors
+
+| Scenario | Response |
+|---|---|
+| Unknown holder in `GET /delegates/:holder` | `200 OK` with empty array (not 404) |
+| Malformed event payload | Log warning, skip event, do not crash indexer |
+| RPC connection failure | Retry with exponential back-off; surface `503` on REST if index is stale |
+
+### Frontend errors
+
+| Scenario | Handling |
+|---|---|
+| `set_delegate` transaction rejected by contract | Display contract error message; keep form open |
+| `revoke_delegate` transaction rejected | Display error; do not close confirmation dialog |
+| Backend `GET /delegates/:holder` fails | Show stale-data warning; disable revoke button |
+| Wallet not connected | Disable delegate management panel; prompt connection |
+
+---
+
+## Testing Strategy
+
+### Dual testing approach
+
+Both unit/integration tests and property-based tests are required. They are complementary:
+unit/integration tests catch concrete bugs and verify specific scenarios; property-based tests
+verify universal correctness across randomized inputs.
+
+### Contract: integration tests (`contracts/niffyinsure/tests/delegate.rs`)
+
+Use the `soroban-sdk` test harness (`Env::default()`, `mock_all_auths()`,
+`Address::generate(&env)`).
+
+Unit/integration test cases (specific examples and edge cases):
+- `set_delegate_requires_holder_auth` — call without holder auth, expect panic.
+- `revoke_delegate_requires_holder_auth` — call without holder auth, expect panic.
+- `multisig_holder_can_set_delegate` — use `mock_all_auths` to simulate multisig holder.
+- `backend_get_delegates_returns_empty_for_unknown_holder` — REST example test.
+
+Property-based tests use the [`proptest`](https://github.com/proptest-rs/proptest) crate (Rust).
+Each test runs a minimum of 100 iterations.
+
+```toml
+# contracts/niffyinsure/Cargo.toml (dev-dependencies)
+proptest = "1"
+```
+
+Property test stubs (one test per property, tagged with feature and property number):
+
+```rust
+// Feature: delegate-authorization, Property 1: set_delegate round-trip
+proptest! {
+    #[test]
+    fn prop_set_delegate_round_trip(expiry_offset in 1u32..10_000u32, scope in any_scope()) { ... }
+}
+
+// Feature: delegate-authorization, Property 2: set_delegate rejects past expiry_ledger
+proptest! {
+    #[test]
+    fn prop_set_delegate_rejects_past_expiry(offset in 0u32..1_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 3: revoke removes record
+proptest! {
+    #[test]
+    fn prop_revoke_removes_record(expiry_offset in 1u32..10_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 4: DelegateUpdated event fields
+proptest! {
+    #[test]
+    fn prop_delegate_updated_event_fields(expiry_offset in 1u32..10_000u32, scope in any_scope()) { ... }
+}
+
+// Feature: delegate-authorization, Property 7: expired delegate rejected
+proptest! {
+    #[test]
+    fn prop_expired_delegate_rejected(expiry_offset in 1u32..100u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 8: unknown delegate rejected
+proptest! {
+    #[test]
+    fn prop_unknown_delegate_rejected() { ... }
+}
+
+// Feature: delegate-authorization, Property 9: holder remains owner after delegate renew
+proptest! {
+    #[test]
+    fn prop_holder_remains_owner_after_delegate_renew(expiry_offset in 1u32..10_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 10: claimant is holder after delegate file_claim
+proptest! {
+    #[test]
+    fn prop_claimant_is_holder_after_delegate_file_claim(expiry_offset in 1u32..10_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 11: payout recipient is policy.holder
+proptest! {
+    #[test]
+    fn prop_payout_recipient_is_holder(expiry_offset in 1u32..10_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 13: vote restricted to direct holders
+proptest! {
+    #[test]
+    fn prop_vote_restricted_to_direct_holders() { ... }
+}
+
+// Feature: delegate-authorization, Property 14: scope violation rejected
+proptest! {
+    #[test]
+    fn prop_scope_violation_rejected(expiry_offset in 1u32..10_000u32) { ... }
+}
+
+// Feature: delegate-authorization, Property 15: holder bypasses delegate lookup
+proptest! {
+    #[test]
+    fn prop_holder_bypasses_delegate_lookup() { ... }
+}
+
+// Feature: delegate-authorization, Property 16: delegate cannot modify assignments
+proptest! {
+    #[test]
+    fn prop_delegate_cannot_modify_assignments(expiry_offset in 1u32..10_000u32) { ... }
+}
+```
+
+### Frontend: Jest + fast-check (`frontend/`)
+
+```typescript
+// Feature: delegate-authorization, Property 17: expiry warning threshold
+fc.assert(fc.property(
+  fc.integer({ min: 0 }), fc.integer({ min: 0 }),
+  (current, expiry) => {
+    const result = isNearExpiry(current, expiry);
+    return result === (expiry - current < 1000 && expiry > current);
+  }
+), { numRuns: 100 });
+```
+
+### Backend: Jest + fast-check (`backend/`)
+
+```typescript
+// Feature: delegate-authorization, Property 18: backend removes revoked delegate
+fc.assert(fc.property(
+  fc.record({ holder: fc.string(), policyId: fc.nat(), delegate: fc.string(), ... }),
+  (entry) => {
+    addToIndex(entry);
+    handleDelegateUpdated({ ...entry, action: "Revoked" });
+    return getDelegates(entry.holder).every(d => d.delegate !== entry.delegate);
+  }
+), { numRuns: 100 });
+```
+
+### Coverage targets
+
+- Contract: all new error variants exercised by at least one test.
+- Backend: `GET /delegates/:holder` endpoint covered by integration example test.
+- Frontend: `isNearExpiry` helper covered by property test; `DelegatePanel` and `RiskDisclosure`
+  covered by React Testing Library snapshot tests.

--- a/.kiro/specs/delegate-authorization/requirements.md
+++ b/.kiro/specs/delegate-authorization/requirements.md
@@ -1,0 +1,203 @@
+# Requirements Document
+
+## Introduction
+
+The delegate authorization feature allows a policyholder (cold holder key) to designate a trusted
+address (hot wallet or service account) to perform a limited set of actions on their behalf within
+the NiffyInsure Soroban smart contract. Delegates may renew coverage and file claims within an
+explicit authorization window; they may never vote on claims, redirect payouts, or modify delegate
+assignments. The feature is scoped to the on-chain contract, the Node/TypeScript backend, and the
+Next.js frontend.
+
+## Glossary
+
+- **Holder**: The Address that owns a Policy; the only party that may set or revoke delegates for
+  that policy.
+- **Delegate**: An Address authorized by a Holder to perform a restricted set of actions on one or
+  more of the Holder's policies.
+- **Delegate_Registry**: The on-chain component responsible for storing, validating, and expiring
+  delegate authorizations.
+- **Delegate_Record**: A single authorization entry mapping a Delegate address to an
+  `expiry_ledger` and a `DelegateScope` for a specific (Holder, policy_id) pair.
+- **DelegateScope**: A bitmask or enum set that enumerates which actions a Delegate is permitted to
+  perform (e.g., `Renew`, `FileClaim`).
+- **expiry_ledger**: The Soroban ledger sequence number after which a Delegate_Record is no longer
+  valid; the Delegate_Registry treats `current_ledger >= expiry_ledger` as expired.
+- **Policy**: An on-chain insurance policy record as defined in `types.rs`.
+- **Claim**: An on-chain claim record as defined in `types.rs`.
+- **Contract**: The NiffyInsure Soroban smart contract.
+- **Frontend**: The Next.js application at `frontend/src/`.
+- **Backend**: The Node/TypeScript service at `backend/src/`.
+- **require_auth**: The Soroban SDK call that enforces that a given Address has signed the current
+  transaction.
+
+---
+
+## Requirements
+
+### Requirement 1: Delegate Storage and Lifecycle
+
+**User Story:** As a Holder, I want to register a Delegate address with an expiry ledger and a
+scope, so that a hot wallet can act on my behalf for a bounded time without holding my cold key.
+
+#### Acceptance Criteria
+
+1. THE Delegate_Registry SHALL store Delegate_Records keyed by `(holder, policy_id, delegate)`
+   containing `expiry_ledger` and `DelegateScope`.
+2. WHEN a Holder calls `set_delegate(policy_id, delegate, expiry_ledger, scope)`, THE
+   Delegate_Registry SHALL require `require_auth` on the Holder's address before writing the
+   Delegate_Record.
+3. WHEN a Holder calls `set_delegate` with an `expiry_ledger` less than or equal to the current
+   ledger sequence, THE Delegate_Registry SHALL reject the call with `Error::DelegateExpiredWindow`.
+4. WHEN a Holder calls `revoke_delegate(policy_id, delegate)`, THE Delegate_Registry SHALL require
+   `require_auth` on the Holder's address and remove the Delegate_Record.
+5. IF a Delegate_Record does not exist for a given `(holder, policy_id, delegate)` triple, THEN
+   THE Delegate_Registry SHALL treat the Delegate as unauthorized for all actions on that policy.
+6. THE Delegate_Registry SHALL emit a `DelegateUpdated` event on every successful `set_delegate`
+   and `revoke_delegate` call containing fields: `holder`, `policy_id`, `delegate`,
+   `expiry_ledger`, `scope`, and `action` (`Set` or `Revoked`).
+
+---
+
+### Requirement 2: Delegate Authentication in Renew and File Paths
+
+**User Story:** As a Delegate, I want to renew a policy or file a claim on behalf of a Holder, so
+that the Holder's cold key does not need to be online for routine operations.
+
+#### Acceptance Criteria
+
+1. WHEN `renew_policy` is called with a `caller` address that is not the Holder, THE Contract SHALL
+   verify that a valid, non-expired Delegate_Record exists for `(holder, policy_id, caller)` with
+   `DelegateScope::Renew` before proceeding.
+2. WHEN `file_claim` is called with a `caller` address that is not the Holder, THE Contract SHALL
+   verify that a valid, non-expired Delegate_Record exists for `(holder, policy_id, caller)` with
+   `DelegateScope::FileClaim` before proceeding.
+3. THE Contract SHALL call `require_auth` on the `caller` address in both `renew_policy` and
+   `file_claim` regardless of whether the caller is the Holder or a Delegate.
+4. IF a Delegate_Record for the caller exists but `current_ledger >= expiry_ledger`, THEN THE
+   Contract SHALL reject the call with `Error::DelegateExpired` without modifying any state.
+5. IF no valid Delegate_Record exists for the caller on the target policy, THEN THE Contract SHALL
+   reject the call with `Error::UnauthorizedDelegate` without modifying any state.
+6. WHILE a Delegate is performing `renew_policy`, THE Contract SHALL use the Holder's address as
+   the premium payer and policy owner; the Delegate address SHALL NOT become the policy owner.
+7. WHILE a Delegate is performing `file_claim`, THE Contract SHALL set `claimant` to the Holder's
+   address; the Delegate address SHALL NOT appear as the claimant.
+
+---
+
+### Requirement 3: Payout Integrity Under Delegate-Filed Claims
+
+**User Story:** As a Holder, I want to ensure that a Delegate filing a claim on my behalf cannot
+redirect the payout to themselves or any address other than the Holder, so that my funds remain
+secure.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL derive the payout recipient for every approved claim exclusively from
+   `policy.holder`; the payout recipient SHALL NOT be a parameter supplied by the caller.
+2. IF a `file_claim` call includes a payout address field that differs from `policy.holder`, THEN
+   THE Contract SHALL reject the call with `Error::InvalidPayoutAddress`.
+3. THE Contract SHALL NOT expose any entrypoint that allows a Delegate to modify the `claimant`
+   field of an existing Claim after it has been filed.
+
+---
+
+### Requirement 4: Delegate Voting Prohibition
+
+**User Story:** As a product owner, I want delegates to be prohibited from voting on claims by
+default, so that governance integrity is preserved and legal risk is minimized.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL restrict `vote_on_claim` to addresses that are the direct Holder of an active
+   policy; Delegate addresses SHALL NOT cast votes.
+2. WHEN `vote_on_claim` is called by an address that holds no active policy as a direct Holder, THE
+   Contract SHALL reject the call with `Error::NotAVoter`.
+3. THE Contract SHALL NOT grant voting rights to a Delegate even when the Delegate holds a
+   `DelegateScope` that includes `Renew` or `FileClaim`.
+4. WHERE a future product requirement explicitly enables delegate voting, THE Contract SHALL require
+   a separate `DelegateScope::Vote` flag that is absent from all default scope values.
+
+---
+
+### Requirement 5: Adversarial and Edge-Case Rejection
+
+**User Story:** As a security engineer, I want the contract to reject all unauthorized or
+out-of-window delegate actions at the earliest possible point, so that no partial state changes
+occur.
+
+#### Acceptance Criteria
+
+1. IF a Delegate_Record exists but `current_ledger >= expiry_ledger`, THEN THE Contract SHALL
+   revert the entire transaction with `Error::DelegateExpired` before any storage write.
+2. IF the caller address does not match the Holder and no Delegate_Record exists for the caller,
+   THEN THE Contract SHALL revert with `Error::UnauthorizedDelegate` before any storage write.
+3. IF the caller is a valid Delegate but the requested action is not in the Delegate_Record's
+   `DelegateScope`, THEN THE Contract SHALL revert with `Error::DelegateScopeViolation` before any
+   storage write.
+4. WHEN the Holder calls any entrypoint directly, THE Contract SHALL bypass delegate lookup and
+   apply only Holder-level authorization checks.
+5. THE Contract SHALL NOT allow a Delegate to call `set_delegate` or `revoke_delegate` on any
+   policy; only the Holder may modify delegate assignments.
+
+---
+
+### Requirement 6: Multisig Holder Compatibility
+
+**User Story:** As a Holder using a multisig or composite signer, I want delegate operations to
+remain compatible with my signing setup, so that I can manage delegates without breaking my
+existing security model.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL treat a multisig Address as a standard Holder Address; `require_auth` on a
+   multisig Address SHALL follow Soroban's native multisig resolution rules without special-casing
+   in the Contract.
+2. THE Contract SHALL NOT impose a single-key assumption on the Holder address in any delegate
+   management entrypoint.
+3. THE Backend SHALL document in its API response for `get_delegate_info` that callers using
+   composite signers must collect all required signatures before submitting `set_delegate` or
+   `revoke_delegate` transactions.
+
+---
+
+### Requirement 7: Frontend Risk Disclosure and Revocation UI
+
+**User Story:** As a Holder interacting with the Frontend, I want clear warnings about delegate
+risks and an accessible revocation flow, so that I can make informed decisions and quickly remove
+compromised delegates.
+
+#### Acceptance Criteria
+
+1. THE Frontend SHALL display a risk-disclosure notice before a Holder submits a `set_delegate`
+   transaction, stating that delegates can act on the Holder's behalf and that phishing attacks may
+   target delegate credentials.
+2. THE Frontend SHALL present a delegate management panel listing all active Delegate_Records for
+   the connected Holder, including `delegate` address, `expiry_ledger`, and `scope`.
+3. WHEN a Holder initiates revocation from the delegate management panel, THE Frontend SHALL
+   require explicit confirmation before submitting the `revoke_delegate` transaction.
+4. THE Frontend SHALL display the current ledger sequence alongside each `expiry_ledger` value so
+   the Holder can assess remaining authorization time.
+5. IF a Delegate_Record's `expiry_ledger` is within 1000 ledgers of the current ledger sequence,
+   THEN THE Frontend SHALL display a visual expiry warning on that record.
+
+---
+
+### Requirement 8: Event Schema and Observability
+
+**User Story:** As a backend operator, I want structured `DelegateUpdated` events emitted on every
+delegate change, so that off-chain systems can maintain an accurate delegate index without polling
+storage.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL emit a `DelegateUpdated` event for every `set_delegate` call with the
+   following fields: `holder: Address`, `policy_id: u32`, `delegate: Address`,
+   `expiry_ledger: u32`, `scope: DelegateScope`, `action: DelegateAction::Set`.
+2. THE Contract SHALL emit a `DelegateUpdated` event for every `revoke_delegate` call with the
+   following fields: `holder: Address`, `policy_id: u32`, `delegate: Address`,
+   `expiry_ledger: 0`, `scope: DelegateScope::None`, `action: DelegateAction::Revoked`.
+3. THE Backend SHALL index `DelegateUpdated` events and expose a `GET /delegates/:holder` endpoint
+   returning the current active delegate set for a Holder.
+4. WHEN a `DelegateUpdated` event with `action: Revoked` is received, THE Backend SHALL remove the
+   corresponding entry from its delegate index.

--- a/.kiro/specs/delegate-authorization/tasks.md
+++ b/.kiro/specs/delegate-authorization/tasks.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Delegate Authorization
+
+## Overview
+
+Implement scoped, time-bounded delegate authorization across the Soroban contract, Node/TypeScript
+backend, and Next.js frontend. Tasks build incrementally: types → storage → core delegate logic →
+contract entrypoints → adversarial tests → backend indexer/API → frontend UI.
+
+## Tasks
+
+- [ ] 1. Add delegate types to `types.rs`
+  - Add `DelegateScope` enum (`None`, `Renew`, `FileClaim`, `RenewAndFileClaim`) with `#[contracttype]`
+  - Add `DelegateAction` enum (`Set`, `Revoked`) with `#[contracttype]`
+  - Add `DelegateRecord` struct (`expiry_ledger: u32`, `scope: DelegateScope`) with `#[contracttype]`
+  - _Requirements: 1.1_
+
+- [ ] 2. Extend `storage.rs` with delegate persistence
+  - Add `Delegate(Address, u32, Address)` variant to `DataKey` enum
+  - Implement `set_delegate`, `get_delegate`, `remove_delegate` helpers using `env.storage().persistent()`
+  - _Requirements: 1.1, 1.2, 1.4_
+
+- [ ] 3. Add new error variants to `validate.rs`
+  - Add `DelegateExpiredWindow`, `DelegateExpired`, `UnauthorizedDelegate`, `DelegateScopeViolation`, `NotAVoter`, `InvalidPayoutAddress` to the `Error` enum
+  - _Requirements: 1.3, 2.4, 2.5, 3.2, 4.2, 5.1, 5.2, 5.3_
+
+- [ ] 4. Create `delegate.rs` module with auth check and event emission
+  - [ ] 4.1 Implement `check_delegate_auth(env, holder, policy_id, caller, required_scope) -> Result<(), Error>`
+    - Short-circuit `Ok(())` when `caller == holder`
+    - Load `DelegateRecord`; return `UnauthorizedDelegate` if absent
+    - Return `DelegateExpired` if `current_ledger >= record.expiry_ledger`
+    - Return `DelegateScopeViolation` if scope does not cover `required_scope`
+    - _Requirements: 2.1, 2.2, 2.4, 2.5, 5.1, 5.2, 5.3, 5.4_
+  - [ ] 4.2 Implement `emit_delegate_updated(env, holder, policy_id, delegate, expiry_ledger, scope, action)`
+    - Emit contract event with all six fields per the `DelegateUpdated` schema
+    - _Requirements: 1.6, 8.1, 8.2_
+  - [ ]* 4.3 Write property test: Property 1 — `set_delegate` round-trip
+    - **Property 1: set_delegate round-trip**
+    - **Validates: Requirements 1.1**
+  - [ ]* 4.4 Write property test: Property 4 — `DelegateUpdated` event fields
+    - **Property 4: DelegateUpdated event fields**
+    - **Validates: Requirements 1.6, 8.1, 8.2**
+
+- [ ] 5. Implement `set_delegate` and `revoke_delegate` entrypoints in `lib.rs`
+  - [ ] 5.1 Add `mod delegate;` to `lib.rs` and expose `set_delegate` and `revoke_delegate` in `#[contractimpl]`
+    - `set_delegate(env, holder, policy_id, delegate, expiry_ledger, scope)`: call `require_auth(&holder)`, validate `expiry_ledger > current_ledger`, write record, emit event
+    - `revoke_delegate(env, holder, policy_id, delegate)`: call `require_auth(&holder)`, remove record, emit event with `expiry_ledger=0` and `scope=None`
+    - _Requirements: 1.2, 1.3, 1.4, 1.6, 5.5_
+  - [ ]* 5.2 Write property test: Property 2 — `set_delegate` rejects past expiry
+    - **Property 2: set_delegate rejects past or current expiry_ledger**
+    - **Validates: Requirements 1.3**
+  - [ ]* 5.3 Write property test: Property 3 — `revoke_delegate` removes record
+    - **Property 3: revoke_delegate removes the record**
+    - **Validates: Requirements 1.4**
+  - [ ]* 5.4 Write unit test: `set_delegate_requires_holder_auth`
+    - Call `set_delegate` without holder auth; expect panic
+    - _Requirements: 1.2_
+  - [ ]* 5.5 Write unit test: `revoke_delegate_requires_holder_auth`
+    - Call `revoke_delegate` without holder auth; expect panic
+    - _Requirements: 1.4_
+  - [ ]* 5.6 Write unit test: `multisig_holder_can_set_delegate`
+    - Use `mock_all_auths` to simulate multisig holder setting a delegate
+    - _Requirements: 6.1, 6.2_
+
+- [ ] 6. Checkpoint — Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 7. Wire delegate checks into `renew_policy` in `policy.rs` and `lib.rs`
+  - Add `caller: Address` parameter to `renew_policy`
+  - Call `require_auth(&caller)` then `check_delegate_auth(holder, policy_id, caller, DelegateScope::Renew)`
+  - Ensure `policy.holder` remains unchanged after a delegate renew (premium payer = holder)
+  - _Requirements: 2.1, 2.3, 2.6_
+  - [ ]* 7.1 Write property test: Property 5 — delegate with Renew scope can renew
+    - **Property 5: Delegate with Renew scope can renew_policy**
+    - **Validates: Requirements 2.1**
+  - [ ]* 7.2 Write property test: Property 9 — holder remains owner after delegate renew
+    - **Property 9: Holder remains policy owner after delegate renew**
+    - **Validates: Requirements 2.6**
+  - [ ]* 7.3 Write property test: Property 15 — holder bypasses delegate lookup
+    - **Property 15: Holder always bypasses delegate lookup**
+    - **Validates: Requirements 5.4**
+
+- [ ] 8. Wire delegate checks into `file_claim` in `claim.rs` and `lib.rs`
+  - Add `caller: Address` parameter to `file_claim`
+  - Call `require_auth(&caller)` then `check_delegate_auth(holder, policy_id, caller, DelegateScope::FileClaim)`
+  - Derive `claimant` and payout recipient exclusively from `policy.holder`; reject any explicit payout address != `policy.holder` with `Error::InvalidPayoutAddress`
+  - _Requirements: 2.2, 2.3, 2.7, 3.1, 3.2, 3.3_
+  - [ ]* 8.1 Write property test: Property 6 — delegate with FileClaim scope can file_claim
+    - **Property 6: Delegate with FileClaim scope can file_claim**
+    - **Validates: Requirements 2.2**
+  - [ ]* 8.2 Write property test: Property 10 — claimant is holder after delegate file_claim
+    - **Property 10: Claimant is always the Holder after delegate file_claim**
+    - **Validates: Requirements 2.7**
+  - [ ]* 8.3 Write property test: Property 11 — payout recipient is policy.holder
+    - **Property 11: Payout recipient is always policy.holder**
+    - **Validates: Requirements 3.1**
+  - [ ]* 8.4 Write property test: Property 12 — file_claim rejects mismatched payout address
+    - **Property 12: file_claim rejects mismatched payout address**
+    - **Validates: Requirements 3.2**
+
+- [ ] 9. Add voter restriction to `vote_on_claim` in `claim.rs` and `lib.rs`
+  - Add check that `voter` is a direct Holder of at least one active policy; reject with `Error::NotAVoter` otherwise
+  - Ensure delegate addresses are rejected even when they hold a valid `DelegateRecord`
+  - _Requirements: 4.1, 4.2, 4.3_
+  - [ ]* 9.1 Write property test: Property 13 — vote restricted to direct holders
+    - **Property 13: vote_on_claim is restricted to direct Holders of active policies**
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+
+- [ ] 10. Write adversarial integration tests in `contracts/niffyinsure/tests/delegate.rs`
+  - [ ]* 10.1 Write property test: Property 7 — expired delegate rejected before state change
+    - **Property 7: Expired delegate is rejected before any state change**
+    - **Validates: Requirements 2.4, 5.1**
+  - [ ]* 10.2 Write property test: Property 8 — unknown delegate rejected before state change
+    - **Property 8: Unknown delegate is rejected before any state change**
+    - **Validates: Requirements 2.5, 5.2**
+  - [ ]* 10.3 Write property test: Property 14 — scope violation rejected before state change
+    - **Property 14: Scope violation is rejected before any state change**
+    - **Validates: Requirements 5.3**
+  - [ ]* 10.4 Write property test: Property 16 — delegate cannot modify assignments
+    - **Property 16: Delegate cannot modify delegate assignments**
+    - **Validates: Requirements 5.5**
+
+- [ ] 11. Checkpoint — Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 12. Implement backend event indexer and REST endpoint in `backend/src/index.ts`
+  - [ ] 12.1 Add in-memory `DelegateIndex` map and `DelegateIndexEntry` interface
+    - Implement `handleDelegateUpdated(event)`: upsert on `Set`, remove on `Revoked`
+    - _Requirements: 8.3, 8.4_
+  - [ ] 12.2 Add `GET /delegates/:holder` route returning the active delegate array for a holder (empty array for unknown holders)
+    - _Requirements: 8.3_
+  - [ ] 12.3 Add Soroban RPC polling loop that feeds `DelegateUpdated` events into `handleDelegateUpdated`
+    - Log and skip malformed events; do not crash the indexer
+    - _Requirements: 8.3, 8.4_
+  - [ ]* 12.4 Write property test: Property 18 — backend removes revoked delegate from index
+    - **Property 18: Backend removes revoked delegate from index**
+    - **Validates: Requirements 8.4**
+  - [ ]* 12.5 Write unit test: `backend_get_delegates_returns_empty_for_unknown_holder`
+    - _Requirements: 8.3_
+
+- [ ] 13. Implement frontend `DelegatePanel` and `RiskDisclosure` components
+  - [ ] 13.1 Create `frontend/src/app/components/RiskDisclosure.tsx`
+    - Modal component shown before `set_delegate` submission with phishing risk warning text
+    - Requires explicit user confirmation before proceeding
+    - _Requirements: 7.1, 7.3_
+  - [ ] 13.2 Create `frontend/src/app/components/DelegatePanel.tsx`
+    - List active delegates for connected holder (fetched from `GET /delegates/:holder`)
+    - Display `delegate` address, `expiry_ledger`, `scope`, and current ledger sequence per record
+    - Show visual expiry warning when `expiry_ledger - current_ledger < 1000`
+    - Revoke button triggers `RiskDisclosure` confirmation then submits `revoke_delegate` transaction
+    - Disable panel and prompt wallet connection when wallet is not connected
+    - _Requirements: 7.2, 7.3, 7.4, 7.5_
+  - [ ] 13.3 Export `isNearExpiry(currentLedger: number, expiryLedger: number): boolean` helper from `DelegatePanel.tsx`
+    - Returns `true` when `expiryLedger - currentLedger < 1000` and `expiryLedger > currentLedger`
+    - _Requirements: 7.5_
+  - [ ]* 13.4 Write property test: Property 17 — expiry warning threshold
+    - **Property 17: Expiry warning threshold**
+    - **Validates: Requirements 7.5**
+  - [ ]* 13.5 Write snapshot tests for `DelegatePanel` and `RiskDisclosure` using React Testing Library
+    - _Requirements: 7.1, 7.2_
+
+- [ ] 14. Final checkpoint — Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Property tests use `proptest` (Rust contract) and `fast-check` (TypeScript backend/frontend)
+- Add `proptest = "1"` to `contracts/niffyinsure/Cargo.toml` dev-dependencies before running property tests
+- All authorization checks must occur before any storage write (fail-fast per Requirements 5.1–5.3)
+- `policy.holder` is the single source of truth for payout recipient; never a caller-supplied parameter


### PR DESCRIPTION
closes #26

implement delegate maps with TTL or explicit revocation.
Wire delegate checks into renew/file paths only as allowed.
Forbid delegate voting unless spec demands; test both cases.
Emit DelegateUpdated events with scope fields.
Add adversarial tests: expired delegate, wrong delegate, holder override.