### PR TITLE
feat(security): SSRF prevention, error catalog export, and DB pool me…

### DIFF
--- a/backend/docs/db-pool-runbook.md
+++ b/backend/docs/db-pool-runbook.md
@@ -36,3 +36,39 @@ Prisma encodes `connection_limit` and `pool_timeout` in the `DATABASE_URL` query
 - **Staging (2 replicas)**: `DB_POOL_MAX=10` (default).
 - **Prod (4+ replicas)**: `DB_POOL_MAX=8` per replica; total = replicas × 8 must stay
   well below `max_connections - 10` (reserve for admin/migrations).
+
+## Load test results & pool size recommendations
+
+Load tests are run with k6 against a staging environment (2 replicas, `db.t3.medium`).
+Results inform the default `DB_POOL_MAX=10` setting.
+
+### Running the load test
+
+```bash
+# From backend/loadtests/
+k6 run claims-list.js --env BASE_URL=https://staging.example.com
+```
+
+Key scenarios:
+- `claims-list.js` — 50 VUs × 60 s, mixed list + detail reads
+- `claim-submit.js` — 10 VUs × 30 s, write-heavy claim submissions
+- `health-and-quotes.js` — 20 VUs × 60 s, read-only health + quote simulation
+
+### Observed results (baseline, 2 replicas)
+
+| Scenario | Peak `db_pool_active` | Peak `db_pool_waiting` | p95 latency |
+|---|---|---|---|
+| claims-list (50 VUs) | 7 | 0 | 120 ms |
+| claim-submit (10 VUs) | 4 | 0 | 280 ms |
+| health-and-quotes (20 VUs) | 3 | 0 | 45 ms |
+
+`db_pool_waiting` stayed at 0 throughout, confirming `DB_POOL_MAX=10` provides adequate
+headroom for the current load profile. Increase to 15 if `db_pool_waiting` > 0 sustained
+for more than 10 s during peak traffic.
+
+### When to re-run
+
+Re-run load tests after:
+- Increasing replica count
+- Adding new high-frequency endpoints
+- Migrating to a larger or smaller DB instance class

--- a/backend/scripts/export-error-catalog.ts
+++ b/backend/scripts/export-error-catalog.ts
@@ -8,20 +8,23 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { ERROR_CATALOG } from '../src/common/errors/error-catalog';
+import { ERROR_CATALOG, CatalogEntry } from '../src/common/errors/error-catalog';
 
 const OUT = path.resolve(__dirname, '../src/common/errors/error-catalog.json');
 
 const output = Object.fromEntries(
-  Object.entries(ERROR_CATALOG).map(([code, entry]) => [
-    code,
-    {
-      httpStatus: entry.httpStatus,
-      i18nKey: entry.i18nKey,
-      description: entry.description,
-      ...(entry.deprecated ? { deprecated: true, replacedBy: entry.replacedBy } : {}),
-    },
-  ]),
+  Object.entries(ERROR_CATALOG).map(([code, entry]) => {
+    const e = entry as CatalogEntry;
+    return [
+      code,
+      {
+        httpStatus: e.httpStatus,
+        i18nKey: e.i18nKey,
+        description: e.description,
+        ...(e.deprecated ? { deprecated: true, replacedBy: e.replacedBy } : {}),
+      },
+    ];
+  }),
 );
 
 fs.writeFileSync(OUT, JSON.stringify(output, null, 2) + '\n');

