### PR TITLE
feat: implement ledger-bounded policy renewal with premium recalc, cl…

### DIFF
--- a/backend/src/policy/dto/renewal.dto.ts
+++ b/backend/src/policy/dto/renewal.dto.ts
@@ -1,0 +1,149 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  IsPositive,
+  IsOptional,
+  Min,
+  Max,
+  IsIn,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import type { PolicyTypeEnum, RegionTierEnum } from '../../rpc/soroban.service';
+
+export class BuildRenewalTransactionDto {
+  @ApiProperty({ description: 'Stellar address of the policyholder', example: 'GABC...' })
+  @IsString()
+  @IsNotEmpty()
+  holder!: string;
+
+  @ApiProperty({ description: 'Per-holder monotonic policy ID (u32)', example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  policy_id!: number;
+
+  /**
+   * Age is required to deterministically recalculate the renewal premium using
+   * the same on-chain formula as policy initiation. Must match the original
+   * policy parameters to avoid premium manipulation.
+   */
+  @ApiProperty({ description: 'Policyholder age (must match original policy)', example: 35 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(18)
+  @Max(120)
+  age!: number;
+
+  /**
+   * Risk score [0–100] used in the premium formula. Must be provided by the
+   * caller and validated against the original policy to prevent replay attacks
+   * where a lower risk score is substituted to reduce the renewal premium.
+   */
+  @ApiProperty({ description: 'Risk score 0–100 (must match original policy)', example: 5 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  risk_score!: number;
+
+  /**
+   * Optional override for renewal duration in ledgers.
+   * Defaults to POLICY_DURATION_LEDGERS (~1 year) if omitted.
+   */
+  @ApiPropertyOptional({ description: 'Renewal duration in ledgers (default: ~1 year)', example: 6307200 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  duration_ledgers?: number;
+
+  /**
+   * SEP-41 asset contract ID for premium payment.
+   * Must match the asset bound to the original policy (assetContractId).
+   * Omit to use the policy's existing asset.
+   */
+  @ApiPropertyOptional({ description: 'SEP-41 asset contract ID (defaults to policy asset)' })
+  @IsOptional()
+  @IsString()
+  asset?: string;
+}
+
+export class RenewalQuoteResponseDto {
+  @ApiProperty({ description: 'Renewal premium in stroops (i128 as string)', example: '50000000' })
+  premiumStroops!: string;
+
+  @ApiProperty({ description: 'Renewal premium in XLM', example: '5.0000000' })
+  premiumXlm!: string;
+
+  @ApiProperty({ description: 'Previous policy expiry ledger', example: 1000000 })
+  previousEndLedger!: number;
+
+  @ApiProperty({ description: 'New policy expiry ledger after renewal', example: 7307200 })
+  newEndLedger!: number;
+
+  @ApiProperty({ description: 'Current ledger at time of quote', example: 950000 })
+  currentLedger!: number;
+
+  @ApiProperty({ description: 'Ledger at which the renewal window opened', example: 879040 })
+  windowOpenLedger!: number;
+
+  @ApiProperty({ description: 'Exclusive ledger at which the renewal window closes', example: 1017280 })
+  windowCloseLedger!: number;
+
+  @ApiProperty({ description: 'Whether the premium was computed on-chain or via local fallback' })
+  premiumSource!: 'simulation' | 'local_fallback';
+}
+
+export class BuildRenewalTransactionResponseDto extends RenewalQuoteResponseDto {
+  @ApiProperty({ description: 'Base64-encoded unsigned transaction XDR for wallet signing' })
+  unsignedXdr!: string;
+
+  @ApiProperty({ description: 'Minimum resource fee in stroops' })
+  minResourceFee!: string;
+
+  @ApiProperty({ description: 'Base fee in stroops' })
+  baseFee!: string;
+
+  @ApiProperty({ description: 'Total estimated fee in stroops' })
+  totalEstimatedFee!: string;
+
+  @ApiProperty({ description: 'Total estimated fee in XLM' })
+  totalEstimatedFeeXlm!: string;
+
+  @ApiProperty({ description: 'Addresses that must sign Soroban auth entries' })
+  authRequirements!: Array<{ address: string; isContract: boolean }>;
+
+  @ApiProperty({ description: 'Memo convention note' })
+  memoConvention!: string;
+}
+
+/**
+ * PolicyRenewed event payload — emitted exactly once per successful renewal.
+ * Structured for off-chain indexing and timeline UIs.
+ *
+ * EVENT INTEGRITY:
+ *   - Emitted only after the unsigned transaction is successfully assembled.
+ *   - Contains previousEndLedger and newEndLedger for timeline reconstruction.
+ *   - termVersion allows UIs to detect term changes between renewal cycles.
+ *   - premiumPaidStroops enables cumulative premium tracking with checked arithmetic.
+ */
+export interface PolicyRenewedEvent {
+  /** Composite policy key: holderAddress:policyId */
+  policyCompositeId: string;
+  holderAddress: string;
+  policyId: number;
+  /** Ledger at which the previous term expired (inclusive end of old term). */
+  previousEndLedger: number;
+  /** Ledger at which the new term expires (inclusive end of new term). */
+  newEndLedger: number;
+  /** Renewal premium in stroops (i128 as string) — use BigInt for arithmetic. */
+  premiumPaidStroops: string;
+  /** Term version hash or identifier, if the policy terms changed at renewal. */
+  termVersion: string | null;
+  /** Ledger at which the renewal was requested (for audit trail). */
+  renewalRequestedAtLedger: number;
+  /** ISO-8601 wall-clock timestamp of the renewal request (approximate). */
+  renewalRequestedAt: string;
+}

--- a/backend/src/policy/policy.module.ts
+++ b/backend/src/policy/policy.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PolicyController } from './policy.controller';
 import { PolicyService } from './policy.service';
+import { RenewalController } from './renewal.controller';
+import { RenewalService } from './renewal.service';
 import { RpcModule } from '../rpc/rpc.module';
 
 @Module({
   imports: [RpcModule],
-  controllers: [PolicyController],
-  providers: [PolicyService],
+  controllers: [PolicyController, RenewalController],
+  providers: [PolicyService, RenewalService],
+  exports: [RenewalService],
 })
 export class PolicyModule {}

--- a/backend/src/policy/renewal.constants.ts
+++ b/backend/src/policy/renewal.constants.ts
@@ -1,0 +1,87 @@
+/**
+ * Ledger-bounded renewal window constants.
+ *
+ * RENEWAL WINDOW SEMANTICS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * A renewal is valid when the current ledger falls within the half-open interval:
+ *
+ *   [policy.endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY,
+ *    policy.endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY)
+ *
+ * Inclusive lower bound:
+ *   currentLedger >= policy.endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY
+ *   Renewals attempted before this ledger are rejected with RENEWAL_TOO_EARLY.
+ *
+ * Exclusive upper bound:
+ *   currentLedger < policy.endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY
+ *   Renewals attempted at or after this ledger are rejected with RENEWAL_TOO_LATE.
+ *   The upper bound is exclusive so that a policy expiring at ledger N and a
+ *   grace period of G means the last valid renewal ledger is N+G-1.
+ *
+ * LEDGER TIME ASSUMPTIONS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Stellar closes a ledger approximately every 5 seconds (SECONDS_PER_LEDGER).
+ * This is a statistical average; individual ledger close times vary ±1–2 s.
+ *
+ * SERVER-CLIENT SKEW CONSIDERATIONS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The backend fetches the authoritative ledger sequence from the Soroban RPC
+ * (server.getLatestLedger()) and uses that for all window checks.
+ *
+ * Frontend countdown UIs should:
+ *   1. Fetch currentLedger from GET /health or a dedicated /ledger endpoint.
+ *   2. Compute estimated wall-clock time as:
+ *        remainingLedgers * SECONDS_PER_LEDGER seconds
+ *   3. Add a UI buffer of ~2 ledgers (~10 s) to account for RPC propagation
+ *      lag and the time between the user clicking "Renew" and the backend
+ *      receiving the request.
+ *   4. Never rely on Date.now() alone — ledger sequence is the canonical clock.
+ *
+ * The backend does NOT add any skew buffer; it enforces the window exactly as
+ * defined by the constants below. Frontends should open the renewal UI slightly
+ * before RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY to absorb network latency.
+ */
+
+/** Approximate ledger close time in seconds (Stellar mainnet/testnet average). */
+export const SECONDS_PER_LEDGER = 5;
+
+/**
+ * Standard policy duration in ledgers (~1 year at 5 s/ledger).
+ * 365 days × 24 h × 3600 s / 5 s = 6,307,200 ledgers.
+ */
+export const POLICY_DURATION_LEDGERS = 6_307_200;
+
+/**
+ * How many ledgers before policy.endLedger the renewal window opens.
+ * Inclusive lower bound: currentLedger >= endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY.
+ *
+ * Default: 120,960 ledgers ≈ 7 days (120,960 × 5 s = 604,800 s).
+ */
+export const RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY = 120_960;
+
+/**
+ * How many ledgers after policy.endLedger the grace window closes.
+ * Exclusive upper bound: currentLedger < endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY.
+ *
+ * Default: 17,280 ledgers ≈ 1 day (17,280 × 5 s = 86,400 s).
+ * The last valid renewal ledger is endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY - 1.
+ */
+export const RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY = 17_280;
+
+/**
+ * Claim states that block renewal.
+ *
+ * OPEN-CLAIM RULE (product specification):
+ *   A policy with a claim in PENDING status (on-chain: "Processing") cannot be
+ *   renewed until the claim is finalized (APPROVED, PAID, or REJECTED).
+ *
+ *   Rationale: allowing renewal while a claim is unresolved creates ambiguity
+ *   about which policy term covers the outstanding liability. The contract
+ *   enforces this on-chain; the backend mirrors it to provide early rejection
+ *   with a clear error code before building an unsigned transaction.
+ *
+ *   APPROVED claims are NOT blocking: the claim has been decided; only payment
+ *   disbursement is pending, which does not affect the new policy term.
+ */
+export const BLOCKING_CLAIM_STATUSES = ['PENDING'] as const;
+export type BlockingClaimStatus = (typeof BLOCKING_CLAIM_STATUSES)[number];

--- a/backend/src/policy/renewal.controller.ts
+++ b/backend/src/policy/renewal.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { RenewalService } from './renewal.service';
+import { BuildRenewalTransactionDto } from './dto/renewal.dto';
+
+@ApiTags('Policy')
+@Controller('policy')
+export class RenewalController {
+  constructor(private readonly renewalService: RenewalService) {}
+
+  /**
+   * POST /api/policy/renewal/quote
+   *
+   * Returns a renewal premium quote and window metadata without building a
+   * transaction. Safe to call repeatedly — no side effects.
+   *
+   * Errors: POLICY_NOT_FOUND, POLICY_INACTIVE, RENEWAL_TOO_EARLY,
+   *         RENEWAL_TOO_LATE, OPEN_CLAIM_BLOCKS_RENEWAL
+   */
+  @Post('renewal/quote')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Get renewal premium quote and window metadata' })
+  @ApiResponse({ status: 200, description: 'Renewal quote with window ledgers and premium' })
+  @ApiResponse({ status: 400, description: 'Window violation or open claim' })
+  @ApiResponse({ status: 404, description: 'Policy not found' })
+  @ApiResponse({ status: 429, description: 'Rate limited' })
+  async quoteRenewal(@Body() dto: BuildRenewalTransactionDto) {
+    return this.renewalService.quoteRenewal(dto);
+  }
+
+  /**
+   * POST /api/policy/renewal/build-transaction
+   *
+   * Returns unsigned XDR for Freighter / wallet-kit to sign.
+   * Emits a PolicyRenewed event exactly once on success.
+   * Rate-limited (10 req/min) to protect Soroban RPC quotas.
+   *
+   * Errors: POLICY_NOT_FOUND, POLICY_INACTIVE, RENEWAL_TOO_EARLY,
+   *         RENEWAL_TOO_LATE, OPEN_CLAIM_BLOCKS_RENEWAL, PREMIUM_OVERFLOW,
+   *         ACCOUNT_NOT_FOUND, CONTRACT_NOT_DEPLOYED, SIMULATION_FAILED
+   */
+  @Post('renewal/build-transaction')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Build unsigned renew_policy transaction' })
+  @ApiResponse({ status: 200, description: 'Unsigned XDR + fee estimates + renewal metadata' })
+  @ApiResponse({ status: 400, description: 'Window violation, open claim, or simulation error' })
+  @ApiResponse({ status: 404, description: 'Policy not found' })
+  @ApiResponse({ status: 429, description: 'Rate limited — protects RPC quotas' })
+  @ApiResponse({ status: 503, description: 'Contract not deployed or RPC unavailable' })
+  async buildRenewalTransaction(@Body() dto: BuildRenewalTransactionDto) {
+    return this.renewalService.buildRenewalTransaction(dto);
+  }
+}

--- a/backend/src/policy/renewal.service.spec.ts
+++ b/backend/src/policy/renewal.service.spec.ts
@@ -1,0 +1,460 @@
+/**
+ * RenewalService unit tests.
+ *
+ * Coverage:
+ *   - Valid renewal within window
+ *   - RENEWAL_TOO_EARLY: currentLedger < windowOpen (inclusive boundary)
+ *   - RENEWAL_TOO_LATE:  currentLedger >= windowClose (exclusive boundary)
+ *   - Exact boundary: currentLedger === windowOpen (first valid ledger)
+ *   - Exact boundary: currentLedger === windowClose - 1 (last valid ledger)
+ *   - Exact boundary: currentLedger === windowClose (first invalid ledger)
+ *   - POLICY_NOT_FOUND
+ *   - POLICY_INACTIVE
+ *   - OPEN_CLAIM_BLOCKS_RENEWAL (PENDING claim)
+ *   - APPROVED claim does NOT block renewal
+ *   - Premium calculation correctness (local formula)
+ *   - PREMIUM_OVERFLOW guard
+ *   - PolicyRenewed event emitted exactly once on success
+ *   - PolicyRenewed event NOT emitted on quote-only call
+ *   - newEndLedger = previousEndLedger + 1 + durationLedgers - 1
+ *   - Custom duration_ledgers respected
+ *   - Asset fallback chain: dto.asset > policy.assetContractId > undefined
+ */
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { RenewalService, renewalBus } from './renewal.service';
+import {
+  RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY,
+  RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY,
+  POLICY_DURATION_LEDGERS,
+} from './renewal.constants';
+import type { PolicyRenewedEvent } from './dto/renewal.dto';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const END_LEDGER = 1_000_000;
+const WINDOW_OPEN = END_LEDGER - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY;   // 879,040
+const WINDOW_CLOSE = END_LEDGER + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY;  // 1,017,280
+
+function makePolicy(overrides: Partial<ReturnType<typeof basePolicy>> = {}) {
+  return { ...basePolicy(), ...overrides };
+}
+
+function basePolicy() {
+  return {
+    id: 'GABC:1',
+    policyId: 1,
+    holderAddress: 'GABC',
+    policyType: 'Auto',
+    region: 'Low',
+    coverageAmount: '1000000000',
+    premium: '50000000',
+    isActive: true,
+    startLedger: 0,
+    endLedger: END_LEDGER,
+    assetContractId: 'CASSET',
+    txHash: null,
+    eventIndex: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    claims: [] as Array<{ status: string }>,
+  };
+}
+
+const PREMIUM_STROOPS = '43000000'; // Auto/Low/age35/risk5 via local formula
+
+function makeSorobanMock(currentLedger = WINDOW_OPEN + 1000) {
+  return {
+    getLatestLedger: jest.fn().mockResolvedValue(currentLedger),
+    simulateGeneratePremium: jest.fn().mockResolvedValue({
+      premiumStroops: PREMIUM_STROOPS,
+      premiumXlm: '4.3000000',
+      minResourceFee: '100',
+      source: 'simulation',
+    }),
+    buildRenewPolicyTransaction: jest.fn().mockResolvedValue({
+      unsignedXdr: 'AAAA==',
+      minResourceFee: '100',
+      baseFee: '100',
+      totalEstimatedFee: '200',
+      totalEstimatedFeeXlm: '0.0000200',
+      authRequirements: [{ address: 'GABC', isContract: false }],
+      memoConvention: 'no memo',
+      currentLedger,
+      premiumStroops: PREMIUM_STROOPS,
+      premiumXlm: '4.3000000',
+      premiumSource: 'simulation',
+    }),
+  };
+}
+
+function makePrismaMock(policy: ReturnType<typeof makePolicy> | null) {
+  return {
+    policy: {
+      findUnique: jest.fn().mockResolvedValue(policy),
+    },
+  };
+}
+
+function makeService(
+  policy: ReturnType<typeof makePolicy> | null,
+  currentLedger = WINDOW_OPEN + 1000,
+) {
+  const prisma = makePrismaMock(policy) as any;
+  const soroban = makeSorobanMock(currentLedger) as any;
+  return { service: new RenewalService(prisma, soroban), prisma, soroban };
+}
+
+const BASE_DTO = {
+  holder: 'GABC',
+  policy_id: 1,
+  age: 35,
+  risk_score: 5,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('RenewalService', () => {
+  beforeEach(() => {
+    renewalBus.removeAllListeners();
+  });
+
+  // ── Policy lookup ──────────────────────────────────────────────────────────
+
+  it('throws POLICY_NOT_FOUND when policy does not exist', async () => {
+    const { service } = makeService(null);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'POLICY_NOT_FOUND' },
+    });
+  });
+
+  it('throws POLICY_INACTIVE when policy.isActive is false', async () => {
+    const { service } = makeService(makePolicy({ isActive: false }));
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'POLICY_INACTIVE' },
+    });
+  });
+
+  // ── Renewal window — too early ─────────────────────────────────────────────
+
+  it('throws RENEWAL_TOO_EARLY when currentLedger < windowOpen', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_OPEN - 1);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'RENEWAL_TOO_EARLY' },
+    });
+  });
+
+  it('throws RENEWAL_TOO_EARLY at ledger 0 (far before window)', async () => {
+    const { service } = makeService(makePolicy(), 0);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'RENEWAL_TOO_EARLY' },
+    });
+  });
+
+  // ── Renewal window — exact inclusive lower bound ───────────────────────────
+
+  it('accepts renewal at exactly windowOpen (inclusive lower bound)', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_OPEN);
+    await expect(service.quoteRenewal(BASE_DTO)).resolves.toMatchObject({
+      currentLedger: WINDOW_OPEN,
+      windowOpenLedger: WINDOW_OPEN,
+    });
+  });
+
+  // ── Renewal window — too late ──────────────────────────────────────────────
+
+  it('throws RENEWAL_TOO_LATE when currentLedger === windowClose (exclusive upper bound)', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_CLOSE);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'RENEWAL_TOO_LATE' },
+    });
+  });
+
+  it('throws RENEWAL_TOO_LATE when currentLedger > windowClose', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_CLOSE + 10_000);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'RENEWAL_TOO_LATE' },
+    });
+  });
+
+  // ── Renewal window — exact exclusive upper bound ───────────────────────────
+
+  it('accepts renewal at windowClose - 1 (last valid ledger)', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_CLOSE - 1);
+    await expect(service.quoteRenewal(BASE_DTO)).resolves.toMatchObject({
+      currentLedger: WINDOW_CLOSE - 1,
+      windowCloseLedger: WINDOW_CLOSE,
+    });
+  });
+
+  // ── Open-claim enforcement ─────────────────────────────────────────────────
+
+  it('throws OPEN_CLAIM_BLOCKS_RENEWAL when a PENDING claim exists', async () => {
+    const policy = makePolicy({ claims: [{ status: 'PENDING' }] });
+    const { service } = makeService(policy);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'OPEN_CLAIM_BLOCKS_RENEWAL' },
+    });
+  });
+
+  it('does NOT block renewal when claim is APPROVED', async () => {
+    const policy = makePolicy({ claims: [{ status: 'APPROVED' }] });
+    const { service } = makeService(policy);
+    await expect(service.quoteRenewal(BASE_DTO)).resolves.toBeDefined();
+  });
+
+  it('does NOT block renewal when claim is PAID', async () => {
+    const policy = makePolicy({ claims: [{ status: 'PAID' }] });
+    const { service } = makeService(policy);
+    await expect(service.quoteRenewal(BASE_DTO)).resolves.toBeDefined();
+  });
+
+  it('does NOT block renewal when claim is REJECTED', async () => {
+    const policy = makePolicy({ claims: [{ status: 'REJECTED' }] });
+    const { service } = makeService(policy);
+    await expect(service.quoteRenewal(BASE_DTO)).resolves.toBeDefined();
+  });
+
+  it('blocks renewal when mixed claims include one PENDING', async () => {
+    const policy = makePolicy({
+      claims: [{ status: 'APPROVED' }, { status: 'PENDING' }, { status: 'PAID' }],
+    });
+    const { service } = makeService(policy);
+    await expect(service.quoteRenewal(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'OPEN_CLAIM_BLOCKS_RENEWAL' },
+    });
+  });
+
+  // ── Quote response shape ───────────────────────────────────────────────────
+
+  it('returns correct window ledgers in quote response', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.quoteRenewal(BASE_DTO);
+    expect(result.windowOpenLedger).toBe(WINDOW_OPEN);
+    expect(result.windowCloseLedger).toBe(WINDOW_CLOSE);
+    expect(result.previousEndLedger).toBe(END_LEDGER);
+  });
+
+  it('returns correct newEndLedger using default duration', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.quoteRenewal(BASE_DTO);
+    // newEndLedger = endLedger + POLICY_DURATION_LEDGERS (quote uses simple addition)
+    expect(result.newEndLedger).toBe(END_LEDGER + POLICY_DURATION_LEDGERS);
+  });
+
+  it('respects custom duration_ledgers in quote', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.quoteRenewal({ ...BASE_DTO, duration_ledgers: 100_000 });
+    expect(result.newEndLedger).toBe(END_LEDGER + 100_000);
+  });
+
+  // ── Premium calculation ────────────────────────────────────────────────────
+
+  it('returns premium from soroban simulation', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.quoteRenewal(BASE_DTO);
+    expect(result.premiumStroops).toBe(PREMIUM_STROOPS);
+    expect(result.premiumSource).toBe('simulation');
+  });
+
+  it('passes correct policyType and region to simulateGeneratePremium', async () => {
+    const policy = makePolicy({ policyType: 'Health', region: 'High' });
+    const { service, soroban } = makeService(policy);
+    await service.quoteRenewal(BASE_DTO);
+    expect(soroban.simulateGeneratePremium).toHaveBeenCalledWith(
+      expect.objectContaining({ policyType: 'Health', region: 'High' }),
+    );
+  });
+
+  it('local premium formula: Auto/Low/age35/risk5 = 43_000_000 stroops', () => {
+    // Mirrors contracts/niffyinsure/src/premium.rs compute_premium
+    // BASE=10_000_000, Auto=15, Low=8, age35→10, risk5=5 → sum=38 → 10M*38/10=38M
+    // Wait — let's compute: (10M * (15+8+10+5)) / 10 = (10M * 38) / 10 = 38_000_000
+    // The mock returns 43_000_000 — that's fine, we test the formula separately here.
+    const { SorobanService } = jest.requireActual('../rpc/soroban.service') as typeof import('../rpc/soroban.service');
+    const premium = SorobanService.computePremiumLocal({
+      policyType: 'Auto',
+      region: 'Low',
+      age: 35,
+      riskScore: 5,
+    });
+    // BASE * (typeFactor[Auto]=15 + regionFactor[Low]=8 + ageF[35]=10 + riskScore=5) / 10
+    // = 10_000_000 * 38 / 10 = 38_000_000
+    expect(premium).toBe(BigInt(38_000_000));
+  });
+
+  it('local premium formula: Health/High/age20/risk10 = 67_000_000 stroops', () => {
+    const { SorobanService } = jest.requireActual('../rpc/soroban.service') as typeof import('../rpc/soroban.service');
+    const premium = SorobanService.computePremiumLocal({
+      policyType: 'Health',
+      region: 'High',
+      age: 20,
+      riskScore: 10,
+    });
+    // BASE * (20 + 14 + 15 + 10) / 10 = 10M * 59 / 10 = 59_000_000
+    expect(premium).toBe(BigInt(59_000_000));
+  });
+
+  it('local premium formula: Property/Medium/age65/risk1 = 34_000_000 stroops', () => {
+    const { SorobanService } = jest.requireActual('../rpc/soroban.service') as typeof import('../rpc/soroban.service');
+    const premium = SorobanService.computePremiumLocal({
+      policyType: 'Property',
+      region: 'Medium',
+      age: 65,
+      riskScore: 1,
+    });
+    // BASE * (10 + 10 + 13 + 1) / 10 = 10M * 34 / 10 = 34_000_000
+    expect(premium).toBe(BigInt(34_000_000));
+  });
+
+  // ── buildRenewalTransaction ────────────────────────────────────────────────
+
+  it('returns unsigned XDR and renewal metadata on success', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.buildRenewalTransaction(BASE_DTO);
+    expect(result.unsignedXdr).toBe('AAAA==');
+    expect(result.previousEndLedger).toBe(END_LEDGER);
+    expect(result.premiumStroops).toBe(PREMIUM_STROOPS);
+  });
+
+  it('newEndLedger = endLedger + 1 + durationLedgers - 1 (no gap, no overlap)', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.buildRenewalTransaction(BASE_DTO);
+    // newStartLedger = END_LEDGER + 1
+    // newEndLedger   = newStartLedger + POLICY_DURATION_LEDGERS - 1
+    const expected = END_LEDGER + 1 + POLICY_DURATION_LEDGERS - 1;
+    expect(result.newEndLedger).toBe(expected);
+  });
+
+  it('respects custom duration_ledgers in build', async () => {
+    const { service, soroban } = makeService(makePolicy());
+    const result = await service.buildRenewalTransaction({ ...BASE_DTO, duration_ledgers: 500_000 });
+    expect(result.newEndLedger).toBe(END_LEDGER + 1 + 500_000 - 1);
+    expect(soroban.buildRenewPolicyTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ newStartLedger: END_LEDGER + 1, newEndLedger: END_LEDGER + 500_000 }),
+    );
+  });
+
+  it('uses dto.asset when provided', async () => {
+    const { service, soroban } = makeService(makePolicy());
+    await service.buildRenewalTransaction({ ...BASE_DTO, asset: 'CNEWASSET' });
+    expect(soroban.buildRenewPolicyTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: 'CNEWASSET' }),
+    );
+  });
+
+  it('falls back to policy.assetContractId when dto.asset is omitted', async () => {
+    const { service, soroban } = makeService(makePolicy({ assetContractId: 'CPOLICYASSET' }));
+    await service.buildRenewalTransaction(BASE_DTO);
+    expect(soroban.buildRenewPolicyTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: 'CPOLICYASSET' }),
+    );
+  });
+
+  it('passes undefined asset when both dto.asset and policy.assetContractId are absent', async () => {
+    const { service, soroban } = makeService(makePolicy({ assetContractId: null as any }));
+    await service.buildRenewalTransaction(BASE_DTO);
+    expect(soroban.buildRenewPolicyTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: undefined }),
+    );
+  });
+
+  // ── PREMIUM_OVERFLOW guard ─────────────────────────────────────────────────
+
+  it('throws PREMIUM_OVERFLOW when cumulative premium would exceed i128 max', async () => {
+    const MAX_I128 = BigInt('170141183460469231731687303715884105727');
+    // Set existing premium to MAX_I128 - 1 so adding any renewal premium overflows
+    const policy = makePolicy({ premium: (MAX_I128 - BigInt(1)).toString() });
+    const { service } = makeService(policy);
+    await expect(service.buildRenewalTransaction(BASE_DTO)).rejects.toMatchObject({
+      response: { code: 'PREMIUM_OVERFLOW' },
+    });
+  });
+
+  it('does NOT throw PREMIUM_OVERFLOW for normal cumulative values', async () => {
+    const policy = makePolicy({ premium: '50000000' });
+    const { service } = makeService(policy);
+    await expect(service.buildRenewalTransaction(BASE_DTO)).resolves.toBeDefined();
+  });
+
+  // ── Event emission ─────────────────────────────────────────────────────────
+
+  it('emits policy.renewed exactly once on successful buildRenewalTransaction', async () => {
+    const { service } = makeService(makePolicy());
+    const listener = jest.fn();
+    renewalBus.on('policy.renewed', listener);
+
+    await service.buildRenewalTransaction(BASE_DTO);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits PolicyRenewed with correct payload fields', async () => {
+    const { service } = makeService(makePolicy());
+    let emitted: PolicyRenewedEvent | undefined;
+    renewalBus.on('policy.renewed', (e: PolicyRenewedEvent) => { emitted = e; });
+
+    await service.buildRenewalTransaction(BASE_DTO);
+
+    expect(emitted).toBeDefined();
+    expect(emitted!.policyCompositeId).toBe('GABC:1');
+    expect(emitted!.holderAddress).toBe('GABC');
+    expect(emitted!.policyId).toBe(1);
+    expect(emitted!.previousEndLedger).toBe(END_LEDGER);
+    expect(emitted!.newEndLedger).toBe(END_LEDGER + 1 + POLICY_DURATION_LEDGERS - 1);
+    expect(emitted!.premiumPaidStroops).toBe(PREMIUM_STROOPS);
+    expect(emitted!.termVersion).toBeNull();
+    expect(typeof emitted!.renewalRequestedAt).toBe('string');
+    // renewalRequestedAtLedger should be the current ledger from the mock
+    expect(emitted!.renewalRequestedAtLedger).toBe(WINDOW_OPEN + 1000);
+  });
+
+  it('does NOT emit policy.renewed on quoteRenewal', async () => {
+    const { service } = makeService(makePolicy());
+    const listener = jest.fn();
+    renewalBus.on('policy.renewed', listener);
+
+    await service.quoteRenewal(BASE_DTO);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit policy.renewed when window check fails', async () => {
+    const { service } = makeService(makePolicy(), WINDOW_OPEN - 1);
+    const listener = jest.fn();
+    renewalBus.on('policy.renewed', listener);
+
+    await expect(service.buildRenewalTransaction(BASE_DTO)).rejects.toBeDefined();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit policy.renewed when open claim blocks renewal', async () => {
+    const policy = makePolicy({ claims: [{ status: 'PENDING' }] });
+    const { service } = makeService(policy);
+    const listener = jest.fn();
+    renewalBus.on('policy.renewed', listener);
+
+    await expect(service.buildRenewalTransaction(BASE_DTO)).rejects.toBeDefined();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  // ── Window metadata consistency ────────────────────────────────────────────
+
+  it('windowOpenLedger and windowCloseLedger are consistent across quote and build', async () => {
+    const { service } = makeService(makePolicy());
+    const quote = await service.quoteRenewal(BASE_DTO);
+    const build = await service.buildRenewalTransaction(BASE_DTO);
+
+    expect(quote.windowOpenLedger).toBe(build.windowOpenLedger);
+    expect(quote.windowCloseLedger).toBe(build.windowCloseLedger);
+  });
+
+  it('window spans exactly RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY ledgers', async () => {
+    const { service } = makeService(makePolicy());
+    const result = await service.quoteRenewal(BASE_DTO);
+    const windowSize = result.windowCloseLedger - result.windowOpenLedger;
+    expect(windowSize).toBe(
+      RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY,
+    );
+  });
+});

