### PR TITLE
fix(indexer): wire ReconciliationService, AdminPoliciesService, Confi…

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -56,6 +56,7 @@ export class AdminController {
     private readonly privacyService: PrivacyService,
     private readonly rateLimitService: RateLimitService,
     private readonly queueMonitor: QueueMonitorService,
+    private readonly configService: ConfigService,
   ) {}
 
   /**

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -27,7 +27,7 @@ import { MetricsModule } from '../metrics/metrics.module';
     }),
   ],
   controllers: [AdminController],
-  providers: [AdminService, AuditService, QueueMonitorService],
+  providers: [AdminService, AdminPoliciesService, AuditService, QueueMonitorService],
   exports: [AuditService, QueueMonitorService],
 })
 export class AdminModule implements NestModule {

--- a/backend/src/events/parser-registry.spec.ts
+++ b/backend/src/events/parser-registry.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Parser registry — mixed-version event stream tests.
+ *
+ * Verifies that selectParser() routes events to the correct versioned parser
+ * based on the deployment registry, and that unknown schemas produce WarningRows.
+ */
+
+import {
+  selectParser,
+  initDeploymentRegistry,
+  isWarningRow,
+  EventParserV1,
+  EventParserV2,
+} from '../events/parser-registry';
+import { SCHEMA_VERSION } from '../events/events.schema';
+
+const CONTRACT_V1 = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+const CONTRACT_V2 = 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBSC4';
+const TX = 'deadbeef';
+
+beforeEach(() => {
+  // Reset registry before each test
+  initDeploymentRegistry([]);
+});
+
+describe('selectParser — deployment registry routing', () => {
+  it('returns V1 parser for ledgers in V1 range', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0, toLedger: 1000 },
+      { contractId: CONTRACT_V1, schemaVersion: 2, fromLedger: 1000 },
+    ]);
+
+    const parser = selectParser(CONTRACT_V1, 500);
+    expect(parser.schemaVersion).toBe(1);
+  });
+
+  it('returns V2 parser for ledgers in V2 range', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0, toLedger: 1000 },
+      { contractId: CONTRACT_V1, schemaVersion: 2, fromLedger: 1000 },
+    ]);
+
+    const parser = selectParser(CONTRACT_V1, 1500);
+    expect(parser.schemaVersion).toBe(2);
+  });
+
+  it('boundary: ledger exactly at toLedger uses next range', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0, toLedger: 1000 },
+      { contractId: CONTRACT_V1, schemaVersion: 2, fromLedger: 1000 },
+    ]);
+
+    // toLedger is exclusive, so ledger 1000 should use V2
+    const parser = selectParser(CONTRACT_V1, 1000);
+    expect(parser.schemaVersion).toBe(2);
+  });
+
+  it('falls back to V1 when no deployment entry matches', () => {
+    initDeploymentRegistry([]);
+    const parser = selectParser(CONTRACT_V1, 999);
+    expect(parser.schemaVersion).toBe(1);
+  });
+
+  it('isolates different contractIds — V2 contract does not affect V1 contract routing', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0 },
+      { contractId: CONTRACT_V2, schemaVersion: 2, fromLedger: 0 },
+    ]);
+
+    expect(selectParser(CONTRACT_V1, 500).schemaVersion).toBe(1);
+    expect(selectParser(CONTRACT_V2, 500).schemaVersion).toBe(2);
+  });
+});
+
+describe('mixed-version event stream parsing', () => {
+  const v1Topics = ['niffyins', 'clm_filed', 1n, 'GABC1111111111111111111111111111111111111111111111111111'];
+  const v1Payload = {
+    version: SCHEMA_VERSION,
+    policy_id: 3,
+    amount: '5000000',
+    evidence_hashes: [],
+    filed_at: 100,
+  };
+
+  it('V1 parser correctly parses a V1 event', () => {
+    initDeploymentRegistry([{ contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0 }]);
+
+    const parser = selectParser(CONTRACT_V1, 100);
+    const result = parser.parse(v1Topics, v1Payload, 100, TX);
+
+    expect(isWarningRow(result)).toBe(false);
+    if (!isWarningRow(result)) {
+      expect(result.key).toBe('niffyins:clm_filed');
+      expect(result.schemaVersion).toBe(SCHEMA_VERSION);
+    }
+  });
+
+  it('V2 parser delegates to V1 for known events (migration stub)', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0, toLedger: 500 },
+      { contractId: CONTRACT_V1, schemaVersion: 2, fromLedger: 500 },
+    ]);
+
+    const parser = selectParser(CONTRACT_V1, 600);
+    expect(parser.schemaVersion).toBe(2);
+
+    const result = parser.parse(v1Topics, v1Payload, 600, TX);
+    expect(isWarningRow(result)).toBe(false);
+    if (!isWarningRow(result)) {
+      expect(result.key).toBe('niffyins:clm_filed');
+    }
+  });
+
+  it('unknown event key produces a WarningRow (observable warning)', () => {
+    const parser = new EventParserV1();
+    const result = parser.parse(['niffyins', 'unknown_event_xyz'], {}, 100, TX);
+
+    expect(isWarningRow(result)).toBe(true);
+    if (isWarningRow(result)) {
+      expect(result.kind).toBe('unknown_schema');
+      expect(result.reason).toContain('unknown_event_key');
+    }
+  });
+
+  it('topics shorter than 2 produce a WarningRow', () => {
+    const parser = new EventParserV1();
+    const result = parser.parse(['niffyins'], {}, 100, TX);
+
+    expect(isWarningRow(result)).toBe(true);
+    if (isWarningRow(result)) {
+      expect(result.reason).toBe('topics_too_short');
+    }
+  });
+
+  it('mixed stream: V1 events before upgrade and V2 events after parse correctly', () => {
+    initDeploymentRegistry([
+      { contractId: CONTRACT_V1, schemaVersion: 1, fromLedger: 0, toLedger: 1000 },
+      { contractId: CONTRACT_V1, schemaVersion: 2, fromLedger: 1000 },
+    ]);
+
+    // Pre-upgrade event (ledger 500, V1 parser)
+    const preParser = selectParser(CONTRACT_V1, 500);
+    const preResult = preParser.parse(v1Topics, v1Payload, 500, TX);
+    expect(isWarningRow(preResult)).toBe(false);
+
+    // Post-upgrade event (ledger 1500, V2 parser — delegates to V1 for known events)
+    const postParser = selectParser(CONTRACT_V1, 1500);
+    const postResult = postParser.parse(v1Topics, v1Payload, 1500, TX);
+    expect(isWarningRow(postResult)).toBe(false);
+  });
+
+  it('new parser versions can be added without modifying existing parser code', () => {
+    // Verify V1 and V2 are independent instances
+    const v1 = new EventParserV1();
+    const v2 = new EventParserV2();
+    expect(v1.schemaVersion).toBe(1);
+    expect(v2.schemaVersion).toBe(2);
+    // V1 parse result is unaffected by V2 existence
+    const r = v1.parse(v1Topics, v1Payload, 100, TX);
+    expect(isWarningRow(r)).toBe(false);
+  });
+});

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { IndexerService } from './indexer.service';
 import { IndexerWorker } from './indexer.worker';
 import { ReindexWorkerService } from './reindex.worker';
