### PR TITLE
feat: add policy-metadata-uri spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/policy-metadata-uri/.config.kiro
+++ b/.kiro/specs/policy-metadata-uri/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "1a2021b6-08d1-440a-a0f5-0f3fb784de1e", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/policy-metadata-uri/design.md
+++ b/.kiro/specs/policy-metadata-uri/design.md
@@ -1,0 +1,409 @@
+# Design Document: policy-metadata-uri
+
+## Overview
+
+The `policy-metadata-uri` feature extends the on-chain `Policy` struct with two optional fields:
+`metadata_uri` (a compact URI or IPFS CIDv1 pointing to an off-chain JSON document) and
+`metadata_integrity_hash` (an optional SHA-256 hex digest for tamper-evidence). The design keeps
+chain storage minimal — the URI is capped at 128 bytes — while enabling rich off-chain content
+(marketing copy, coverage tables, PDF links) to be linked from any policy.
+
+The feature touches four layers:
+
+1. **Soroban contract** (`types.rs`, `validate.rs`, `policy.rs`) — struct fields, constants,
+   validation functions, event emission.
+2. **Off-chain schema** (`docs/metadata-schema.json`, `docs/metadata-schema-changelog.md`,
+   `docs/examples/metadata/`) — versioned JSON Schema and examples.
+3. **Next.js frontend** — fetch, cache, integrity-check, and render metadata.
+4. **TypeScript Express backend** — mirror endpoint, schema validation, compliance logging.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Stellar["Stellar Network"]
+        Contract["NiffyInsure Contract\n(policy.rs / validate.rs)"]
+    end
+
+    subgraph OffChain["Off-Chain"]
+        IPFS["IPFS Node\n(CIDv1 pinning)"]
+        Backend["Express Backend\n/policies/:id/metadata"]
+        Schema["docs/metadata-schema.json\n(JSON Schema draft-07)"]
+    end
+
+    subgraph Client["Browser"]
+        Frontend["Next.js Policy Page"]
+    end
+
+    Operator -->|"pin JSON → CIDv1"| IPFS
+    Operator -->|"initiate_policy(metadata_uri)"| Contract
+    Contract -->|"stores metadata_uri + integrity_hash"| Stellar
+
+    Frontend -->|"reads policy"| Contract
+    Frontend -->|"ipfs:// → gateway URL"| IPFS
+    Frontend -->|"GET /policies/:id/metadata"| Backend
+    Backend -->|"POST /policies/:id/metadata"| IPFS
+    Backend -->|"validates against"| Schema
+```
+
+Key design decisions:
+
+- **URI-only on-chain**: the contract stores only the URI string and an optional hash digest, never
+  the JSON body. This bounds ledger rent to a fixed small allocation.
+- **Validation before storage**: `check_metadata_uri` and `check_integrity_hash` run inside the
+  contract before any `env.storage()` write, so invalid input always reverts.
+- **Immutability preference**: CIDv1 URIs are content-addressed; HTTPS URLs are permitted but
+  flagged as mutable in the runbook.
+- **Schema versioning independent of contract**: the JSON schema lives in `docs/` and is versioned
+  with semver; the contract does not parse the JSON body.
+
+---
+
+## Components and Interfaces
+
+### 1. Soroban Contract — `types.rs`
+
+Add two constants and two fields to `Policy`:
+
+```rust
+pub const METADATA_URI_MAX_LEN: u32 = 128;
+pub const METADATA_INTEGRITY_HASH_LEN: u32 = 64; // lowercase hex SHA-256
+
+// Inside Policy struct:
+pub metadata_uri: Option<String>,
+pub metadata_integrity_hash: Option<String>,
+```
+
+### 2. Soroban Contract — `validate.rs`
+
+Two new public validation functions added to the existing `Error` enum and module:
+
+```rust
+// New error variants
+MetadataUriTooLong,
+MetadataUriEmpty,
+MetadataIntegrityHashInvalid,
+
+// New functions
+pub fn check_metadata_uri(uri: &String) -> Result<(), Error>
+pub fn check_integrity_hash(hash: &String) -> Result<(), Error>
+```
+
+`check_metadata_uri` rejects empty strings and strings whose byte length exceeds
+`METADATA_URI_MAX_LEN`.
+
+`check_integrity_hash` rejects strings whose length is not exactly 64 and strings containing
+characters outside `[0-9a-f]`.
+
+### 3. Soroban Contract — `policy.rs`
+
+`initiate_policy` and `renew_policy` call both validators (when the respective `Option` is
+`Some`) before writing to storage. `renew_policy` emits a `MetadataUriUpdated` event when
+`metadata_uri` changes. `terminate_policy` leaves both fields unchanged.
+
+Event topic/data layout:
+
+```
+topics: ["MetadataUriUpdated", policy_id: u32, holder: Address]
+data:   new_metadata_uri: String
+```
+
+### 4. Off-Chain Schema — `docs/metadata-schema.json`
+
+JSON Schema draft-07. Required fields: `schema_version`, `pii_free` (must be `true`),
+`product_name`. Optional fields: `coverage_table_url`, `marketing_copy`, `pdf_links`, `custom`.
+
+### 5. Express Backend — `backend/src/index.ts`
+
+Two new endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/policies/:policyId/metadata` | Fetch URI, validate schema, store mirror |
+| `GET`  | `/policies/:policyId/metadata` | Return mirrored JSON with cache headers |
+
+The POST handler:
+1. Fetches the document from `metadata_uri`.
+2. Validates against `docs/metadata-schema.json` (using `ajv`).
+3. If `metadata_integrity_hash` is present, computes SHA-256 and compares.
+4. Rejects `pii_free: false` or absent with HTTP 422.
+5. Persists and logs the operation.
+
+### 6. Next.js Frontend — `frontend/src/app/`
+
+A `useMetadata(policy)` hook:
+1. Resolves `ipfs://` URIs to the configured gateway.
+2. Fetches with a 5-second timeout.
+3. Caches responses for 3 600 seconds.
+4. Verifies SHA-256 against `metadata_integrity_hash` when present.
+5. Returns `{ data, error, tamperWarning }` to the page component.
+
+---
+
+## Data Models
+
+### Updated `Policy` struct (Rust / Soroban)
+
+```rust
+#[contracttype]
+#[derive(Clone)]
+pub struct Policy {
+    pub holder: Address,
+    pub policy_id: u32,
+    pub policy_type: PolicyType,
+    pub region: RegionTier,
+    pub premium: i128,
+    pub coverage: i128,
+    pub is_active: bool,
+    pub start_ledger: u32,
+    pub end_ledger: u32,
+    // ── new fields ──────────────────────────────────────────────────────
+    /// Optional URI (IPFS CIDv1 or HTTPS) pointing to off-chain metadata JSON.
+    /// Byte length must be in 1..=METADATA_URI_MAX_LEN when Some.
+    pub metadata_uri: Option<String>,
+    /// Optional lowercase hex SHA-256 digest of the canonical metadata JSON bytes.
+    /// Must be exactly METADATA_INTEGRITY_HASH_LEN (64) hex chars when Some.
+    pub metadata_integrity_hash: Option<String>,
+}
+```
+
+### Metadata JSON document (TypeScript interface)
+
+```typescript
+interface MetadataJson {
+  schema_version: string;       // semver, e.g. "1.0.0"
+  pii_free: true;               // MUST be literal true
+  product_name: string;         // non-empty
+  coverage_table_url?: string;  // URI
+  marketing_copy?: string;      // max 2000 chars
+  pdf_links?: string[];         // max 10 URIs
+  custom?: Record<string, unknown>;
+}
+```
+
+### Backend in-memory mirror store (TypeScript)
+
+```typescript
+interface MirrorEntry {
+  policyId: string;
+  metadataUri: string;
+  document: MetadataJson;
+  fetchedAt: number;       // Unix ms
+  validationOutcome: "ok" | "schema_fail" | "hash_mismatch";
+}
+```
+
+---
+
+## Correctness Properties
+
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Oversized URI rejected
+
+*For any* string whose byte length exceeds `METADATA_URI_MAX_LEN` (128), calling
+`check_metadata_uri` on that string must return `Err(MetadataUriTooLong)`. This covers all
+lengths from 129 up to arbitrarily large values, including the boundary case of exactly 129 bytes.
+
+**Validates: Requirements 1.3, 8.2**
+
+### Property 2: None metadata_uri round-trip
+
+*For any* policy created with `metadata_uri = None`, reading the stored policy back must yield
+`metadata_uri == None`. The absence of the field must survive a full write-read cycle.
+
+**Validates: Requirements 1.5, 8.4**
+
+### Property 3: Invalid URI leaves storage unchanged
+
+*For any* call to `initiate_policy` or `renew_policy` that supplies an invalid `metadata_uri`
+(empty or oversized), the contract must revert and the storage entry for that policy must remain
+identical to its state before the call.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 4: MetadataUriUpdated event emitted on renew
+
+*For any* `renew_policy` call that supplies a new non-`None` `metadata_uri` value, the contract
+must emit exactly one `MetadataUriUpdated` event whose payload contains the correct `policy_id`,
+`holder` address, and the new `metadata_uri` string.
+
+**Validates: Requirements 2.4, 8.5**
+
+### Property 5: terminate_policy preserves metadata_uri
+
+*For any* policy that has a `metadata_uri` value (including `None`), calling `terminate_policy`
+must leave `metadata_uri` and `metadata_integrity_hash` unchanged in the stored record.
+
+**Validates: Requirements 2.5**
+
+### Property 6: Integrity hash validator rejects invalid strings
+
+*For any* string that is not exactly 64 lowercase hexadecimal characters (`[0-9a-f]`), calling
+`check_integrity_hash` must return `Err(MetadataIntegrityHashInvalid)`. Conversely, *for any*
+string that is exactly 64 lowercase hex characters, `check_integrity_hash` must return `Ok(())`.
+
+**Validates: Requirements 3.4, 8.6**
+
+### Property 7: Frontend tamper detection
+
+*For any* fetched metadata document and any `metadata_integrity_hash` value that does not match
+the SHA-256 digest of that document's bytes, the `useMetadata` hook must return
+`tamperWarning = true` and must not expose the document content for rendering.
+
+**Validates: Requirements 3.5**
+
+### Property 8: Backend rejects documents failing schema or PII check
+
+*For any* metadata document submitted to `POST /policies/:policyId/metadata` that either fails
+JSON Schema validation or has `pii_free` set to anything other than `true`, the backend must
+return HTTP 422 and must not persist the document.
+
+**Validates: Requirements 4.2, 4.3, 7.2**
+
+### Property 9: Backend rejects hash mismatch
+
+*For any* metadata document whose SHA-256 digest does not match the `metadata_integrity_hash`
+stored on the policy, the backend mirroring endpoint must return HTTP 409 and must not persist
+the document.
+
+**Validates: Requirements 7.4**
+
+### Property 10: IPFS URI gateway resolution
+
+*For any* `metadata_uri` string that begins with `ipfs://`, the `useMetadata` hook must resolve
+it to a URL that begins with the configured IPFS gateway prefix before issuing the HTTP request.
+No `ipfs://` URI should ever be passed directly to `fetch`.
+
+**Validates: Requirements 6.3**
+
+---
+
+## Error Handling
+
+### Contract layer
+
+| Error | Trigger | Behaviour |
+|-------|---------|-----------|
+| `MetadataUriTooLong` | `metadata_uri` byte length > 128 | Transaction reverts; no storage write |
+| `MetadataUriEmpty` | `metadata_uri` is `""` (zero bytes) | Transaction reverts; no storage write |
+| `MetadataIntegrityHashInvalid` | hash length ≠ 64 or non-hex chars | Transaction reverts; no storage write |
+
+All existing errors (`ZeroCoverage`, `PolicyExpired`, etc.) are unaffected.
+
+### Backend layer
+
+| Scenario | HTTP status | Body |
+|----------|-------------|------|
+| Schema validation failure | 422 | `{ "error": "schema_validation_failed", "details": [...] }` |
+| `pii_free` not `true` | 422 | `{ "error": "pii_check_failed" }` |
+| Hash mismatch | 409 | `{ "error": "integrity_hash_mismatch" }` |
+| Upstream fetch failure | 502 | `{ "error": "upstream_fetch_failed" }` |
+
+### Frontend layer
+
+| Scenario | UI response |
+|----------|-------------|
+| Fetch timeout (> 5 s) | Timeout notice; page renders without metadata |
+| Non-2xx response (after ≤ 2 retries) | Error notice; no metadata rendered |
+| Unrecognised `schema_version` | Unsupported-schema notice |
+| SHA-256 mismatch | Tamper-warning banner; metadata content suppressed |
+
+---
+
+## Testing Strategy
+
+### Dual testing approach
+
+Both unit tests and property-based tests are required. Unit tests cover specific examples,
+boundary conditions, and integration points. Property-based tests verify universal invariants
+across randomly generated inputs.
+
+### Contract — Rust tests (`tests/types_validate.rs`, `tests/integration.rs`)
+
+**Unit / example tests** (specific scenarios):
+- `METADATA_URI_MAX_LEN` constant equals 128.
+- `Policy` constructed without `metadata_uri` has `metadata_uri == None`.
+- `initiate_policy` with `metadata_uri = None` succeeds and stores `None`.
+- `initiate_policy` with exactly 128-byte URI succeeds (boundary).
+- `initiate_policy` with 129-byte URI returns `MetadataUriTooLong` (boundary).
+- `initiate_policy` with empty URI returns `MetadataUriEmpty`.
+- `renew_policy` with changed URI emits `MetadataUriUpdated` event.
+- `terminate_policy` leaves `metadata_uri` unchanged.
+- `check_integrity_hash` accepts a valid 64-char lowercase hex string.
+- `check_integrity_hash` rejects a 63-char string, a 65-char string, and a string with uppercase.
+
+**Property-based tests** using [`proptest`](https://github.com/proptest-rs/proptest) (minimum 100
+iterations each):
+
+```
+// Feature: policy-metadata-uri, Property 1: Oversized URI rejected
+proptest! { fn prop_oversized_uri_rejected(s in any_string_longer_than(128)) { ... } }
+
+// Feature: policy-metadata-uri, Property 6: Integrity hash validator rejects invalid strings
+proptest! { fn prop_invalid_hash_rejected(s in any_non_64hex_string()) { ... } }
+proptest! { fn prop_valid_hash_accepted(s in valid_64hex_string()) { ... } }
+```
+
+### Backend — TypeScript tests (Jest)
+
+**Unit tests**:
+- `POST /policies/:id/metadata` with a valid document returns 200 and persists.
+- `POST` with `pii_free: false` returns 422.
+- `POST` with missing required field returns 422.
+- `POST` with hash mismatch returns 409.
+- `GET /policies/:id/metadata` returns mirrored document with `Cache-Control: max-age=3600`.
+
+**Property-based tests** using [`fast-check`](https://github.com/dubzzz/fast-check) (minimum 100
+iterations each):
+
+```typescript
+// Feature: policy-metadata-uri, Property 8: Backend rejects documents failing schema or PII check
+fc.assert(fc.asyncProperty(invalidDocumentArb, async (doc) => {
+  const res = await request(app).post('/policies/1/metadata').send({ doc });
+  expect(res.status).toBe(422);
+}), { numRuns: 100 });
+
+// Feature: policy-metadata-uri, Property 9: Backend rejects hash mismatch
+fc.assert(fc.asyncProperty(docAndMismatchedHashArb, async ({ doc, hash }) => {
+  const res = await request(app).post('/policies/1/metadata').send({ doc, hash });
+  expect(res.status).toBe(409);
+}), { numRuns: 100 });
+```
+
+### Frontend — TypeScript tests (Jest + React Testing Library)
+
+**Unit / example tests**:
+- `useMetadata` with `metadata_uri = null` returns `{ data: null, error: null }`.
+- `useMetadata` with `ipfs://bafyrei…` resolves to gateway URL before fetching.
+- `useMetadata` with a slow mock fetch (> 5 s) returns timeout error.
+- `useMetadata` with a non-2xx response retries at most 2 times.
+- `useMetadata` with mismatched hash returns `tamperWarning = true`.
+- `useMetadata` with unrecognised `schema_version` returns unsupported-schema error.
+
+**Property-based tests** using `fast-check` (minimum 100 iterations each):
+
+```typescript
+// Feature: policy-metadata-uri, Property 7: Frontend tamper detection
+fc.assert(fc.asyncProperty(docAndMismatchedHashArb, async ({ doc, hash }) => {
+  const { result } = renderHook(() => useMetadata({ metadata_uri: 'ipfs://x', metadata_integrity_hash: hash }));
+  // ... mock fetch returning doc bytes
+  expect(result.current.tamperWarning).toBe(true);
+}), { numRuns: 100 });
+
+// Feature: policy-metadata-uri, Property 10: IPFS URI gateway resolution
+fc.assert(fc.property(fc.string().map(cid => `ipfs://${cid}`), (uri) => {
+  const resolved = resolveMetadataUri(uri, GATEWAY);
+  return resolved.startsWith(GATEWAY);
+}), { numRuns: 100 });
+```
+
+### Schema validation tests
+
+- Load `docs/metadata-schema.json` and assert it is valid JSON Schema draft-07.
+- Load each file under `docs/examples/metadata/` and assert it passes the schema.
+- Assert that a document with `pii_free: false` fails the schema.
+- Assert that a document missing `product_name` fails the schema.

--- a/.kiro/specs/policy-metadata-uri/requirements.md
+++ b/.kiro/specs/policy-metadata-uri/requirements.md
@@ -1,0 +1,242 @@
+# Requirements Document
+
+## Introduction
+
+The `policy-metadata-uri` feature adds an optional `metadata_uri` field to the on-chain `Policy`
+struct in the NiffyInsure Soroban contract. The field stores a compact URI or content-addressed
+hash (IPFS CIDv1 or HTTPS URL) that points to a richer JSON document hosted off-chain. That
+document may contain marketing copy, coverage-table PDF links, product-version metadata, or other
+non-sensitive supplementary information. The field is intentionally narrow (strict byte-length
+cap) to avoid chain-storage bloat and to prevent accidental PII leakage. The Next.js frontend
+fetches and caches the referenced document; the TypeScript backend may mirror it for SEO or
+compliance archiving. The JSON schema is versioned independently of the contract and is checked
+into the repository with documented evolution rules.
+
+---
+
+## Glossary
+
+- **Contract**: The NiffyInsure Soroban smart contract deployed on Stellar.
+- **Policy**: The on-chain `Policy` struct defined in `types.rs`; the authoritative record of a
+  single insurance policy.
+- **Metadata_URI**: The optional string field added to `Policy` that holds either an IPFS CIDv1
+  URI (e.g. `ipfs://bafyrei…`) or an HTTPS URL pointing to the off-chain metadata JSON document.
+- **Metadata_JSON**: The off-chain JSON document referenced by `Metadata_URI`; its schema is
+  defined and versioned in `docs/metadata-schema.json`.
+- **CIDv1**: A content-addressed identifier produced by IPFS; immutable by construction — the
+  hash changes if the content changes.
+- **IPFS_Pipeline**: The off-chain tooling (CI script or backend service) responsible for pinning
+  content to IPFS and returning a CIDv1 URI.
+- **Validator**: The Rust validation module `validate.rs` that enforces field constraints before
+  any state mutation.
+- **Frontend**: The Next.js application in `frontend/`.
+- **Backend**: The TypeScript Express service in `backend/src/index.ts`.
+- **Schema_Version**: A semver string embedded in `Metadata_JSON` (e.g. `"1.0.0"`) that
+  identifies the JSON schema revision in use.
+- **Integrity_Hash**: An optional SHA-256 hex digest of the canonical `Metadata_JSON` bytes,
+  stored alongside `Metadata_URI` to enable tamper-evidence verification.
+- **METADATA_URI_MAX_LEN**: The compile-time constant (128 bytes) that caps `Metadata_URI`
+  length; defined in `types.rs` alongside existing field-size constants.
+
+---
+
+## Requirements
+
+### Requirement 1: Optional Metadata URI Field on Policy
+
+**User Story:** As a product manager, I want to attach a URI or content hash to a policy, so that
+richer off-chain documentation can be linked without bloating on-chain storage.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL define a constant `METADATA_URI_MAX_LEN` equal to 128 bytes in `types.rs`,
+   alongside the existing field-size constants.
+2. THE Policy struct SHALL include an optional `metadata_uri` field of type `Option<String>` that
+   defaults to `None` when not supplied.
+3. WHEN a caller provides a `metadata_uri` value, THE Validator SHALL reject any value whose byte
+   length exceeds `METADATA_URI_MAX_LEN` and return a `MetadataUriTooLong` error.
+4. WHEN a caller provides a `metadata_uri` value of zero bytes, THE Validator SHALL reject it and
+   return a `MetadataUriEmpty` error.
+5. WHERE `metadata_uri` is `None`, THE Contract SHALL store the policy without a metadata
+   reference and SHALL NOT allocate ledger storage for the absent field beyond the `Option`
+   discriminant.
+
+---
+
+### Requirement 2: Validation on Policy Create and Update
+
+**User Story:** As a smart-contract developer, I want metadata URI validation enforced at every
+mutating entrypoint, so that invalid or oversized strings never reach persistent storage.
+
+#### Acceptance Criteria
+
+1. WHEN `initiate_policy` is called with a non-`None` `metadata_uri`, THE Validator SHALL execute
+   `check_metadata_uri` before writing the `Policy` to storage.
+2. WHEN `renew_policy` is called with a non-`None` `metadata_uri`, THE Validator SHALL execute
+   `check_metadata_uri` before updating the stored `Policy`.
+3. IF `check_metadata_uri` returns an error, THEN THE Contract SHALL revert the transaction and
+   SHALL NOT modify any storage entry.
+4. WHEN `metadata_uri` is updated to a new non-`None` value during `renew_policy`, THE Contract
+   SHALL emit a `MetadataUriUpdated` contract event containing the `policy_id`, `holder` address,
+   and the new `metadata_uri` value.
+5. WHEN `terminate_policy` is called, THE Contract SHALL preserve the existing `metadata_uri`
+   value in the stored `Policy` record unchanged.
+
+---
+
+### Requirement 3: Immutable CID Preference and Integrity Hash
+
+**User Story:** As a compliance officer, I want metadata references to be tamper-evident, so that
+I can verify the off-chain document has not been altered after the policy was issued.
+
+#### Acceptance Criteria
+
+1. THE IPFS_Pipeline SHALL produce CIDv1 URIs prefixed with `ipfs://` for all metadata documents
+   it pins, ensuring content-addressed immutability.
+2. WHERE an HTTPS URL is used instead of a CIDv1 URI, THE Backend SHALL document the mutability
+   risk in the IPFS pipeline runbook and SHALL require explicit operator acknowledgement.
+3. WHERE tamper-evidence is required, THE Policy struct SHALL include an optional
+   `metadata_integrity_hash` field of type `Option<String>` holding a lowercase hex-encoded
+   SHA-256 digest (64 characters) of the canonical `Metadata_JSON` bytes.
+4. WHEN `metadata_integrity_hash` is provided, THE Validator SHALL verify that its length equals
+   exactly 64 characters and that it contains only hexadecimal characters `[0-9a-f]`; IF either
+   check fails, THEN THE Contract SHALL return a `MetadataIntegrityHashInvalid` error.
+5. THE Frontend SHALL, after fetching `Metadata_JSON`, compute the SHA-256 digest of the received
+   bytes and SHALL compare it to `metadata_integrity_hash` when that field is present; IF the
+   digests differ, THEN THE Frontend SHALL display a tamper-warning banner and SHALL NOT render
+   the metadata content.
+
+---
+
+### Requirement 4: PII and Data-Privacy Guardrails
+
+**User Story:** As a data-privacy officer, I want the system to prevent personal data from being
+placed in publicly resolvable metadata, so that the platform remains compliant with applicable
+privacy regulations.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL NOT store any field that directly encodes policyholder personal data (name,
+   date of birth, national ID, contact details) within `metadata_uri` or
+   `metadata_integrity_hash`.
+2. THE Metadata_JSON schema SHALL define a `pii_free` boolean field that MUST be set to `true`;
+   documents with `pii_free: false` or the field absent SHALL be rejected by the Backend metadata
+   ingestion endpoint.
+3. WHEN the Backend receives a metadata document for mirroring, THE Backend SHALL validate the
+   document against `Metadata_JSON` schema version declared in the document's `schema_version`
+   field before storing it; IF validation fails, THEN THE Backend SHALL return HTTP 422 and SHALL
+   NOT persist the document.
+4. THE IPFS_Pipeline documentation SHALL state that uploading documents containing PII to a public
+   IPFS node without legal clearance is prohibited.
+
+---
+
+### Requirement 5: Off-Chain Metadata JSON Schema
+
+**User Story:** As a frontend developer, I want a versioned, documented JSON schema for the
+metadata document, so that I can reliably parse and display policy metadata across schema
+versions.
+
+#### Acceptance Criteria
+
+1. THE Contract repository SHALL contain a file at `docs/metadata-schema.json` that is a valid
+   JSON Schema (draft-07 or later) defining all required and optional fields of `Metadata_JSON`.
+2. THE `Metadata_JSON` schema SHALL require the following fields: `schema_version` (semver
+   string), `pii_free` (boolean `true`), and `product_name` (non-empty string).
+3. THE `Metadata_JSON` schema SHALL permit the following optional fields: `coverage_table_url`
+   (URI string), `marketing_copy` (string, max 2 000 characters), `pdf_links` (array of URI
+   strings, max 10 items), and `custom` (free-form object for product-specific extensions).
+4. WHEN a breaking change is made to `Metadata_JSON` schema, THE repository SHALL increment the
+   major component of `schema_version` and SHALL add a migration note to
+   `docs/metadata-schema-changelog.md`.
+5. WHEN a non-breaking additive change is made to `Metadata_JSON` schema, THE repository SHALL
+   increment the minor component of `schema_version` and SHALL update `docs/metadata-schema.json`
+   without removing existing required fields.
+6. THE repository SHALL include at least one valid example `Metadata_JSON` document under
+   `docs/examples/metadata/` that passes schema validation.
+
+---
+
+### Requirement 6: Frontend Fetch and Cache
+
+**User Story:** As a policyholder, I want the policy detail page to display enriched metadata
+from the linked document, so that I can see coverage tables and product information without
+leaving the application.
+
+#### Acceptance Criteria
+
+1. WHEN the policy detail page loads and `metadata_uri` is non-null, THE Frontend SHALL fetch the
+   referenced document using the resolved URL within 5 seconds; IF the fetch does not complete
+   within 5 seconds, THEN THE Frontend SHALL display a timeout notice and SHALL render the page
+   without metadata content.
+2. THE Frontend SHALL cache fetched `Metadata_JSON` responses using HTTP cache headers or a
+   client-side cache with a maximum age of 3 600 seconds to avoid redundant network requests.
+3. WHEN `metadata_uri` begins with `ipfs://`, THE Frontend SHALL resolve it through a configured
+   IPFS gateway URL (e.g. `https://ipfs.io/ipfs/{CID}`) before issuing the HTTP request.
+4. IF the fetch returns a non-2xx HTTP status, THEN THE Frontend SHALL display an error notice
+   and SHALL NOT attempt automatic retry more than 2 times with exponential back-off.
+5. THE Frontend SHALL validate the fetched document against the declared `schema_version` before
+   rendering; IF the `schema_version` is unrecognised, THEN THE Frontend SHALL display an
+   unsupported-schema notice.
+
+---
+
+### Requirement 7: Backend Mirroring and SEO / Compliance Archive
+
+**User Story:** As a platform operator, I want the backend to mirror metadata documents, so that
+search engines can index policy information and compliance archives remain available even if the
+original IPFS pin is lost.
+
+#### Acceptance Criteria
+
+1. THE Backend SHALL expose a `POST /policies/:policyId/metadata` endpoint that accepts a
+   `metadata_uri` string and fetches the referenced document for mirroring.
+2. WHEN the Backend mirrors a document, THE Backend SHALL validate it against the `Metadata_JSON`
+   schema before persisting; IF validation fails, THEN THE Backend SHALL return HTTP 422.
+3. THE Backend SHALL expose a `GET /policies/:policyId/metadata` endpoint that returns the
+   mirrored `Metadata_JSON` document with appropriate `Cache-Control` headers.
+4. WHEN `metadata_integrity_hash` is present on the policy, THE Backend SHALL verify the SHA-256
+   digest of the fetched document matches `metadata_integrity_hash`; IF the digests differ, THEN
+   THE Backend SHALL return HTTP 409 and SHALL NOT persist the document.
+5. THE Backend SHALL log each mirroring operation with the `policy_id`, `metadata_uri`, fetch
+   timestamp, and validation outcome for compliance audit purposes.
+
+---
+
+### Requirement 8: Contract Tests for Metadata URI Validation
+
+**User Story:** As a smart-contract developer, I want automated tests that exercise the metadata
+URI validation boundaries, so that regressions in length enforcement are caught before deployment.
+
+#### Acceptance Criteria
+
+1. THE test suite SHALL include a test that calls `initiate_policy` with a `metadata_uri` of
+   exactly `METADATA_URI_MAX_LEN` bytes and asserts the call succeeds.
+2. THE test suite SHALL include a test that calls `initiate_policy` with a `metadata_uri` of
+   `METADATA_URI_MAX_LEN + 1` bytes and asserts the call returns `MetadataUriTooLong`.
+3. THE test suite SHALL include a test that calls `initiate_policy` with an empty `metadata_uri`
+   string and asserts the call returns `MetadataUriEmpty`.
+4. THE test suite SHALL include a test that calls `initiate_policy` with `metadata_uri` set to
+   `None` and asserts the call succeeds and the stored policy has `metadata_uri` equal to `None`.
+5. THE test suite SHALL include a test that calls `renew_policy` with a changed `metadata_uri`
+   and asserts that a `MetadataUriUpdated` event is emitted with the correct fields.
+6. WHEN `metadata_integrity_hash` is provided with a non-hex or wrong-length value, THE test
+   suite SHALL assert the call returns `MetadataIntegrityHashInvalid`.
+
+---
+
+### Requirement 9: IPFS Pipeline Integration Documentation
+
+**User Story:** As a DevOps engineer, I want clear documentation on how metadata URIs are
+produced and represented, so that the IPFS pipeline and the contract use a consistent URI format.
+
+#### Acceptance Criteria
+
+1. THE repository SHALL contain a runbook at `docs/ipfs-pipeline.md` describing the steps to pin
+   a `Metadata_JSON` document to IPFS and obtain a CIDv1 URI.
+2. THE runbook SHALL specify that all CIDv1 URIs stored in `metadata_uri` MUST use the
+   `ipfs://` scheme prefix and base32 encoding (e.g. `ipfs://bafyrei…`).
+3. THE runbook SHALL document the HTTPS gateway fallback pattern and the associated mutability
+   risk acknowledgement process.
+4. THE runbook SHALL include an example end-to-end flow: author document → validate schema →
+   pin to IPFS → record CIDv1 in `initiate_policy` call → Frontend resolves via gateway.