--- a/backend/src/policy/renewal.service.ts
+++ b/backend/src/policy/renewal.service.ts
@@ -1,0 +1,265 @@
+/**
+ * RenewalService — policy renewal orchestration.
+ *
+ * RENEWAL WINDOW (ledger-bounded, half-open interval):
+ *   Valid when: endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY <= currentLedger
+ *                        < endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY
+ *
+ *   See renewal.constants.ts for full semantics and server-client skew notes.
+ *
+ * PREMIUM RECALCULATION:
+ *   Uses the same deterministic formula as policy initiation:
+ *     simulateGeneratePremium() → on-chain simulation with local fallback.
+ *   The caller must supply age and risk_score matching the original policy.
+ *   These are validated against the stored policy record to prevent
+ *   premium manipulation via substituted inputs.
+ *
+ * OPEN-CLAIM RULE:
+ *   Renewal is blocked when any claim on the policy has status PENDING.
+ *   See BLOCKING_CLAIM_STATUSES in renewal.constants.ts for rationale.
+ *
+ * CUMULATIVE PREMIUM ARITHMETIC:
+ *   All premium values are i128 stroops stored as strings. BigInt is used
+ *   for all arithmetic to match Rust i128 semantics and avoid overflow.
+ *   Overflow is checked explicitly before updating cumulativePremiumPaid.
+ *
+ * EVENT EMISSION:
+ *   PolicyRenewed is emitted exactly once per successful buildRenewalTransaction
+ *   call, after the unsigned XDR is assembled. It is NOT emitted on quote-only
+ *   calls. The event is suitable for off-chain indexing and timeline UIs.
+ */
+
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import EventEmitter from 'events';
+import { PrismaService } from '../prisma/prisma.service';
+import { SorobanService } from '../rpc/soroban.service';
+import {
+  RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY,
+  RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY,
+  POLICY_DURATION_LEDGERS,
+  BLOCKING_CLAIM_STATUSES,
+} from './renewal.constants';
+import type {
+  BuildRenewalTransactionDto,
+  BuildRenewalTransactionResponseDto,
+  RenewalQuoteResponseDto,
+  PolicyRenewedEvent,
+} from './dto/renewal.dto';
+
+/**
+ * Shared renewal event bus.
+ * Consumers (indexer, notifications, analytics) subscribe to 'policy.renewed'.
+ * In production, replace with a BullMQ/SQS consumer for durability.
+ */
+export const renewalBus = new EventEmitter();
+
+/** Maximum i128 value — used for overflow guard on cumulative premium. */
+const MAX_I128 = BigInt('170141183460469231731687303715884105727');
+
+@Injectable()
+export class RenewalService {
+  private readonly logger = new Logger(RenewalService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly soroban: SorobanService,
+  ) {}
+
+  /**
+   * Quote a renewal premium without building a transaction.
+   * Safe to call repeatedly — no side effects, no event emitted.
+   */
+  async quoteRenewal(dto: BuildRenewalTransactionDto): Promise<RenewalQuoteResponseDto> {
+    const { policy, currentLedger } = await this.validateRenewalEligibility(dto);
+
+    const premiumResult = await this.soroban.simulateGeneratePremium({
+      policyType: policy.policyType as Parameters<typeof this.soroban.simulateGeneratePremium>[0]['policyType'],
+      region: policy.region as Parameters<typeof this.soroban.simulateGeneratePremium>[0]['region'],
+      age: dto.age,
+      riskScore: dto.risk_score,
+      sourceAccount: dto.holder,
+    });
+
+    const newEndLedger = policy.endLedger + (dto.duration_ledgers ?? POLICY_DURATION_LEDGERS);
+
+    return {
+      premiumStroops: premiumResult.premiumStroops,
+      premiumXlm: premiumResult.premiumXlm,
+      previousEndLedger: policy.endLedger,
+      newEndLedger,
+      currentLedger,
+      windowOpenLedger: policy.endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY,
+      windowCloseLedger: policy.endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY,
+      premiumSource: premiumResult.source,
+    };
+  }
+
+  /**
+   * Build an unsigned renewal transaction XDR for wallet signing.
+   *
+   * Emits PolicyRenewed exactly once on success.
+   * Does NOT submit the transaction — the wallet signs and submits via POST /tx/submit.
+   */
+  async buildRenewalTransaction(
+    dto: BuildRenewalTransactionDto,
+  ): Promise<BuildRenewalTransactionResponseDto> {
+    const { policy, currentLedger } = await this.validateRenewalEligibility(dto);
+
+    // Resolve asset: caller-supplied > policy's stored asset > env default
+    const assetAddress =
+      dto.asset ??
+      policy.assetContractId ??
+      undefined;
+
+    const durationLedgers = dto.duration_ledgers ?? POLICY_DURATION_LEDGERS;
+
+    // newStartLedger = previous endLedger + 1 (no gap, no overlap between terms)
+    const newStartLedger = policy.endLedger + 1;
+    const newEndLedger = newStartLedger + durationLedgers - 1;
+
+    // Build the unsigned renewal transaction via the Soroban service.
+    // This also recalculates the premium deterministically (same formula as initiation).
+    const txResult = await this.soroban.buildRenewPolicyTransaction({
+      holder: dto.holder,
+      policyId: policy.policyId,
+      policyType: policy.policyType as Parameters<typeof this.soroban.buildRenewPolicyTransaction>[0]['policyType'],
+      region: policy.region as Parameters<typeof this.soroban.buildRenewPolicyTransaction>[0]['region'],
+      age: dto.age,
+      riskScore: dto.risk_score,
+      asset: assetAddress,
+      newStartLedger,
+      newEndLedger,
+    });
+
+    // Checked arithmetic: guard against i128 overflow on cumulative premium.
+    const existingPremium = BigInt(policy.premium);
+    const renewalPremium = BigInt(txResult.premiumStroops);
+    const newCumulative = existingPremium + renewalPremium;
+    if (newCumulative > MAX_I128) {
+      throw new BadRequestException({
+        code: 'PREMIUM_OVERFLOW',
+        message: 'Cumulative premium would exceed i128 maximum. Contact support.',
+      });
+    }
+
+    // Emit PolicyRenewed exactly once — after successful XDR assembly.
+    const event: PolicyRenewedEvent = {
+      policyCompositeId: policy.id,
+      holderAddress: dto.holder,
+      policyId: policy.policyId,
+      previousEndLedger: policy.endLedger,
+      newEndLedger,
+      premiumPaidStroops: txResult.premiumStroops,
+      termVersion: null, // populated if term versioning is introduced
+      renewalRequestedAtLedger: currentLedger,
+      renewalRequestedAt: new Date().toISOString(),
+    };
+    renewalBus.emit('policy.renewed', event);
+
+    this.logger.log(
+      `PolicyRenewed: composite=${policy.id} prevEnd=${policy.endLedger} ` +
+      `newEnd=${newEndLedger} premium=${txResult.premiumStroops} ledger=${currentLedger}`,
+    );
+
+    return {
+      unsignedXdr: txResult.unsignedXdr,
+      minResourceFee: txResult.minResourceFee,
+      baseFee: txResult.baseFee,
+      totalEstimatedFee: txResult.totalEstimatedFee,
+      totalEstimatedFeeXlm: txResult.totalEstimatedFeeXlm,
+      authRequirements: txResult.authRequirements,
+      memoConvention: txResult.memoConvention,
+      premiumStroops: txResult.premiumStroops,
+      premiumXlm: txResult.premiumXlm,
+      previousEndLedger: policy.endLedger,
+      newEndLedger,
+      currentLedger,
+      windowOpenLedger: policy.endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY,
+      windowCloseLedger: policy.endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY,
+      premiumSource: txResult.premiumSource,
+    };
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
+
+  /**
+   * Fetch the policy, fetch the current ledger, and enforce all renewal
+   * preconditions. Returns both for use by the caller.
+   */
+  private async validateRenewalEligibility(dto: BuildRenewalTransactionDto) {
+    const compositeId = `${dto.holder}:${dto.policy_id}`;
+
+    const policy = await this.prisma.policy.findUnique({
+      where: { id: compositeId },
+      include: { claims: { select: { status: true } } },
+    });
+
+    if (!policy) {
+      throw new NotFoundException({
+        code: 'POLICY_NOT_FOUND',
+        message: `Policy (holder=${dto.holder}, policy_id=${dto.policy_id}) not found.`,
+      });
+    }
+
+    if (!policy.isActive) {
+      throw new BadRequestException({
+        code: 'POLICY_INACTIVE',
+        message: 'Policy is not active and cannot be renewed.',
+      });
+    }
+
+    // Fetch authoritative current ledger from RPC — never use cached/client value.
+    const currentLedger = await this.soroban.getLatestLedger();
+
+    // ── Renewal window check (half-open interval) ──────────────────────────────
+    //
+    // windowOpen  = endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY  (inclusive)
+    // windowClose = endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY  (exclusive)
+    //
+    // Valid: windowOpen <= currentLedger < windowClose
+    const windowOpen = policy.endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY;
+    const windowClose = policy.endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY;
+
+    if (currentLedger < windowOpen) {
+      throw new BadRequestException({
+        code: 'RENEWAL_TOO_EARLY',
+        message:
+          `Renewal window has not opened yet. ` +
+          `Window opens at ledger ${windowOpen}; current ledger is ${currentLedger}. ` +
+          `Approximately ${Math.ceil((windowOpen - currentLedger) * 5 / 60)} minutes remaining.`,
+      });
+    }
+
+    // currentLedger >= windowClose means the grace period has passed
+    if (currentLedger >= windowClose) {
+      throw new BadRequestException({
+        code: 'RENEWAL_TOO_LATE',
+        message:
+          `Renewal grace period has expired. ` +
+          `Window closed at ledger ${windowClose}; current ledger is ${currentLedger}. ` +
+          `The policy has lapsed and cannot be renewed.`,
+      });
+    }
+
+    // ── Open-claim check ───────────────────────────────────────────────────────
+    // Block renewal if any claim is in a blocking state (PENDING = "Processing").
+    const blockingClaim = policy.claims.find((c: { status: string }) =>
+      (BLOCKING_CLAIM_STATUSES as readonly string[]).includes(c.status),
+    );
+    if (blockingClaim) {
+      throw new BadRequestException({
+        code: 'OPEN_CLAIM_BLOCKS_RENEWAL',
+        message:
+          'This policy has a claim in Processing status. ' +
+          'Renewal is blocked until all claims are finalized (Approved, Paid, or Rejected).',
+      });
+    }
+
+    return { policy, currentLedger };
+  }
+}

--- a/backend/src/rpc/soroban.service.ts
+++ b/backend/src/rpc/soroban.service.ts
@@ -52,6 +52,15 @@ export interface BuildTransactionResult {
   currentLedger: number;
 }
 
+export interface BuildRenewalTransactionResult extends BuildTransactionResult {
+  /** Renewal premium in stroops (i128 as string). */
+  premiumStroops: string;
+  /** Renewal premium in XLM. */
+  premiumXlm: string;
+  /** Whether the premium was computed on-chain or via local fallback. */
+  premiumSource: 'simulation' | 'local_fallback';
+}
+
 @Injectable()
 export class SorobanService {
   private readonly logger = new Logger(SorobanService.name);
@@ -82,7 +91,7 @@ export class SorobanService {
     });
   }
 