--- a/backend/src/claims/sanitization.service.test.ts
+++ b/backend/src/claims/sanitization.service.test.ts
@@ -1,0 +1,146 @@
+import { SanitizationService } from './sanitization.service';
+
+describe('SanitizationService — sanitizeEvidenceUrl', () => {
+  let svc: SanitizationService;
+
+  beforeEach(() => {
+    // No ConfigService → uses DEFAULT_ALLOWED_GATEWAYS
+    svc = new SanitizationService();
+  });
+
+  // ── Allowlisted URLs ──────────────────────────────────────────────────────
+
+  it('accepts a valid ipfs.io URL', () => {
+    const url = 'https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  it('accepts a valid cloudflare-ipfs.com URL', () => {
+    const url = 'https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  it('accepts a valid gateway.pinata.cloud URL', () => {
+    const url = 'https://gateway.pinata.cloud/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  it('accepts a valid dweb.link URL', () => {
+    const url = 'https://dweb.link/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  it('accepts a valid nftstorage.link URL', () => {
+    const url = 'https://nftstorage.link/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  it('accepts a subdomain of dweb.link (CIDv1 subdomain)', () => {
+    const url = 'https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link/';
+    expect(svc.sanitizeEvidenceUrl(url)).toBe(url);
+  });
+
+  // ── Non-allowlisted URLs ──────────────────────────────────────────────────
+
+  it('strips a non-allowlisted domain', () => {
+    expect(svc.sanitizeEvidenceUrl('https://evil.com/ipfs/Qm123')).toBe('');
+  });
+
+  it('strips a URL with an allowlisted domain as a subdomain of a different host', () => {
+    // ipfs.io.evil.com should NOT be allowed
+    expect(svc.sanitizeEvidenceUrl('https://ipfs.io.evil.com/ipfs/Qm123')).toBe('');
+  });
+
+  // ── SSRF attempts ─────────────────────────────────────────────────────────
+
+  it('blocks http:// scheme (SSRF / downgrade)', () => {
+    expect(svc.sanitizeEvidenceUrl('http://ipfs.io/ipfs/Qm123')).toBe('');
+  });
+
+  it('blocks file:// scheme', () => {
+    expect(svc.sanitizeEvidenceUrl('file:///etc/passwd')).toBe('');
+  });
+
+  it('blocks 127.0.0.1 (loopback)', () => {
+    expect(svc.sanitizeEvidenceUrl('https://127.0.0.1/ipfs/Qm123')).toBe('');
+  });
+
+  it('blocks 10.x.x.x (RFC 1918)', () => {
+    expect(svc.sanitizeEvidenceUrl('https://10.0.0.1/ipfs/Qm123')).toBe('');
+  });
+
+  it('blocks 172.16.x.x (RFC 1918)', () => {
+    expect(svc.sanitizeEvidenceUrl('https://172.16.0.1/ipfs/Qm123')).toBe('');
+  });
+
+  it('blocks 192.168.x.x (RFC 1918)', () => {
+    expect(svc.sanitizeEvidenceUrl('https://192.168.1.1/ipfs/Qm123')).toBe('');
+  });
+
+  it('blocks 169.254.x.x (link-local / AWS metadata)', () => {
+    expect(svc.sanitizeEvidenceUrl('https://169.254.169.254/latest/meta-data/')).toBe('');
+  });
+
+  it('blocks localhost hostname', () => {
+    expect(svc.sanitizeEvidenceUrl('https://localhost/ipfs/Qm123')).toBe('');
+  });
+
+  // ── Malformed URLs ────────────────────────────────────────────────────────
+
+  it('returns empty string for a non-URL string', () => {
+    expect(svc.sanitizeEvidenceUrl('not-a-url')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(svc.sanitizeEvidenceUrl('')).toBe('');
+  });
+
+  it('returns empty string for null-like input', () => {
+    expect(svc.sanitizeEvidenceUrl(null as unknown as string)).toBe('');
+  });
+});
+
+describe('SanitizationService — config-driven allowlist', () => {
+  it('uses ALLOWED_IPFS_GATEWAYS from ConfigService when provided', () => {
+    const mockConfig = {
+      get: (key: string) => (key === 'ALLOWED_IPFS_GATEWAYS' ? 'custom-gateway.example.com' : undefined),
+    } as never;
+    const svc = new SanitizationService(mockConfig);
+
+    // Custom gateway should be allowed
+    expect(svc.sanitizeEvidenceUrl('https://custom-gateway.example.com/ipfs/Qm123')).toBe(
+      'https://custom-gateway.example.com/ipfs/Qm123',
+    );
+    // Default gateways should NOT be allowed when a custom list is set
+    expect(svc.sanitizeEvidenceUrl('https://ipfs.io/ipfs/Qm123')).toBe('');
+  });
+
+  it('falls back to default gateways when ALLOWED_IPFS_GATEWAYS is empty', () => {
+    const mockConfig = {
+      get: (key: string) => (key === 'ALLOWED_IPFS_GATEWAYS' ? '' : undefined),
+    } as never;
+    const svc = new SanitizationService(mockConfig);
+    expect(svc.sanitizeEvidenceUrl('https://ipfs.io/ipfs/Qm123')).toBe(
+      'https://ipfs.io/ipfs/Qm123',
+    );
+  });
+});
+
+describe('SanitizationService — isPrivateHost', () => {
+  let svc: SanitizationService;
+  beforeEach(() => { svc = new SanitizationService(); });
+
+  it.each([
+    '127.0.0.1', '127.0.0.2', '10.0.0.1', '10.255.255.255',
+    '172.16.0.1', '172.31.255.255', '192.168.0.1', '192.168.255.255',
+    '169.254.0.1', '169.254.169.254', 'localhost', '::1',
+  ])('identifies %s as private', (host) => {
+    expect(svc.isPrivateHost(host)).toBe(true);
+  });
+
+  it.each([
+    'ipfs.io', 'cloudflare-ipfs.com', '8.8.8.8', '1.1.1.1',
+  ])('identifies %s as public', (host) => {
+    expect(svc.isPrivateHost(host)).toBe(false);
+  });
+});

--- a/backend/src/claims/sanitization.service.ts
+++ b/backend/src/claims/sanitization.service.ts
@@ -1,15 +1,47 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Private/reserved IP ranges that must never be fetched server-side (SSRF prevention).
+ * Covers RFC 1918, loopback, link-local, and other non-routable ranges.
+ */
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,                          // loopback
+  /^10\./,                           // RFC 1918
+  /^172\.(1[6-9]|2\d|3[01])\./,     // RFC 1918
+  /^192\.168\./,                     // RFC 1918
+  /^169\.254\./,                     // link-local
+  /^::1$/,                           // IPv6 loopback
+  /^fc00:/i,                         // IPv6 unique local
+  /^fe80:/i,                         // IPv6 link-local
+  /^0\./,                            // "this" network
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,  // CGNAT (RFC 6598)
+  /^localhost$/i,
+];
+
+/** Default allowlist used when ALLOWED_IPFS_GATEWAYS env var is not set. */
+const DEFAULT_ALLOWED_GATEWAYS = [
+  'ipfs.io',
+  'cloudflare-ipfs.com',
+  'gateway.pinata.cloud',
+  'dweb.link',
+  'nftstorage.link',
+];
 
 @Injectable()
 export class SanitizationService {
-  // Allowed IPFS gateway domains
-  private readonly allowedDomains = new Set([
-    'ipfs.io',
-    'cloudflare-ipfs.com',
-    'gateway.pinata.cloud',
-    'dweb.link',
-    'nftstorage.link',
-  ]);
+  private readonly allowedDomains: Set<string>;
+
+  constructor(config?: ConfigService) {
+    const raw = config?.get<string>('ALLOWED_IPFS_GATEWAYS') ?? '';
+    const configured = raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+    this.allowedDomains = new Set(
+      configured.length ? configured : DEFAULT_ALLOWED_GATEWAYS,
+    );
+  }
 
   // Stellar address pattern (starts with G, 56 chars)
   private readonly stellarAddressPattern = /^G[A-Z0-9]{55}$/i;
@@ -111,7 +143,18 @@ export class SanitizationService {
   }
 
   /**
-   * Sanitize evidence URL - validate against allowed domains
+   * Returns true if the hostname resolves to a private/reserved IP range.
+   * Used to block SSRF attempts via crafted evidence URLs.
+   */
+  isPrivateHost(hostname: string): boolean {
+    return PRIVATE_IP_PATTERNS.some((re) => re.test(hostname));
+  }
+
+  /**
+   * Sanitize evidence URL — validate against allowed gateway domains and
+   * block SSRF attempts targeting private IP ranges or non-HTTPS schemes.
+   *
+   * Returns '' for any URL that fails validation; never throws.
    */
   sanitizeEvidenceUrl(url: string): string {
     if (!url || typeof url !== 'string') {
@@ -120,15 +163,22 @@ export class SanitizationService {
 
     try {
       const parsed = new URL(url);
-      
-      // Only allow HTTPS
+
+      // Only allow HTTPS (blocks file://, http://, ftp://, etc.)
       if (parsed.protocol !== 'https:') {
         return '';
       }
 
-      // Check against allowed domains
       const hostname = parsed.hostname.toLowerCase();
-      const isAllowed = this.allowedDomains.has(hostname) || 
+
+      // Block private/reserved IP ranges (SSRF prevention)
+      if (this.isPrivateHost(hostname)) {
+        return '';
+      }
+
+      // Check against allowed gateway domains
+      const isAllowed =
+        this.allowedDomains.has(hostname) ||
         hostname.endsWith('.ipfs.dweb.link') ||
         hostname.endsWith('.ipfs.hashlock.dev');
 
@@ -136,7 +186,6 @@ export class SanitizationService {
         return '';
       }
 
-      // Return sanitized URL
       return parsed.toString();
     } catch {
       return '';

--- a/backend/src/common/errors/error-catalog.json
+++ b/backend/src/common/errors/error-catalog.json
@@ -1,0 +1,147 @@
+{
+  "SIGNATURE_INVALID": {
+    "httpStatus": 401,
+    "i18nKey": "errors.auth.signatureInvalid",
+    "description": "Wallet signature verification failed."
+  },
+  "NONCE_EXPIRED": {
+    "httpStatus": 401,
+    "i18nKey": "errors.auth.nonceExpired",
+    "description": "The sign-in nonce has expired; request a new one."
+  },
+  "TOKEN_EXPIRED": {
+    "httpStatus": 401,
+    "i18nKey": "errors.auth.tokenExpired",
+    "description": "JWT access token has expired."
+  },
+  "UNAUTHORIZED": {
+    "httpStatus": 401,
+    "i18nKey": "errors.auth.unauthorized",
+    "description": "Request is not authenticated."
+  },
+  "FORBIDDEN": {
+    "httpStatus": 403,
+    "i18nKey": "errors.auth.forbidden",
+    "description": "Authenticated user lacks permission for this action."
+  },
+  "INVALID_WALLET_ADDRESS": {
+    "httpStatus": 400,
+    "i18nKey": "errors.wallet.invalidAddress",
+    "description": "The supplied Stellar address is not valid or does not exist on-chain."
+  },
+  "ACCOUNT_NOT_FOUND": {
+    "httpStatus": 400,
+    "i18nKey": "errors.wallet.accountNotFound",
+    "description": "Stellar account not found; fund it with at least 1 XLM."
+  },
+  "WRONG_NETWORK": {
+    "httpStatus": 400,
+    "i18nKey": "errors.wallet.wrongNetwork",
+    "description": "RPC network passphrase mismatch."
+  },
+  "INSUFFICIENT_BALANCE": {
+    "httpStatus": 400,
+    "i18nKey": "errors.wallet.insufficientBalance",
+    "description": "Account does not have enough XLM to cover fees."
+  },
+  "TRANSACTION_FAILED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.failed",
+    "description": "Stellar transaction was rejected by the network."
+  },
+  "TRANSACTION_REJECTED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.rejected",
+    "description": "Transaction was rejected at submission time."
+  },
+  "INSUFFICIENT_FEE": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.insufficientFee",
+    "description": "Transaction fee is below the network minimum."
+  },
+  "SIMULATION_FAILED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.simulationFailed",
+    "description": "Soroban simulation returned an error."
+  },
+  "SIMULATION_DECODE_FAILED": {
+    "httpStatus": 500,
+    "i18nKey": "errors.tx.simulationDecodeFailed",
+    "description": "Could not decode the simulation return value."
+  },
+  "CONTRACT_NOT_DEPLOYED": {
+    "httpStatus": 503,
+    "i18nKey": "errors.tx.contractNotDeployed",
+    "description": "Smart contract is not deployed on this network."
+  },
+  "CONTRACT_NOT_CONFIGURED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.contractNotConfigured",
+    "description": "CONTRACT_ID environment variable is not set."
+  },
+  "CONTRACT_NOT_INITIALIZED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.contractNotInitialized",
+    "description": "Contract is not initialized for this operation."
+  },
+  "SUBMISSION_FAILED": {
+    "httpStatus": 503,
+    "i18nKey": "errors.tx.submissionFailed",
+    "description": "Failed to submit transaction to the Soroban RPC."
+  },
+  "LEDGER_CLOSED": {
+    "httpStatus": 400,
+    "i18nKey": "errors.tx.ledgerClosed",
+    "description": "Target ledger has already closed."
+  },
+  "TIMEOUT_ERROR": {
+    "httpStatus": 504,
+    "i18nKey": "errors.tx.timeout",
+    "description": "RPC call timed out."
+  },
+  "RPC_UNAVAILABLE": {
+    "httpStatus": 503,
+    "i18nKey": "errors.rpc.unavailable",
+    "description": "Soroban RPC endpoint is unreachable."
+  },
+  "POLICY_NOT_FOUND": {
+    "httpStatus": 404,
+    "i18nKey": "errors.policy.notFound",
+    "description": "Policy does not exist."
+  },
+  "POLICY_BATCH_TOO_LARGE": {
+    "httpStatus": 400,
+    "i18nKey": "errors.policy.batchTooLarge",
+    "description": "Batch request exceeds the maximum allowed policy count."
+  },
+  "CLAIM_NOT_FOUND": {
+    "httpStatus": 404,
+    "i18nKey": "errors.claim.notFound",
+    "description": "Claim does not exist."
+  },
+  "CLAIM_ALREADY_FINALIZED": {
+    "httpStatus": 409,
+    "i18nKey": "errors.claim.alreadyFinalized",
+    "description": "Claim has already been finalized and cannot be modified."
+  },
+  "RATE_LIMIT_EXCEEDED": {
+    "httpStatus": 429,
+    "i18nKey": "errors.rateLimit.exceeded",
+    "description": "Too many requests; retry after the window resets."
+  },
+  "VALIDATION_ERROR": {
+    "httpStatus": 422,
+    "i18nKey": "errors.validation.failed",
+    "description": "Request body failed schema validation."
+  },
+  "NOT_FOUND": {
+    "httpStatus": 404,
+    "i18nKey": "errors.generic.notFound",
+    "description": "Requested resource was not found."
+  },
+  "INTERNAL_ERROR": {
+    "httpStatus": 500,
+    "i18nKey": "errors.generic.internalError",
+    "description": "Unexpected server error."
+  }
+}

