### PR TITLE
feat(storybook): init Storybook for Next.js, add stories for 6 UI components, CI workflow (#240)

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,39 @@
+name: Storybook
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-storybook:
+    name: Build Storybook (visual regression guard)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static-${{ github.sha }}
+          path: frontend/storybook-static/
+          retention-days: 14

--- a/STORYBOOK.md
+++ b/STORYBOOK.md
@@ -1,0 +1,45 @@
+# Storybook
+
+Visual component catalogue for NiffyInsur's UI primitives.
+
+## Running
+
+```bash
+cd frontend
+npm run storybook        # dev server → http://localhost:6006
+npm run build-storybook  # static build → frontend/storybook-static/
+```
+
+## Naming Conventions
+
+Stories follow the `Category/ComponentName` pattern:
+
+| Title | Component |
+|---|---|
+| `UI/Button` | `Button` |
+| `UI/Input` | `Input` |
+| `UI/StatusBadge` | `StatusBadge` |
+| `UI/WalletAddress` | `WalletAddress` |
+| `UI/LedgerCountdown` | `LedgerCountdown` |
+| `UI/SkeletonRow` | `SkeletonRow` |
+
+Story names within a file describe the **state** being shown, e.g. `Active`, `Disabled`, `DeadlinePassed`, `AllStates`.
+
+## File Location
+
+Story files live next to the component they document:
+
+```
+src/components/ui/button.tsx
+src/components/ui/button.stories.tsx   ← same directory
+```
+
+## Mocking Rules
+
+- Stories must **not** require a live Stellar wallet or backend.
+- Use static mock addresses and ledger numbers.
+- Wrap components that need React Query in a `QueryClientProvider` decorator if needed (see `.storybook/preview.ts`).
+
+## CI
+
+`npm run build-storybook` runs on every push/PR to `main` via `.github/workflows/storybook.yml`. A failing build blocks merge.

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/nextjs'
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.tsx'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/nextjs',
+    options: {},
+  },
+  docs: { autodocs: 'tag' },
+}
+
+export default config

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,17 @@
+import type { Preview } from '@storybook/react'
+import '../src/app/globals.css'
+
+const preview: Preview = {
+  parameters: {
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#ffffff' },
+        { name: 'dark', value: '#0a0a0a' },
+      ],
+    },
+    controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+  },
+}
+
+export default preview

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "check-docs": "node scripts/check-docs-links.js"
+    "check-docs": "node scripts/check-docs-links.js",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.3.0",
@@ -57,6 +59,11 @@
     "jest": "^29",
     "jest-environment-jsdom": "^30.3.0",
     "postcss": "^8.5.8",
+    "@storybook/nextjs": "^8.6.0",
+    "@storybook/react": "^8.6.0",
+    "@storybook/addon-essentials": "^8.6.0",
+    "@storybook/addon-interactions": "^8.6.0",
+    "storybook": "^8.6.0",
     "tailwindcss": "^4.2.2",
     "ts-jest": "^29.4.6",
     "typescript": "^5"

--- a/frontend/src/components/ui/button.stories.tsx
+++ b/frontend/src/components/ui/button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from './button'
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+    },
+    size: { control: 'select', options: ['default', 'sm', 'lg', 'icon'] },
+    disabled: { control: 'boolean' },
+  },
+}
+export default meta
+type Story = StoryObj<typeof Button>
+
+export const Default: Story = { args: { children: 'Button' } }
+export const Destructive: Story = { args: { children: 'Delete', variant: 'destructive' } }
+export const Outline: Story = { args: { children: 'Outline', variant: 'outline' } }
+export const Ghost: Story = { args: { children: 'Ghost', variant: 'ghost' } }
+export const Disabled: Story = { args: { children: 'Disabled', disabled: true } }
+export const Small: Story = { args: { children: 'Small', size: 'sm' } }
+export const Large: Story = { args: { children: 'Large', size: 'lg' } }

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -47,6 +47,7 @@ export {
   CardContent,
 } from './card'
 export { Badge, badgeVariants } from './badge'
+export { StatusBadge, type StatusBadgeProps, type InsuranceStatus } from './status-badge'
 export { WalletAddress, type WalletAddressProps, type StellarNetwork } from './wallet-address'
 export { Stepper, StepContent, type Step } from './stepper'
 export { InlineError } from './inline-error'

--- a/frontend/src/components/ui/input.stories.tsx
+++ b/frontend/src/components/ui/input.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Input } from './input'
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    type: { control: 'select', options: ['text', 'email', 'password', 'number'] },
+  },
+}
+export default meta
+type Story = StoryObj<typeof Input>
+
+export const Default: Story = { args: { placeholder: 'Enter value…' } }
+export const WithValue: Story = { args: { defaultValue: 'GXXXXXXXX' } }
+export const Disabled: Story = { args: { placeholder: 'Disabled', disabled: true } }
+export const Password: Story = { args: { type: 'password', placeholder: 'Password' } }

--- a/frontend/src/components/ui/ledger-countdown.stories.tsx
+++ b/frontend/src/components/ui/ledger-countdown.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { LedgerCountdown } from '../claims/LedgerCountdown'
+
+// Static mock data — no live Stellar node required
+const CURRENT = 50_000
+const meta: Meta<typeof LedgerCountdown> = {
+  title: 'UI/LedgerCountdown',
+  component: LedgerCountdown,
+  tags: ['autodocs'],
+  args: { currentLedger: CURRENT, avgCloseSeconds: 5 },
+}
+export default meta
+type Story = StoryObj<typeof LedgerCountdown>
+
+export const HoursRemaining: Story = {
+  args: { targetLedger: CURRENT + 720 }, // ~1 h
+}
+export const DaysRemaining: Story = {
+  args: { targetLedger: CURRENT + 17_280 }, // ~1 d
+}
+export const MinutesRemaining: Story = {
+  args: { targetLedger: CURRENT + 12 }, // ~1 min
+}
+export const DeadlinePassed: Story = {
+  args: { targetLedger: CURRENT - 1 },
+}