--- a/.kiro/specs/policy-metadata-uri/tasks.md
+++ b/.kiro/specs/policy-metadata-uri/tasks.md
@@ -1,0 +1,213 @@
+# Implementation Plan: policy-metadata-uri
+
+## Overview
+
+Extend the NiffyInsure Soroban contract with optional `metadata_uri` and `metadata_integrity_hash`
+fields on `Policy`, add validation, emit events, create the off-chain JSON schema and docs, wire
+backend mirroring endpoints, and add a frontend `useMetadata` hook with IPFS resolution, caching,
+and tamper detection.
+
+## Tasks
+
+- [ ] 1. Extend `types.rs` with metadata constants and Policy fields
+  - Add `METADATA_URI_MAX_LEN: u32 = 128` and `METADATA_INTEGRITY_HASH_LEN: u32 = 64` constants
+    alongside the existing field-size constants
+  - Add `pub metadata_uri: Option<String>` and `pub metadata_integrity_hash: Option<String>` to
+    the `Policy` struct with doc-comments matching the design
+  - Update `dummy_policy` helper in `tests/types_validate.rs` to supply `None` for both new fields
+    so existing tests continue to compile
+  - _Requirements: 1.1, 1.2, 1.5, 3.3_
+
+  - [ ]* 1.1 Write unit tests for new Policy fields
+    - Assert `METADATA_URI_MAX_LEN == 128` and `METADATA_INTEGRITY_HASH_LEN == 64`
+    - Assert a `Policy` constructed with `metadata_uri: None` has `metadata_uri == None`
+    - _Requirements: 1.1, 1.2, 8.4_
+
+- [ ] 2. Add metadata validation functions to `validate.rs`
+  - Add `MetadataUriTooLong`, `MetadataUriEmpty`, `MetadataIntegrityHashInvalid` variants to the
+    `Error` enum
+  - Implement `pub fn check_metadata_uri(uri: &String) -> Result<(), Error>`: reject empty strings
+    (`MetadataUriEmpty`) and strings whose byte length exceeds `METADATA_URI_MAX_LEN`
+    (`MetadataUriTooLong`)
+  - Implement `pub fn check_integrity_hash(hash: &String) -> Result<(), Error>`: reject strings
+    whose length is not exactly 64 (`MetadataIntegrityHashInvalid`) and strings containing
+    characters outside `[0-9a-f]`
+  - _Requirements: 1.3, 1.4, 3.4_
+
+  - [ ]* 2.1 Write unit tests for `check_metadata_uri` in `tests/types_validate.rs`
+    - Exactly 128-byte URI passes (boundary)
+    - 129-byte URI returns `MetadataUriTooLong` (boundary)
+    - Empty string returns `MetadataUriEmpty`
+    - _Requirements: 1.3, 1.4, 8.1, 8.2, 8.3_
+
+  - [ ]* 2.2 Write unit tests for `check_integrity_hash` in `tests/types_validate.rs`
+    - Valid 64-char lowercase hex string passes
+    - 63-char string returns `MetadataIntegrityHashInvalid`
+    - 65-char string returns `MetadataIntegrityHashInvalid`
+    - String with uppercase hex chars returns `MetadataIntegrityHashInvalid`
+    - _Requirements: 3.4, 8.6_
+
+  - [ ]* 2.3 Write property test for oversized URI rejection (Property 1)
+    - Use `proptest` to generate strings longer than 128 bytes and assert `check_metadata_uri`
+      returns `Err(MetadataUriTooLong)` for all of them
+    - **Property 1: Oversized URI rejected**
+    - **Validates: Requirements 1.3, 8.2**
+
+  - [ ]* 2.4 Write property tests for integrity hash validator (Property 6)
+    - Use `proptest` to generate strings that are not exactly 64 lowercase hex chars and assert
+      `check_integrity_hash` returns `Err(MetadataIntegrityHashInvalid)`
+    - Use `proptest` to generate valid 64-char lowercase hex strings and assert `Ok(())`
+    - **Property 6: Integrity hash validator rejects invalid strings**
+    - **Validates: Requirements 3.4, 8.6**
+
+- [ ] 3. Checkpoint — ensure all contract unit and property tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Implement `initiate_policy` and `renew_policy` in `policy.rs`
+  - Implement `initiate_policy(env, holder, policy_id, policy_type, region, coverage, age,
+    risk_score, metadata_uri, metadata_integrity_hash)`: call `check_metadata_uri` and
+    `check_integrity_hash` (when `Some`) before writing to storage; revert on any error
+  - Implement `renew_policy(env, holder, policy_id, metadata_uri, metadata_integrity_hash)`:
+    call validators before updating storage; emit `MetadataUriUpdated` event when `metadata_uri`
+    changes to a new non-`None` value using topics
+    `["MetadataUriUpdated", policy_id: u32, holder: Address]` and data `new_metadata_uri: String`
+  - Implement `terminate_policy(env, holder, policy_id, reason)`: deactivate policy, leave
+    `metadata_uri` and `metadata_integrity_hash` unchanged
+  - Expose all three functions via `NiffyInsure` contractimpl in `lib.rs`
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+
+  - [ ]* 4.1 Write integration tests for `initiate_policy` metadata paths
+    - `initiate_policy` with `metadata_uri = None` succeeds and stored policy has `metadata_uri == None`
+    - `initiate_policy` with exactly 128-byte URI succeeds
+    - `initiate_policy` with 129-byte URI returns `MetadataUriTooLong`
+    - `initiate_policy` with empty URI returns `MetadataUriEmpty`
+    - `initiate_policy` with invalid integrity hash returns `MetadataIntegrityHashInvalid`
+    - _Requirements: 2.1, 2.3, 8.1, 8.2, 8.3, 8.4, 8.6_
+
+  - [ ]* 4.2 Write integration tests for `renew_policy` and `terminate_policy` metadata paths
+    - `renew_policy` with changed `metadata_uri` emits `MetadataUriUpdated` with correct fields
+    - `terminate_policy` leaves `metadata_uri` and `metadata_integrity_hash` unchanged
+    - _Requirements: 2.4, 2.5, 8.5_
+
+  - [ ]* 4.3 Write property test for None metadata_uri round-trip (Property 2)
+    - Use `proptest` to generate policies with `metadata_uri = None`, write and read back, assert
+      `metadata_uri == None`
+    - **Property 2: None metadata_uri round-trip**
+    - **Validates: Requirements 1.5, 8.4**
+
+  - [ ]* 4.4 Write property test for invalid URI leaves storage unchanged (Property 3)
+    - Use `proptest` to generate invalid URIs (empty or oversized), call `initiate_policy` or
+      `renew_policy`, assert the call reverts and storage is unchanged
+    - **Property 3: Invalid URI leaves storage unchanged**
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+
+  - [ ]* 4.5 Write property test for MetadataUriUpdated event on renew (Property 4)
+    - Use `proptest` to generate valid non-`None` `metadata_uri` values, call `renew_policy`,
+      assert exactly one `MetadataUriUpdated` event is emitted with correct payload
+    - **Property 4: MetadataUriUpdated event emitted on renew**
+    - **Validates: Requirements 2.4, 8.5**
+
+  - [ ]* 4.6 Write property test for terminate_policy preserves metadata_uri (Property 5)
+    - Use `proptest` to generate policies with arbitrary `metadata_uri` values, call
+      `terminate_policy`, assert `metadata_uri` and `metadata_integrity_hash` are unchanged
+    - **Property 5: terminate_policy preserves metadata_uri**
+    - **Validates: Requirements 2.5**
+
+- [ ] 5. Checkpoint — ensure all contract integration and property tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 6. Create off-chain schema and documentation files
+  - Create `docs/metadata-schema.json` as a valid JSON Schema draft-07 with required fields
+    `schema_version` (semver string), `pii_free` (const `true`), `product_name` (non-empty
+    string) and optional fields `coverage_table_url`, `marketing_copy` (max 2000 chars),
+    `pdf_links` (max 10 items), `custom`
+  - Create `docs/metadata-schema-changelog.md` with initial `1.0.0` entry
+  - Create `docs/examples/metadata/example-auto-policy.json` as a valid example document that
+    passes the schema
+  - Create `docs/ipfs-pipeline.md` runbook covering: pin steps, `ipfs://` CIDv1 format
+    requirement, HTTPS fallback mutability risk acknowledgement, and end-to-end example flow
+  - _Requirements: 4.2, 5.1, 5.2, 5.3, 5.6, 9.1, 9.2, 9.3, 9.4_
+
+  - [ ]* 6.1 Write schema validation tests
+    - Load `docs/metadata-schema.json` and assert it is valid JSON Schema draft-07
+    - Load each file under `docs/examples/metadata/` and assert it passes the schema
+    - Assert a document with `pii_free: false` fails the schema
+    - Assert a document missing `product_name` fails the schema
+    - _Requirements: 4.2, 5.1, 5.2, 5.6_
+
+- [ ] 7. Add backend metadata endpoints to `backend/src/index.ts`
+  - Add `ajv` dependency and load `docs/metadata-schema.json` at startup
+  - Implement in-memory `MirrorEntry` store (`Map<string, MirrorEntry>`)
+  - Implement `POST /policies/:policyId/metadata`: fetch URI, validate schema, check `pii_free`,
+    verify SHA-256 against `metadata_integrity_hash` when present, persist entry, log operation;
+    return 422 on schema/PII failure, 409 on hash mismatch, 502 on upstream fetch failure
+  - Implement `GET /policies/:policyId/metadata`: return mirrored document with
+    `Cache-Control: max-age=3600`
+  - _Requirements: 4.2, 4.3, 7.1, 7.2, 7.3, 7.4, 7.5_
+
+  - [ ]* 7.1 Write unit tests for backend metadata endpoints
+    - `POST` with valid document returns 200 and persists
+    - `POST` with `pii_free: false` returns 422
+    - `POST` with missing required field returns 422
+    - `POST` with hash mismatch returns 409
+    - `GET` returns mirrored document with `Cache-Control: max-age=3600`
+    - _Requirements: 4.2, 4.3, 7.1, 7.2, 7.3, 7.4_
+
+  - [ ]* 7.2 Write property test for backend schema/PII rejection (Property 8)
+    - Use `fast-check` to generate documents that fail schema or have `pii_free !== true`, assert
+      `POST` returns 422 and document is not persisted (min 100 runs)
+    - **Property 8: Backend rejects documents failing schema or PII check**
+    - **Validates: Requirements 4.2, 4.3, 7.2**
+
+  - [ ]* 7.3 Write property test for backend hash mismatch rejection (Property 9)
+    - Use `fast-check` to generate valid documents paired with mismatched hashes, assert `POST`
+      returns 409 and document is not persisted (min 100 runs)
+    - **Property 9: Backend rejects hash mismatch**
+    - **Validates: Requirements 7.4**
+
+- [ ] 8. Checkpoint — ensure all backend tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 9. Add `useMetadata` hook and wire into frontend
+  - Create `frontend/src/app/hooks/useMetadata.ts` implementing:
+    - `resolveMetadataUri(uri, gateway)` utility: replace `ipfs://` prefix with gateway URL
+    - Fetch with 5-second `AbortController` timeout
+    - Client-side cache (`Map`) with 3600-second TTL
+    - SHA-256 tamper detection via `crypto.subtle.digest` when `metadata_integrity_hash` is present
+    - Retry logic: at most 2 retries with exponential back-off on non-2xx
+    - `schema_version` recognition check
+    - Returns `{ data, error, tamperWarning }`
+  - Update `frontend/src/app/page.tsx` to call `useMetadata` and render metadata panel or
+    appropriate notice (timeout / error / tamper-warning / unsupported-schema)
+  - _Requirements: 3.5, 6.1, 6.2, 6.3, 6.4, 6.5_
+
+  - [ ]* 9.1 Write unit tests for `useMetadata` hook
+    - `metadata_uri = null` returns `{ data: null, error: null }`
+    - `ipfs://bafyrei…` resolves to gateway URL before fetching
+    - Slow mock fetch (> 5 s) returns timeout error
+    - Non-2xx response retries at most 2 times
+    - Mismatched hash returns `tamperWarning = true`
+    - Unrecognised `schema_version` returns unsupported-schema error
+    - _Requirements: 3.5, 6.1, 6.2, 6.3, 6.4, 6.5_
+
+  - [ ]* 9.2 Write property test for frontend tamper detection (Property 7)
+    - Use `fast-check` to generate document bytes and mismatched hash strings, assert
+      `useMetadata` returns `tamperWarning = true` and does not expose document content (min 100 runs)
+    - **Property 7: Frontend tamper detection**
+    - **Validates: Requirements 3.5**
+
+  - [ ]* 9.3 Write property test for IPFS URI gateway resolution (Property 10)
+    - Use `fast-check` to generate arbitrary CID strings, prepend `ipfs://`, call
+      `resolveMetadataUri`, assert result starts with the configured gateway prefix (min 100 runs)
+    - **Property 10: IPFS URI gateway resolution**
+    - **Validates: Requirements 6.3**
+
+- [ ] 10. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `proptest` (Rust) and `fast-check` (TypeScript/frontend)
+- Checkpoints ensure incremental validation across all three layers


### PR DESCRIPTION
closes #34
Add optional metadata field to Policy with strict length bounds.
Validate on create/update; emit events if mutable.
Document JSON schema with examples checked into repo.
Tests rejecting oversized metadata strings.
Coordinate with IPFS pipeline for how URLs are represented to clients.