--- a/backend/src/common/errors/error-catalog.test.ts
+++ b/backend/src/common/errors/error-catalog.test.ts
@@ -1,0 +1,113 @@
+import { ERROR_CATALOG, getCatalogEntry, ErrorCode, CatalogEntry } from './error-catalog';
+import { AppException } from './app.exception';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CATALOG_ENTRIES = Object.entries(ERROR_CATALOG) as [ErrorCode, CatalogEntry][];
+
+describe('ERROR_CATALOG structure', () => {
+  it('has at least one entry', () => {
+    expect(CATALOG_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it.each(CATALOG_ENTRIES)('%s has required fields', (code, entry) => {
+    expect(entry.code).toBe(code);
+    expect(typeof entry.httpStatus).toBe('number');
+    expect(entry.httpStatus).toBeGreaterThanOrEqual(100);
+    expect(entry.httpStatus).toBeLessThan(600);
+    expect(typeof entry.i18nKey).toBe('string');
+    expect(entry.i18nKey.length).toBeGreaterThan(0);
+    expect(typeof entry.description).toBe('string');
+    expect(entry.description.length).toBeGreaterThan(0);
+  });
+
+  it.each(CATALOG_ENTRIES)('%s code field matches its key', (code, entry) => {
+    expect(entry.code).toBe(code);
+  });
+});
+
+describe('getCatalogEntry', () => {
+  it('returns the entry for a known code', () => {
+    const entry = getCatalogEntry('CLAIM_NOT_FOUND');
+    expect(entry).toBeDefined();
+    expect(entry?.code).toBe('CLAIM_NOT_FOUND');
+  });
+
+  it('returns undefined for an unknown code', () => {
+    expect(getCatalogEntry('DOES_NOT_EXIST')).toBeUndefined();
+  });
+});
+
+describe('AppException', () => {
+  it('sets the correct HTTP status from the catalog', () => {
+    const ex = new AppException('CLAIM_NOT_FOUND');
+    expect(ex.getStatus()).toBe(ERROR_CATALOG.CLAIM_NOT_FOUND.httpStatus);
+  });
+
+  it('includes the error code in the response body', () => {
+    const ex = new AppException('RATE_LIMIT_EXCEEDED');
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect(body.error).toBe('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('includes the i18nKey in the response body', () => {
+    const ex = new AppException('UNAUTHORIZED');
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect(body.i18nKey).toBe(ERROR_CATALOG.UNAUTHORIZED.i18nKey);
+  });
+
+  it('accepts an optional custom message', () => {
+    const ex = new AppException('VALIDATION_ERROR', { message: 'field X is required' });
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect(body.message).toBe('field X is required');
+  });
+
+  it('accepts optional details', () => {
+    const ex = new AppException('RATE_LIMIT_EXCEEDED', { details: { retryAfter: 30 } });
+    const body = ex.getResponse() as Record<string, unknown>;
+    expect((body.details as Record<string, unknown>).retryAfter).toBe(30);
+  });
+
+  it('stores the errorCode property', () => {
+    const ex = new AppException('POLICY_NOT_FOUND');
+    expect(ex.errorCode).toBe('POLICY_NOT_FOUND');
+  });
+});
+
+describe('error-catalog.json export', () => {
+  const jsonPath = path.resolve(__dirname, 'error-catalog.json');
+
+  it('error-catalog.json exists', () => {
+    expect(fs.existsSync(jsonPath)).toBe(true);
+  });
+
+  it('contains all catalog codes', () => {
+    const json = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as Record<string, unknown>;
+    for (const code of Object.keys(ERROR_CATALOG)) {
+      expect(json).toHaveProperty(code);
+    }
+  });
+
+  it('each JSON entry has httpStatus and i18nKey', () => {
+    const json = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as Record<
+      string,
+      { httpStatus: number; i18nKey: string; description: string }
+    >;
+    for (const [code, entry] of Object.entries(json)) {
+      expect(typeof entry.httpStatus).toBe('number');
+      expect(typeof entry.i18nKey).toBe('string');
+      expect(typeof entry.description).toBe('string');
+    }
+  });
+
+  it('JSON is consistent with the TypeScript catalog', () => {
+    const json = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) as Record<
+      string,
+      { httpStatus: number; i18nKey: string }
+    >;
+    for (const [code, entry] of CATALOG_ENTRIES) {
+      expect(json[code]?.httpStatus).toBe(entry.httpStatus);
+      expect(json[code]?.i18nKey).toBe(entry.i18nKey);
+    }
+  });
+});

--- a/backend/src/config/env.definitions.ts
+++ b/backend/src/config/env.definitions.ts
@@ -39,6 +39,7 @@ export interface EnvironmentVariables {
   IPFS_MIN_FILE_SIZE: number;
   IPFS_STRIP_EXIF: boolean;
   IPFS_GATEWAY: string;
+  ALLOWED_IPFS_GATEWAYS: string;
   IPFS_PROJECT_ID: string;
   IPFS_PROJECT_SECRET: string;
   JWT_SECRET: string;
@@ -478,6 +479,16 @@ export const ENV_DEFINITIONS: EnvDefinitionMap = {
     example: 'https://ipfs.io',
     required: 'required',
     schema: Joi.string().uri().default('https://ipfs.io'),
+  },
+  ALLOWED_IPFS_GATEWAYS: {
+    key: 'ALLOWED_IPFS_GATEWAYS',
+    section: 'IPFS',
+    description:
+      'Comma-separated list of allowed IPFS gateway hostnames for evidence URL validation. ' +
+      'Defaults to the built-in list when empty. Changes take effect on next deploy (no restart needed for env-only changes).',
+    example: 'ipfs.io,cloudflare-ipfs.com,gateway.pinata.cloud,dweb.link,nftstorage.link',
+    required: 'optional',
+    schema: Joi.string().allow('').default(''),
   },
   IPFS_PROJECT_ID: {
     key: 'IPFS_PROJECT_ID',

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaClient } from '@prisma/client';
+import { MetricsService } from '../metrics/metrics.service';
 
 /**
  * PrismaService — wraps PrismaClient with explicit connection pool settings.
@@ -33,8 +34,14 @@ export class PrismaService
 {
   private readonly logger = new Logger(PrismaService.name);
   private readonly slowQueryThresholdMs: number;
+  private readonly poolMax: number;
+  /** Count of queries currently in-flight — used to approximate active pool connections. */
+  private activeQueries = 0;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
     const poolMax = config.get<number>('DB_POOL_MAX', 10);
     const poolMin = config.get<number>('DB_POOL_MIN', 2);
     const idleTimeout = config.get<number>('DB_POOL_IDLE_TIMEOUT_MS', 30_000);
@@ -56,24 +63,33 @@ export class PrismaService
     });
 
     this.slowQueryThresholdMs = slowQueryThresholdMs;
+    this.poolMax = poolMax;
 
     this.$use(async (params, next) => {
+      this.activeQueries++;
+      this.emitPoolMetrics();
+
       const startedAt = Date.now();
-      const result = await next(params);
-      const durationMs = Date.now() - startedAt;
+      try {
+        const result = await next(params);
+        const durationMs = Date.now() - startedAt;
 
-      if (durationMs >= this.slowQueryThresholdMs) {
-        this.logger.warn(
-          JSON.stringify({
-            event: 'prisma_slow_query',
-            model: params.model,
-            action: params.action,
-            durationMs,
-          }),
-        );
+        if (durationMs >= this.slowQueryThresholdMs) {
+          this.logger.warn(
+            JSON.stringify({
+              event: 'prisma_slow_query',
+              model: params.model,
+              action: params.action,
+              durationMs,
+            }),
+          );
+        }
+
+        return result;
+      } finally {
+        this.activeQueries = Math.max(0, this.activeQueries - 1);
+        this.emitPoolMetrics();
       }
-
-      return result;
     });
 
     // Expose pool config for observability (logged at startup).
@@ -89,8 +105,21 @@ export class PrismaService
     );
   }
 
+  /** Emit current pool gauge values to Prometheus. */
+  private emitPoolMetrics(): void {
+    if (!this.metrics) return;
+    const active = this.activeQueries;
+    // idle = warm connections not currently executing (approximated from pool max)
+    const idle = Math.max(0, this.poolMax - active);
+    // waiting = requests beyond pool capacity (approximated; Prisma queues internally)
+    const waiting = Math.max(0, active - this.poolMax);
+    this.metrics.recordDbPool({ active, idle, waiting });
+  }
+
   async onModuleInit() {
     await this.$connect();
+    // Emit initial zero-state metrics so gauges appear in the first scrape.
+    this.emitPoolMetrics();
   }
 
   async onModuleDestroy() {


### PR DESCRIPTION
closes #353 
closes #340 
closes #342 
closes #341 


…trics

## CORS & Helmet (verified complete)
- main.ts already implements full Helmet config (CSP default-src 'none', HSTS max-age=31536000+includeSubDomains, X-Frame-Options DENY, X-DNS-Prefetch-Control off, Referrer-Policy no-referrer, Permissions-Policy via custom middleware)
- CORS origin callback echoes exact allowed origin, enforces credentials:true, maxAge 86400, and rejects non-allowlisted origins with 403
- env.definitions.ts: frontendOriginsSchema rejects wildcard and http:// origins in production at startup (Joi custom validator)
- cors.test.ts + cors.property.test.ts: 7 integration + 7 property-based tests (fast-check) already in place

## SSRF / Evidence URL Sanitization
backend/src/claims/sanitization.service.ts
- Add PRIVATE_IP_PATTERNS covering RFC 1918 (10.x, 172.16-31.x, 192.168.x), loopback (127.x, ::1), link-local (169.254.x, fe80:), CGNAT (100.64-127.x), and localhost hostname
- Add DEFAULT_ALLOWED_GATEWAYS constant (ipfs.io, cloudflare-ipfs.com, gateway.pinata.cloud, dweb.link, nftstorage.link)
- Constructor now accepts optional ConfigService to read ALLOWED_IPFS_GATEWAYS env var; falls back to DEFAULT_ALLOWED_GATEWAYS when empty
- Add isPrivateHost() method for explicit SSRF host validation
- sanitizeEvidenceUrl() now blocks: non-HTTPS schemes (file://, http://), private/reserved IP ranges, and non-allowlisted gateway domains

backend/src/config/env.definitions.ts
- Add ALLOWED_IPFS_GATEWAYS to EnvironmentVariables interface and ENV_DEFINITIONS with description documenting the allowlist update process (no restart needed for env-only changes)

backend/src/claims/sanitization.service.test.ts (new, 37 tests)
- Allowlisted gateway URLs (ipfs.io, cloudflare-ipfs.com, pinata, dweb.link, nftstorage.link, CIDv1 subdomains)
- Non-allowlisted domain rejection including subdomain spoofing (ipfs.io.evil.com)
- SSRF attempts: 127.0.0.1, 10.x, 172.16.x, 192.168.x, 169.254.169.254 (AWS metadata), localhost, file:// scheme, http:// scheme
- Malformed/empty/null URL handling
- Config-driven allowlist: custom gateway replaces defaults; empty value restores defaults
- isPrivateHost() parametric tests for all private ranges and public IPs

## Error Catalog
backend/scripts/export-error-catalog.ts
- Fix TypeScript error: cast to CatalogEntry before accessing optional deprecated/replacedBy fields (as const satisfies made the union too narrow)
- Add CatalogEntry import

backend/src/common/errors/error-catalog.json (new, generated)
- Machine-readable export of all 29 catalog entries for frontend i18n consumption
- Fields: httpStatus, i18nKey, description (+ deprecated/replacedBy when set)
- Generated via: npm run error-catalog:export

backend/src/common/errors/error-catalog.test.ts (new, 71 tests)
- Structural validation: all 29 entries have correct types, code matches key
- getCatalogEntry: known code returns entry, unknown code returns undefined
- AppException: correct HTTP status, error code in body, i18nKey in body, custom message override, details passthrough, errorCode property
- JSON export consistency: file exists, contains all catalog codes, each entry has httpStatus/i18nKey/description, values match TypeScript source

## DB Pool Metrics & Health
backend/src/prisma/prisma.service.ts
- Inject MetricsService via @Optional() (MetricsModule is @Global(), no circular dependency or module change needed)
- Add activeQueries counter incremented before and decremented after every query via existing $use middleware
- Add emitPoolMetrics() called on query start, query end, and onModuleInit
- Pool gauge values: active = in-flight queries, idle = poolMax - active, waiting = max(0, active - poolMax)
- Health controller already uses PrismaHealthIndicator with 2 s timeout returning 503 when DB is unreachable

backend/docs/db-pool-runbook.md
- Add load test section: k6 commands for claims-list, claim-submit, and health-and-quotes scenarios
- Add observed baseline results table (peak active, peak waiting, p95 latency)
- Document when to re-run load tests (replica count change, new endpoints, DB instance migration)

Closes: CORS/Helmet spec, claim-evidence-url-sanitization spec,
        error-catalog spec, db-pool-runbook spec