--- a/frontend/src/components/ui/skeleton-row.stories.tsx
+++ b/frontend/src/components/ui/skeleton-row.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SkeletonRow } from './skeleton'
+
+const meta: Meta<typeof SkeletonRow> = {
+  title: 'UI/SkeletonRow',
+  component: SkeletonRow,
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof SkeletonRow>
+
+export const Default: Story = {}
+
+export const InTable: Story = {
+  render: () => (
+    <div className="rounded-md border divide-y">
+      <SkeletonRow />
+      <SkeletonRow />
+      <SkeletonRow />
+    </div>
+  ),
+}

--- a/frontend/src/components/ui/status-badge.stories.tsx
+++ b/frontend/src/components/ui/status-badge.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StatusBadge } from './status-badge'
+
+const meta: Meta<typeof StatusBadge> = {
+  title: 'UI/StatusBadge',
+  component: StatusBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['active', 'expired', 'pending', 'approved', 'rejected', 'under_review'],
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof StatusBadge>
+
+export const Active: Story = { args: { status: 'active' } }
+export const Pending: Story = { args: { status: 'pending' } }
+export const UnderReview: Story = { args: { status: 'under_review' } }
+export const Approved: Story = { args: { status: 'approved' } }
+export const Rejected: Story = { args: { status: 'rejected' } }
+export const Expired: Story = { args: { status: 'expired' } }
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {(['active', 'pending', 'under_review', 'approved', 'rejected', 'expired'] as const).map(
+        (s) => <StatusBadge key={s} status={s} />,
+      )}
+    </div>
+  ),
+}

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,0 +1,40 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge'
+
+export type InsuranceStatus =
+  | 'active'
+  | 'expired'
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'under_review'
+
+const STATUS_VARIANT: Record<InsuranceStatus, BadgeProps['variant']> = {
+  active: 'success',
+  approved: 'success',
+  pending: 'warning',
+  under_review: 'warning',
+  expired: 'outline',
+  rejected: 'destructive',
+}
+
+const STATUS_LABEL: Record<InsuranceStatus, string> = {
+  active: 'Active',
+  approved: 'Approved',
+  pending: 'Pending',
+  under_review: 'Under Review',
+  expired: 'Expired',
+  rejected: 'Rejected',
+}
+
+export interface StatusBadgeProps {
+  status: InsuranceStatus
+  className?: string
+}
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  return (
+    <Badge variant={STATUS_VARIANT[status]} className={className}>
+      {STATUS_LABEL[status]}
+    </Badge>
+  )
+}

--- a/frontend/src/components/ui/wallet-address.stories.tsx
+++ b/frontend/src/components/ui/wallet-address.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { WalletAddress } from './wallet-address'
+
+// Static mock addresses — no live wallet required
+const TESTNET_ADDR = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+const MAINNET_ADDR = 'GDRXE2BQUC3AZNPVFSCEZ76NJ3WWL25FYFK6RGZGIEKWE4SOOHSUJUJ6'
+
+const meta: Meta<typeof WalletAddress> = {
+  title: 'UI/WalletAddress',
+  component: WalletAddress,
+  tags: ['autodocs'],
+  argTypes: {
+    network: { control: 'radio', options: ['testnet', 'public'] },
+    showCopy: { control: 'boolean' },
+    showExplorer: { control: 'boolean' },
+  },
+}
+export default meta
+type Story = StoryObj<typeof WalletAddress>
+
+export const Testnet: Story = { args: { address: TESTNET_ADDR, network: 'testnet' } }
+export const Mainnet: Story = { args: { address: MAINNET_ADDR, network: 'public' } }
+export const CopyOnly: Story = { args: { address: TESTNET_ADDR, showExplorer: false } }
+export const ExplorerOnly: Story = { args: { address: TESTNET_ADDR, showCopy: false } }
+export const NoActions: Story = { args: { address: TESTNET_ADDR, showCopy: false, showExplorer: false } }
+export const InvalidAddress: Story = { args: { address: 'not-a-stellar-address' } }


### PR DESCRIPTION
Closes #240 

Files changed:
- frontend/package.json — added storybook, @storybook/nextjs, @storybook/react, @storybook/addon-essentials, @storybook/addon-interactions as 
devDeps; added storybook and build-storybook scripts.
- .storybook/main.ts — @storybook/nextjs framework, scans src/**/*.stories.tsx.
- .storybook/preview.ts — imports globals.css (Tailwind tokens), sets light/dark backgrounds.
- src/components/ui/status-badge.tsx — new StatusBadge component mapping InsuranceStatus → Badge variants.
- *.stories.tsx — six story files: Button, Input, StatusBadge, WalletAddress, LedgerCountdown, SkeletonRow. All use static mock data, zero live 
dependencies.
- .github/workflows/storybook.yml — runs npm run build-storybook on every push/PR to main, uploads the static build as an artifact.
- STORYBOOK.md — naming conventions (UI/ComponentName / state-named stories), file co-location rule, mocking rules, CI description.
