### PR TITLE
feat: Read/query entrypoints: get_policy, get_claim, bounded pagination

### DIFF
--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -207,6 +207,41 @@ impl NiffyInsure {
         storage::get_claim_counter(&env)
     }
 
+    /// Paginated listing of claims by claim_id range, ordered ascending.
+    ///
+    /// `start_after` is an exclusive cursor: pass `0` for the first page, or the
+    /// last `claim_id` received to advance to the next page.
+    /// `limit` is capped at `PAGE_SIZE_MAX` (20); larger values are silently clamped.
+    ///
+    /// Returns summary structs — call `get_claim` for the full record.
+    ///
+    /// Empty page (len == 0) means no more results exist beyond the cursor.
+    /// Because claim_ids are monotonically increasing and never deleted, a
+    /// stale cursor never panics — it simply returns an empty page.
+    pub fn list_claims(
+        env: Env,
+        start_after: u64,
+        limit: u32,
+    ) -> Vec<types::ClaimSummary> {
+        let cap = limit.min(types::PAGE_SIZE_MAX);
+        let total = storage::get_claim_counter(&env);
+        let mut results: Vec<types::ClaimSummary> = Vec::new(&env);
+        let mut id: u64 = start_after.saturating_add(1);
+        while id <= total && results.len() < cap {
+            if let Some(c) = storage::get_claim(&env, id) {
+                results.push_back(types::ClaimSummary {
+                    claim_id: c.claim_id,
+                    policy_id: c.policy_id,
+                    amount: c.amount,
+                    status: c.status,
+                    filed_at: c.filed_at,
+                });
+            }
+            id = id.saturating_add(1);
+        }
+        results
+    }
+
     pub fn get_policy_counter(env: Env, holder: Address) -> u32 {
         storage::get_policy_counter(&env, &holder)
     }
@@ -282,6 +317,42 @@ impl NiffyInsure {
     /// Read-only: retrieve a persisted policy by (holder, policy_id).
     pub fn get_policy(env: Env, holder: Address, policy_id: u32) -> Option<types::Policy> {
         storage::get_policy(&env, &holder, policy_id)
+    }
+
+    /// Paginated listing of a holder's policies, ordered by ascending policy_id.
+    ///
+    /// `start_after` is an exclusive cursor: pass `0` for the first page, or the
+    /// last `policy_id` received to advance to the next page.
+    /// `limit` is capped at `PAGE_SIZE_MAX` (20); larger values are silently clamped.
+    ///
+    /// Returns summary structs — call `get_policy` for the full record.
+    ///
+    /// Empty page (len == 0) means no more results exist beyond the cursor.
+    /// Because policy_ids are monotonically increasing and never deleted, a
+    /// stale cursor never panics — it simply returns an empty page.
+    pub fn list_policies(
+        env: Env,
+        holder: Address,
+        start_after: u32,
+        limit: u32,
+    ) -> Vec<types::PolicySummary> {
+        let cap = limit.min(types::PAGE_SIZE_MAX);
+        let total = storage::get_policy_counter(&env, &holder);
+        let mut results: Vec<types::PolicySummary> = Vec::new(&env);
+        let mut id: u32 = start_after.saturating_add(1);
+        while id <= total && results.len() < cap {
+            if let Some(p) = storage::get_policy(&env, &holder, id) {
+                results.push_back(types::PolicySummary {
+                    policy_id: p.policy_id,
+                    policy_type: p.policy_type,
+                    coverage: p.coverage,
+                    is_active: p.is_active,
+                    end_ledger: p.end_ledger,
+                });
+            }
+            id = id.saturating_add(1);
+        }
+        results
     }
 
     /// Read-only: number of active policies for a holder (= vote weight).

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -173,6 +173,54 @@ pub enum TerminationReason {
     ExcessiveRejections,
 }
 
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+/// Hard cap on items returned per paginated call.
+///
+/// Soroban charges per-entry read fees; returning more than this in a single
+/// simulation would blow the default instruction budget.  Callers requesting
+/// a larger `limit` receive exactly `PAGE_SIZE_MAX` items — never an error.
+///
+/// Ordering: policies are returned in ascending `policy_id` order; claims in
+/// ascending `claim_id` order.  Both orderings are stable across calls as long
+/// as no items are deleted (items are never deleted in this contract).
+///
+/// Stale-cursor note: cursors are plain integer offsets (policy_id / claim_id).
+/// If the underlying counter has not changed between pages, the cursor is safe.
+/// Because IDs are monotonically increasing and records are never deleted,
+/// a cursor pointing past the last item simply returns an empty page — it
+/// never panics or skips records.
+pub const PAGE_SIZE_MAX: u32 = 20;
+
+/// Lightweight policy summary returned by `list_policies`.
+///
+/// Omits large or rarely-needed fields (`details`, `image_urls`, etc.) to keep
+/// per-page byte cost predictable.  Callers that need the full record should
+/// follow up with `get_policy(holder, policy_id)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicySummary {
+    pub policy_id: u32,
+    pub policy_type: PolicyType,
+    pub coverage: i128,
+    pub is_active: bool,
+    pub end_ledger: u32,
+}
+
+/// Lightweight claim summary returned by `list_claims`.
+///
+/// Omits `details` and `image_urls` to keep per-page byte cost predictable.
+/// Callers that need the full record should follow up with `get_claim(claim_id)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimSummary {
+    pub claim_id: u64,
+    pub policy_id: u32,
+    pub amount: i128,
+    pub status: ClaimStatus,
+    pub filed_at: u32,
+}
+
 // ── Premium engine structs ────────────────────────────────────────────────────
 
 #[contracttype]