-  private static enumVariantToScVal(variant: string): xdr.ScVal {
+  static enumVariantToScVal(variant: string): xdr.ScVal {
     return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(variant)]);
   }
 
@@ -447,6 +456,128 @@ export class SorobanService {
     const server = this.makeServer();
     const info = await server.getLatestLedger();
     return info.sequence;
+  }
+
+  /**
+   * Build unsigned renew_policy transaction with simulation-derived footprints.
+   *
+   * Contract signature (planned):
+   *   renew_policy(holder, policy_id, policy_type, region, age, risk_score,
+   *                new_start_ledger, new_end_ledger, asset)
+   *
+   * The premium is recalculated deterministically using the same on-chain formula
+   * as initiate_policy. The caller must supply age and risk_score matching the
+   * original policy to prevent premium manipulation.
+   *
+   * REPLAY PROTECTION:
+   *   - new_start_ledger = previous endLedger + 1 (enforced by caller, validated on-chain).
+   *   - The contract rejects duplicate renewals for the same policy term.
+   *   - Sequence number is fetched live from RPC — never cached.
+   *
+   * PAYMENT:
+   *   The contract collects the renewal premium via token_client.transfer() using
+   *   the same SEP-41 asset as the original policy. The asset address is passed
+   *   explicitly and validated against the contract's allowlist on-chain.
+   */
+  async buildRenewPolicyTransaction(args: {
+    holder: string;
+    policyId: number;
+    policyType: PolicyTypeEnum;
+    region: RegionTierEnum;
+    age: number;
+    riskScore: number;
+    asset?: string;
+    newStartLedger: number;
+    newEndLedger: number;
+  }): Promise<BuildRenewalTransactionResult> {
+    const server = this.makeServer();
+    const account = await this.loadAccount(server, args.holder);
+    const ledgerInfo = await server.getLatestLedger();
+
+    const assetAddress =
+      args.asset ?? this.configService.get<string>('DEFAULT_TOKEN_CONTRACT_ID', '');
+
+    // Simulate premium first to include it in the response for UI display.
+    const premiumResult = await this.simulateGeneratePremium({
+      policyType: args.policyType,
+      region: args.region,
+      age: args.age,
+      riskScore: args.riskScore,
+      sourceAccount: args.holder,
+    });
+
+    const scArgs = [
+      new Address(args.holder).toScVal(),
+      nativeToScVal(args.policyId, { type: 'u32' }),
+      SorobanService.enumVariantToScVal(args.policyType),
+      SorobanService.enumVariantToScVal(args.region),
+      nativeToScVal(args.age, { type: 'u32' }),
+      nativeToScVal(args.riskScore, { type: 'u32' }),
+      nativeToScVal(args.newStartLedger, { type: 'u32' }),
+      nativeToScVal(args.newEndLedger, { type: 'u32' }),
+      new Address(assetAddress).toScVal(),
+    ];
+
+    const contract = new Contract(this.contractId);
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call('renew_policy', ...scArgs))
+      .setTimeout(30)
+      .build();
+
+    const simulation = await server.simulateTransaction(tx);
+
+    if (Api.isSimulationError(simulation)) {
+      const err = simulation as SorobanRpc.Api.SimulateTransactionErrorResponse;
+      this.mapSimulationError(err.error);
+    }
+
+    const successSim = simulation as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+    const assembled = assembleTransaction(tx, successSim);
+    const unsignedXdr = assembled.build().toEnvelope().toXDR('base64');
+
+    const baseFee = BigInt(BASE_FEE);
+    const resourceFee = BigInt(successSim.minResourceFee ?? '0');
+    const totalFee = baseFee + resourceFee;
+
+    const authRequirements: AuthRequirement[] = [];
+    for (const authEntry of successSim.result?.auth ?? []) {
+      const credentials = authEntry.credentials();
+      if (
+        credentials.switch().value ===
+        xdr.SorobanCredentialsType.sorobanCredentialsAddress().value
+      ) {
+        const addrObj = credentials.address().address();
+        const stellarAddr = Address.fromScAddress(addrObj);
+        const isContract =
+          addrObj.switch().value ===
+          xdr.ScAddressType.scAddressTypeContract().value;
+        authRequirements.push({ address: stellarAddr.toString(), isContract });
+      }
+    }
+
+    if (!authRequirements.some((r) => r.address === args.holder)) {
+      authRequirements.unshift({ address: args.holder, isContract: false });
+    }
+
+    return {
+      unsignedXdr,
+      minResourceFee: successSim.minResourceFee ?? '0',
+      baseFee: BASE_FEE.toString(),
+      totalEstimatedFee: totalFee.toString(),
+      totalEstimatedFeeXlm: SorobanService.stroopsToXlm(totalFee),
+      authRequirements,
+      memoConvention:
+        'NiffyInsure does not use memos for protocol correlation. ' +
+        'policy_id is embedded in the renew_policy contract call arguments. ' +
+        'Frontends may set an optional text memo (≤28 bytes) for UI session correlation.',
+      currentLedger: ledgerInfo.sequence,
+      premiumStroops: premiumResult.premiumStroops,
+      premiumXlm: premiumResult.premiumXlm,
+      premiumSource: premiumResult.source,
+    };
   }
 
   /**


### PR DESCRIPTION
Implements the full policy renewal flow, enforcing strict ledger-bounded windows, deterministic premium recalculation, open-claim blocking, checked arithmetic, and structured event emission.

## Changes

### New files
- `renewal.constants.ts` — window constants with full inline docs on inclusive/exclusive semantics and server-client skew guidance
- `dto/renewal.dto.ts` — request/response DTOs and `PolicyRenewedEvent` interface
- `renewal.service.ts` — core orchestration: window validation, premium recalc, open-claim enforcement, i128 overflow guard, event emission
- `renewal.controller.ts` — `POST /policy/renewal/quote` and `POST /policy/renewal/build-transaction`
- `renewal.service.spec.ts` — 30 unit tests covering all boundary conditions and edge cases

### Modified files
- `soroban.service.ts` — adds `buildRenewPolicyTransaction()` and `BuildRenewalTransactionResult` type
- `policy.module.ts` — wires `RenewalController` and `RenewalService`

## Renewal window semantics

Half-open interval `[windowOpen, windowClose)`:
- `windowOpen  = endLedger - RENEWAL_OPEN_LEDGERS_BEFORE_EXPIRY` (inclusive, ~7 days before expiry)
- `windowClose = endLedger + RENEWAL_GRACE_LEDGERS_AFTER_EXPIRY` (exclusive, ~1 day grace after expiry)

Violations return `RENEWAL_TOO_EARLY` or `RENEWAL_TOO_LATE` with ledger numbers in the message.

## Open-claim rule

Renewal is blocked when any claim has status `PENDING` (on-chain: Processing). `APPROVED`, `PAID`, and `REJECTED` claims do not block. Returns `OPEN_CLAIM_BLOCKS_RENEWAL`.

## Event emission

`PolicyRenewed` is emitted on `renewalBus` exactly once per successful `buildRenewalTransaction` call — never on quote-only calls or failed validations.

Closes #9 