+import { ReconciliationService } from './reconciliation.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RpcModule } from '../rpc/rpc.module';
 import { QuoteModule } from '../quote/quote.module';
 
 @Module({
-  imports: [PrismaModule, RpcModule, ConfigModule],
-  providers: [IndexerService, IndexerWorker, ReindexWorkerService],
-  exports: [IndexerService],
+  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forFeature()],
+  providers: [IndexerService, IndexerWorker, ReindexWorkerService, ReconciliationService],
+  exports: [IndexerService, ReconciliationService],
 })
 export class IndexerModule {}

--- a/backend/src/indexer/reconciliation.service.spec.ts
+++ b/backend/src/indexer/reconciliation.service.spec.ts
@@ -1,0 +1,120 @@
+import { ReconciliationService } from './reconciliation.service';
+
+function makePrisma(claims: { id: number; approveVotes: number; rejectVotes: number }[]) {
+  return {
+    claim: {
+      findMany: jest.fn().mockResolvedValue(claims),
+      findUnique: jest.fn().mockImplementation(({ where }: { where: { id: number } }) => {
+        const c = claims.find((x) => x.id === where.id);
+        return Promise.resolve(c ? { approveVotes: c.approveVotes, rejectVotes: c.rejectVotes } : null);
+      }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    vote: {
+      count: jest.fn(),
+    },
+  };
+}
+
+describe('ReconciliationService', () => {
+  describe('runReconciliation', () => {
+    it('reports ok when tallies match vote counts', async () => {
+      const prisma = makePrisma([{ id: 1, approveVotes: 2, rejectVotes: 1 }]);
+      prisma.vote.count
+        .mockResolvedValueOnce(2) // approve
+        .mockResolvedValueOnce(1); // reject
+
+      const svc = new ReconciliationService(prisma as never);
+      const result = await svc.runReconciliation();
+
+      expect(result.ok).toBe(true);
+      expect(result.discrepancies).toBe(0);
+      expect(result.totalChecked).toBe(1);
+      expect(prisma.claim.update).not.toHaveBeenCalled();
+    });
+
+    it('detects and self-heals a tally discrepancy', async () => {
+      const prisma = makePrisma([{ id: 5, approveVotes: 3, rejectVotes: 0 }]);
+      prisma.vote.count
+        .mockResolvedValueOnce(2) // actual approve (stored says 3)
+        .mockResolvedValueOnce(1); // actual reject (stored says 0)
+
+      const svc = new ReconciliationService(prisma as never);
+      const result = await svc.runReconciliation();
+
+      expect(result.ok).toBe(false);
+      expect(result.discrepancies).toBe(1);
+      expect(result.discrepantClaimIds).toEqual([5]);
+      expect(prisma.claim.update).toHaveBeenCalledWith({
+        where: { id: 5 },
+        data: { approveVotes: 2, rejectVotes: 1 },
+      });
+    });
+
+    it('handles multiple claims with mixed results', async () => {
+      const prisma = makePrisma([
+        { id: 1, approveVotes: 1, rejectVotes: 0 },
+        { id: 2, approveVotes: 5, rejectVotes: 2 },
+      ]);
+      prisma.vote.count
+        .mockResolvedValueOnce(1).mockResolvedValueOnce(0) // claim 1 ok
+        .mockResolvedValueOnce(4).mockResolvedValueOnce(2); // claim 2 discrepant
+
+      const svc = new ReconciliationService(prisma as never);
+      const result = await svc.runReconciliation();
+
+      expect(result.discrepancies).toBe(1);
+      expect(result.discrepantClaimIds).toEqual([2]);
+    });
+
+    it('stores last result for getLastResult()', async () => {
+      const prisma = makePrisma([]);
+      const svc = new ReconciliationService(prisma as never);
+
+      expect(svc.getLastResult()).toBeNull();
+      await svc.runReconciliation();
+      expect(svc.getLastResult()).not.toBeNull();
+      expect(svc.getLastResult()?.ok).toBe(true);
+    });
+  });
+
+  describe('getClaimReconciliationStatus', () => {
+    it('returns ok=true when tallies match', async () => {
+      const prisma = makePrisma([{ id: 10, approveVotes: 3, rejectVotes: 1 }]);
+      prisma.vote.count
+        .mockResolvedValueOnce(3) // approve
+        .mockResolvedValueOnce(1); // reject
+
+      const svc = new ReconciliationService(prisma as never);
+      const status = await svc.getClaimReconciliationStatus(10);
+
+      expect(status.ok).toBe(true);
+      expect(status.storedApprove).toBe(3);
+      expect(status.countApprove).toBe(3);
+    });
+
+    it('returns ok=false when tallies diverge', async () => {
+      const prisma = makePrisma([{ id: 10, approveVotes: 3, rejectVotes: 1 }]);
+      prisma.vote.count
+        .mockResolvedValueOnce(2) // approve mismatch
+        .mockResolvedValueOnce(1);
+
+      const svc = new ReconciliationService(prisma as never);
+      const status = await svc.getClaimReconciliationStatus(10);
+
+      expect(status.ok).toBe(false);
+      expect(status.storedApprove).toBe(3);
+      expect(status.countApprove).toBe(2);
+    });
+
+    it('returns ok=true for non-existent claim', async () => {
+      const prisma = makePrisma([]);
+      prisma.vote.count.mockResolvedValue(0);
+
+      const svc = new ReconciliationService(prisma as never);
+      const status = await svc.getClaimReconciliationStatus(999);
+
+      expect(status.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
closes #348 
closes #345 
closes #344 
closes #343 


…gService + add tests

- Inject ConfigService into AdminController constructor (was used but not wired)
- Add AdminPoliciesService to AdminModule providers (missing from DI graph)
- Provide and export ReconciliationService from IndexerModule so ClaimsService can resolve it; add ScheduleModule.forFeature() for @Cron support
- Add reconciliation.service.spec.ts: tally match, discrepancy self-heal, multi-claim mixed results, getClaimReconciliationStatus edge cases
- Add parser-registry.spec.ts: V1/V2 routing, ledger boundary, cross-contract isolation, WarningRow on unknown schema, mixed-version stream coverage