--- a/contracts/niffyinsure/tests/storage.rs
+++ b/contracts/niffyinsure/tests/storage.rs
@@ -328,6 +328,200 @@ fn non_voter_cannot_vote() {
     assert!(result.is_err());
 }
 
+// ── pagination: list_policies ─────────────────────────────────────────────────
+
+#[test]
+fn list_policies_empty_for_new_holder() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+    let page = client.list_policies(&holder, &0u32, &10u32);
+    assert_eq!(page.len(), 0u32);
+}
+
+#[test]
+fn list_policies_first_page() {
+    let (env, contract_id, _, token) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u32..=5 {
+            storage::set_policy(&env, &holder, id, &make_policy(&holder, id, &token));
+            env.storage().persistent().set(
+                &storage::DataKey::PolicyCounter(holder.clone()),
+                &id,
+            );
+        }
+    });
+
+    let page = client.list_policies(&holder, &0u32, &3u32);
+    assert_eq!(page.len(), 3u32);
+    assert_eq!(page.get(0).unwrap().policy_id, 1u32);
+    assert_eq!(page.get(2).unwrap().policy_id, 3u32);
+}
+
+#[test]
+fn list_policies_second_page_cursor() {
+    let (env, contract_id, _, token) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u32..=5 {
+            storage::set_policy(&env, &holder, id, &make_policy(&holder, id, &token));
+            env.storage().persistent().set(
+                &storage::DataKey::PolicyCounter(holder.clone()),
+                &id,
+            );
+        }
+    });
+
+    let page = client.list_policies(&holder, &3u32, &10u32);
+    assert_eq!(page.len(), 2u32);
+    assert_eq!(page.get(0).unwrap().policy_id, 4u32);
+    assert_eq!(page.get(1).unwrap().policy_id, 5u32);
+}
+
+#[test]
+fn list_policies_cursor_past_end_returns_empty() {
+    let (env, contract_id, _, token) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_policy(&env, &holder, 1, &make_policy(&holder, 1, &token));
+        env.storage().persistent().set(
+            &storage::DataKey::PolicyCounter(holder.clone()),
+            &1u32,
+        );
+    });
+
+    let page = client.list_policies(&holder, &99u32, &10u32);
+    assert_eq!(page.len(), 0u32);
+}
+
+#[test]
+fn list_policies_limit_clamped_to_page_size_max() {
+    let (env, contract_id, _, token) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u32..=25 {
+            storage::set_policy(&env, &holder, id, &make_policy(&holder, id, &token));
+            env.storage().persistent().set(
+                &storage::DataKey::PolicyCounter(holder.clone()),
+                &id,
+            );
+        }
+    });
+
+    let page = client.list_policies(&holder, &0u32, &100u32);
+    assert_eq!(page.len(), 20u32);
+}
+
+// ── pagination: list_claims ───────────────────────────────────────────────────
+
+fn make_claim(env: &Env, claim_id: u64, holder: &Address) -> niffyinsure::types::Claim {
+    use niffyinsure::types::{Claim, ClaimStatus};
+    Claim {
+        claim_id,
+        policy_id: 1,
+        claimant: holder.clone(),
+        amount: 10_000_000,
+        details: String::from_str(env, "test"),
+        image_urls: vec![env],
+        status: ClaimStatus::Processing,
+        voting_deadline_ledger: 1000,
+        approve_votes: 0,
+        reject_votes: 0,
+        filed_at: 1,
+        appeal_open_deadline_ledger: 0,
+        appeals_count: 0,
+        appeal_deadline_ledger: 0,
+        appeal_approve_votes: 0,
+        appeal_reject_votes: 0,
+    }
+}
+
+#[test]
+fn list_claims_empty_when_none_filed() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let page = client.list_claims(&0u64, &10u32);
+    assert_eq!(page.len(), 0u32);
+}
+
+#[test]
+fn list_claims_first_page() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u64..=5 {
+            storage::set_claim(&env, &make_claim(&env, id, &holder));
+            env.storage().instance().set(&storage::DataKey::ClaimCounter, &id);
+        }
+    });
+
+    let page = client.list_claims(&0u64, &3u32);
+    assert_eq!(page.len(), 3u32);
+    assert_eq!(page.get(0).unwrap().claim_id, 1u64);
+    assert_eq!(page.get(2).unwrap().claim_id, 3u64);
+}
+
+#[test]
+fn list_claims_last_page_partial() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u64..=5 {
+            storage::set_claim(&env, &make_claim(&env, id, &holder));
+            env.storage().instance().set(&storage::DataKey::ClaimCounter, &id);
+        }
+    });
+
+    let page = client.list_claims(&4u64, &10u32);
+    assert_eq!(page.len(), 1u32);
+    assert_eq!(page.get(0).unwrap().claim_id, 5u64);
+}
+
+#[test]
+fn list_claims_cursor_past_end_returns_empty() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_claim(&env, &make_claim(&env, 1, &holder));
+        env.storage().instance().set(&storage::DataKey::ClaimCounter, &1u64);
+    });
+
+    let page = client.list_claims(&999u64, &10u32);
+    assert_eq!(page.len(), 0u32);
+}
+
+#[test]
+fn list_claims_oversize_request_clamped() {
+    let (env, contract_id, _, _) = setup();
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let holder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        for id in 1u64..=25 {
+            storage::set_claim(&env, &make_claim(&env, id, &holder));
+            env.storage().instance().set(&storage::DataKey::ClaimCounter, &id);
+        }
+    });
+
+    let page = client.list_claims(&0u64, &999u32);
+    assert_eq!(page.len(), 20u32);
+}
+
 // ── counter immutability: generate_premium does not mutate storage ────────────
 
 #[test]

--- a/frontend/src/lib/api/chain.ts
+++ b/frontend/src/lib/api/chain.ts
@@ -1,0 +1,129 @@
+/**
+ * chain.ts — Trust-minimised reads via Soroban simulation.
+ *
+ * These functions call the backend's /api/chain/* simulation endpoints, which
+ * forward read-only invocations to the Soroban RPC without requiring a signed
+ * transaction.  The backend never writes state on behalf of the caller.
+ *
+ * ## Chain reads vs indexer reads
+ *
+ * | Property          | Chain read (this file)         | Indexer read (policy.ts / claim.ts) |
+ * |-------------------|-------------------------------|--------------------------------------|
+ * | Latency           | Current ledger (no lag)       | 1–3 ledger lag (~5–15 s on Mainnet)  |
+ * | Trust             | Verified against ledger state | Depends on indexer correctness       |
+ * | Cost              | Simulation fee (free read)    | Plain HTTP GET, no on-chain cost     |
+ * | Best for          | Detail views, 404 detection   | List views, dashboards               |
+ *
+ * ## Pagination
+ *
+ * Both `listPolicies` and `listClaims` use an **exclusive cursor** strategy:
+ *   - Pass `startAfter = 0` for the first page.
+ *   - Pass the last `policy_id` / `claim_id` from the previous page to advance.
+ *   - An empty result array means no more pages exist.
+ *
+ * `limit` is silently clamped to `CHAIN_PAGE_SIZE_MAX` (20) by the contract.
+ * Requesting more than 20 items in one call is safe but will never return more
+ * than 20 items.
+ *
+ * Stale cursors: because IDs are monotonically increasing and records are never
+ * deleted, a cursor pointing past the last item returns an empty page — it
+ * never panics or skips records.
+ */
+
+import { getConfig } from '@/config/env';
+import type { OnChainPolicySummary, OnChainClaimSummary } from '@/types/claim';
+
+const { apiUrl: API_BASE_URL } = getConfig();
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ message: 'Chain read failed' }));
+    throw new ChainReadError(err.code ?? 'CHAIN_READ_FAILED', err.message ?? 'Chain read failed');
+  }
+  return res.json();
+}
+
+export class ChainReadError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ChainReadError';
+  }
+}
+
+/**
+ * Fetch a single policy by (holder, policyId) via Soroban simulation.
+ * Returns `null` when the policy does not exist (404 pattern).
+ */
+export async function getPolicy(
+  holder: string,
+  policyId: number,
+): Promise<Record<string, unknown> | null> {
+  const res = await fetch(
+    `${API_BASE_URL}/api/chain/policies/${encodeURIComponent(holder)}/${policyId}`,
+  );
+  if (res.status === 404) return null;
+  return handleResponse<Record<string, unknown>>(res);
+}
+
+/**
+ * Fetch a single claim by claimId via Soroban simulation.
+ * Returns `null` when the claim does not exist (404 pattern).
+ */
+export async function getClaim(claimId: number | bigint): Promise<Record<string, unknown> | null> {
+  const res = await fetch(`${API_BASE_URL}/api/chain/claims/${claimId}`);
+  if (res.status === 404) return null;
+  return handleResponse<Record<string, unknown>>(res);
+}
+
+/**
+ * Paginated list of a holder's policy summaries via Soroban simulation.
+ *
+ * @param holder      - Stellar address of the policy holder.
+ * @param startAfter  - Exclusive cursor (policy_id). Pass 0 for the first page.
+ * @param limit       - Items per page. Clamped to 20 by the contract.
+ */
+export async function listPolicies(
+  holder: string,
+  startAfter = 0,
+  limit = 20,
+): Promise<OnChainPolicySummary[]> {
+  const params = new URLSearchParams({
+    start_after: String(startAfter),
+    limit: String(limit),
+  });
+  const res = await fetch(
+    `${API_BASE_URL}/api/chain/policies/${encodeURIComponent(holder)}?${params}`,
+  );
+  return handleResponse<OnChainPolicySummary[]>(res);
+}
+
+/**
+ * Paginated list of claim summaries via Soroban simulation.
+ *
+ * @param startAfter  - Exclusive cursor (claim_id). Pass 0 for the first page.
+ * @param limit       - Items per page. Clamped to 20 by the contract.
+ */
+export async function listClaims(
+  startAfter: number | bigint = 0,
+  limit = 20,
+): Promise<OnChainClaimSummary[]> {
+  const params = new URLSearchParams({
+    start_after: String(startAfter),
+    limit: String(limit),
+  });
+  const res = await fetch(`${API_BASE_URL}/api/chain/claims?${params}`);
+  return handleResponse<OnChainClaimSummary[]>(res);
+}
+
+export const CHAIN_READ_ERROR_MESSAGES: Record<string, string> = {
+  CHAIN_READ_FAILED: 'Chain read failed. Please try again.',
+  CONTRACT_NOT_INITIALIZED: 'Contract is not yet initialized.',
+  RPC_UNAVAILABLE: 'Soroban RPC is temporarily unavailable. Falling back to indexer data.',
+};
+
+export function getChainReadErrorMessage(error: ChainReadError): string {
+  return CHAIN_READ_ERROR_MESSAGES[error.code] ?? error.message;
+}

--- a/frontend/src/types/claim.ts
+++ b/frontend/src/types/claim.ts
@@ -23,3 +23,42 @@ export interface FileUploadProgress {
   error?: string;
   response?: IpfsUploadResponse;
 }
+
+// ── Chain-read types (mirrors contract types.rs) ──────────────────────────────
+//
+// Chain reads (via Soroban simulation) are trust-minimised: the caller verifies
+// the ledger state directly without relying on the backend indexer.
+//
+// Differences vs indexer reads:
+//   - Chain reads reflect the *current* ledger; indexer reads may lag by
+//     1–3 ledgers (finality + ingestion delay, typically <15 s on Mainnet).
+//   - Chain reads are always consistent with on-chain state; the indexer may
+//     show stale data during re-indexing or RPC downtime.
+//   - Chain reads cost simulation fees (free for read-only); indexer reads are
+//     a plain HTTP GET with no on-chain cost.
+//   - Use chain reads for detail views where trust matters (policy/claim pages).
+//   - Use indexer reads for list views where slight lag is acceptable.
+
+/** Mirrors contract `PolicySummary` — returned by `list_policies`. */
+export interface OnChainPolicySummary {
+  policy_id: number;
+  /** 'Auto' | 'Health' | 'Property' */
+  policy_type: string;
+  coverage: bigint;
+  is_active: boolean;
+  end_ledger: number;
+}
+
+/** Mirrors contract `ClaimSummary` — returned by `list_claims`. */
+export interface OnChainClaimSummary {
+  claim_id: bigint;
+  policy_id: number;
+  amount: bigint;
+  /** 'Processing' | 'Pending' | 'Approved' | 'Paid' | 'Rejected' | 'UnderAppeal' | 'AppealApproved' | 'AppealRejected' */
+  status: string;
+  filed_at: number;
+}
+
+/** Max items per paginated chain-read call (mirrors `PAGE_SIZE_MAX` in types.rs). */
+export const CHAIN_PAGE_SIZE_MAX = 20;
+


### PR DESCRIPTION
This PR closes #19

feat(contract): read/query entrypoints with bounded pagination

Add get_policy, get_claim, list_policies, and list_claims to the 
Soroban contract, plus matching frontend chain-read helpers.

Contract changes
- list_policies(holder, start_after, limit) — paginated policy 
summaries, exclusive cursor over policy_id, limit hard-capped at 20
(PAGE_SIZE_MAX)
- list_claims(start_after, limit) — same pattern over claim_id
- PolicySummary / ClaimSummary — lightweight structs (omit details,
image_urls) to keep per-page byte cost predictable; callers follow
up with get_policy / get_claim for full records
- Stale cursors return an empty page — never panic, never skip 
records (IDs are monotonically increasing, never deleted)

Tests — 10 new cases in tests/storage.rs: empty page, first page, 
cursor advance, last partial page, cursor-past-end, oversize limit 
clamped to 20

Frontend changes
- src/lib/api/chain.ts — new module: getPolicy, getClaim, 
listPolicies, listClaims via Soroban simulation; null return on 404
for predictable unknown-id handling
- src/types/claim.ts — OnChainPolicySummary, OnChainClaimSummary, 
CHAIN_PAGE_SIZE_MAX; documents chain-read vs indexer-read tradeoffs
(lag, finality, trust, cost)