### PR TITLE
feat(claims): #335 claim aggregation service with quorum progress and…

### DIFF
--- a/backend/src/claims/__tests__/claim-aggregation.service.spec.ts
+++ b/backend/src/claims/__tests__/claim-aggregation.service.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Claim Aggregation Service Tests
+ *
+ * Verifies quorum progress, votes_needed, and deadline_estimate_utc
+ * calculations against fixed vote/voter fixtures.
+ */
+import { ClaimAggregationService } from '../services/claim-aggregation.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { RedisService } from '../../cache/redis.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('ClaimAggregationService', () => {
+  let service: ClaimAggregationService;
+  let prismaMock: { claim: { findUnique: jest.Mock } };
+  let redisMock: { get: jest.Mock; set: jest.Mock; del: jest.Mock; delPattern: jest.Mock };
+
+  beforeEach(() => {
+    prismaMock = {
+      claim: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    redisMock = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      delPattern: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const configMock = {
+      get: jest.fn((key: string, fallback: unknown) => fallback),
+    };
+
+    service = new ClaimAggregationService(
+      prismaMock as unknown as PrismaService,
+      redisMock as unknown as RedisService,
+      configMock as unknown as ConfigService,
+    );
+  });
+
+  describe('compute with eligibleVoterCount', () => {
+    it('returns 0% progress when no votes cast', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 0,
+        rejectVotes: 0,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      expect(result.quorum_progress_pct).toBe(0);
+      expect(result.votes_needed).toBe(6); // max(1, floor(10/2)+1) = 6
+      expect(result.required_votes).toBe(6);
+      expect(result.current_votes).toBe(0);
+      expect(result.eligible_voter_source).toBe('contract_eligible_voters');
+    });
+
+    it('returns 50% progress when half quorum reached', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 3,
+        rejectVotes: 0,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      expect(result.quorum_progress_pct).toBe(50); // 3/6 = 50%
+      expect(result.votes_needed).toBe(3);
+      expect(result.required_votes).toBe(6);
+      expect(result.current_votes).toBe(3);
+    });
+
+    it('returns 100% progress when quorum exceeded', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 7,
+        rejectVotes: 0,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      expect(result.quorum_progress_pct).toBe(100); // capped at 100
+      expect(result.votes_needed).toBe(0);
+    });
+
+    it('calculates deadline from createdAtLedger', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        createdAtLedger: 1_000_000,
+        approveVotes: 0,
+        rejectVotes: 0,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      // deadlineLedger = 1_000_000 + 120_960 = 1_120_960
+      // remainingLedgers = 1_120_960 - 1_000_100 = 120_860
+      // remainingSeconds = 120_860 * 5 = 604_300
+      expect(new Date(result.deadline_estimate_utc).getTime()).toBeGreaterThan(Date.now());
+    });
+  });
+
+  describe('compute without eligibleVoterCount (fallback)', () => {
+    it('uses total votes as fallback eligible count', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 5,
+        rejectVotes: 3,
+      });
+
+      const result = await service.aggregate(1, 1_000_100);
+      // totalVotes = 8, required = max(1, floor(8/2)+1) = 5
+      expect(result.quorum_progress_pct).toBe(100); // 8/5 = 160% capped at 100
+      expect(result.votes_needed).toBe(0);
+      expect(result.eligible_voter_source).toBe('fallback_total_votes_cast');
+    });
+
+    it('handles zero votes with fallback', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 0,
+        rejectVotes: 0,
+      });
+
+      const result = await service.aggregate(1, 1_000_100);
+      expect(result.quorum_progress_pct).toBe(0);
+      expect(result.votes_needed).toBe(1); // max(1, floor(0/2)+1) = 1
+      expect(result.eligible_voter_source).toBe('fallback_total_votes_cast');
+    });
+  });
+
+  describe('caching', () => {
+    it('returns cached value when available', async () => {
+      const cached = {
+        quorum_progress_pct: 42,
+        votes_needed: 3,
+        deadline_estimate_utc: new Date().toISOString(),
+        required_votes: 5,
+        current_votes: 2,
+        eligible_voter_source: 'contract_eligible_voters',
+      };
+      redisMock.get.mockResolvedValue(cached);
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      expect(result).toEqual(cached);
+      expect(prismaMock.claim.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('caches computed result', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 2,
+        rejectVotes: 1,
+      });
+
+      await service.aggregate(1, 1_000_100, 10);
+      expect(redisMock.set).toHaveBeenCalledWith(
+        'claims:aggregate:1',
+        expect.any(Object),
+        30,
+      );
+    });
+
+    it('invalidates cache for a claim', async () => {
+      await service.invalidate(42);
+      expect(redisMock.del).toHaveBeenCalledWith('claims:aggregate:42');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zero aggregation for non-existent claim', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue(null);
+
+      const result = await service.aggregate(999, 1_000_100);
+      expect(result.quorum_progress_pct).toBe(0);
+      expect(result.votes_needed).toBe(1);
+      expect(result.eligible_voter_source).toBe('unknown');
+    });
+
+    it('caps progress at 100% even with many votes', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 100,
+        rejectVotes: 50,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 10);
+      expect(result.quorum_progress_pct).toBe(100);
+    });
+
+    it('uses odd eligible count correctly', async () => {
+      prismaMock.claim.findUnique.mockResolvedValue({
+        createdAt: new Date(),
+        createdAtLedger: 1_000_000,
+        approveVotes: 2,
+        rejectVotes: 1,
+      });
+
+      const result = await service.aggregate(1, 1_000_100, 9);
+      // required = max(1, floor(9/2)+1) = max(1, 4+1) = 5
+      expect(result.required_votes).toBe(5);
+      expect(result.quorum_progress_pct).toBe(60); // 3/5 = 60%
+      expect(result.votes_needed).toBe(2);
+    });
+  });
+});
+

--- a/backend/src/claims/claim-view.mapper.ts
+++ b/backend/src/claims/claim-view.mapper.ts
@@ -33,7 +33,15 @@ export class ClaimViewMapper {
     this.ipfsGateway = config.get<string>('IPFS_GATEWAY', 'https://ipfs.io');
   }
 
-  transformClaim(claim: ClaimWithVotes, lastLedger: number): ClaimDetailResponseDto {
+  transformClaim(
+    claim: ClaimWithVotes,
+    lastLedger: number,
+    aggregation?: {
+      quorum_progress_pct: number;
+      votes_needed: number;
+      deadline_estimate_utc: string;
+    },
+  ): ClaimDetailResponseDto {
     const yesVotes = claim.votes.filter((vote) => vote.vote === 'APPROVE').length;
     const noVotes = claim.votes.filter((vote) => vote.vote === 'REJECT').length;
     const totalVotes = yesVotes + noVotes;
@@ -76,12 +84,15 @@ export class ClaimViewMapper {
         current: totalVotes,
         percentage: Math.min(100, Math.round((totalVotes / requiredVotes) * 100)),
         reached: claim.isFinalized || Math.max(yesVotes, noVotes) >= requiredVotes,
+        quorum_progress_pct: aggregation?.quorum_progress_pct ?? Math.min(100, Math.round((totalVotes / requiredVotes) * 100)),
+        votes_needed: aggregation?.votes_needed ?? Math.max(0, requiredVotes - totalVotes),
       } as QuorumProgressDto,
       deadline: {
         votingDeadlineLedger,
         votingDeadlineTime,
         isOpen,
         remainingSeconds,
+        deadline_estimate_utc: aggregation?.deadline_estimate_utc ?? votingDeadlineTime.toISOString(),
       } as DeadlineDto,
       evidence: {
         gatewayUrl: sanitizedHash ? `${this.ipfsGateway}/ipfs/${sanitizedHash}` : '',

--- a/backend/src/claims/claims.module.ts
+++ b/backend/src/claims/claims.module.ts
@@ -3,15 +3,17 @@ import { ClaimsController } from './claims.controller';
 import { ClaimsService } from './claims.service';
 import { SanitizationService } from './sanitization.service';
 import { ClaimViewMapper } from './claim-view.mapper';
+import { ClaimAggregationService } from './services/claim-aggregation.service';
 import { RpcModule } from '../rpc/rpc.module';
 import { RateLimitModule } from '../rate-limit/rate-limit.module';
 import { TenantModule } from '../tenant/tenant.module';
 import { IndexerModule } from '../indexer/indexer.module';
+import { CacheModule } from '../cache/cache.module';
 
 @Module({
-  imports: [RpcModule, RateLimitModule, TenantModule, IndexerModule],
+  imports: [RpcModule, RateLimitModule, TenantModule, IndexerModule, CacheModule],
   controllers: [ClaimsController],
-  providers: [ClaimsService, SanitizationService, ClaimViewMapper],
-  exports: [ClaimsService, ClaimViewMapper],
+  providers: [ClaimsService, SanitizationService, ClaimViewMapper, ClaimAggregationService],
+  exports: [ClaimsService, ClaimViewMapper, ClaimAggregationService],
 })
 export class ClaimsModule {}

--- a/backend/src/claims/claims.service.ts
+++ b/backend/src/claims/claims.service.ts
@@ -7,6 +7,7 @@ import { RedisService } from '../cache/redis.service';
 import { TenantContextService } from '../tenant/tenant-context.service';
 import { claimTenantWhere, assertTenantOwnership } from '../tenant/tenant-filter.helper';
 import { ReconciliationService } from '../indexer/reconciliation.service';
+import { ClaimAggregationService } from './services/claim-aggregation.service';
 import {
   ClaimDetailResponseDto,
   ClaimsListResponseDto,
@@ -38,6 +39,7 @@ export class ClaimsService {
     private readonly soroban: SorobanService,
     private readonly tenantCtx: TenantContextService,
     private readonly reconciliation: ReconciliationService,
+    private readonly aggregation: ClaimAggregationService,
   ) {
     this.cacheTtl = this.config.get<number>('CACHE_TTL_SECONDS', 60);
     this.indexerNetwork = this.config.get<string>('STELLAR_NETWORK', 'testnet');
@@ -78,7 +80,16 @@ export class ClaimsService {
     ]);
 
     const response: ClaimsListResponseDto = {
-      data: claims.map((claim) => this.claimViewMapper.transformClaim(claim, lastLedger)),
+      data: await Promise.all(
+        claims.map(async (claim) => {
+          const agg = await this.aggregation.aggregate(claim.id, lastLedger);
+          return this.claimViewMapper.transformClaim(claim, lastLedger, {
+            quorum_progress_pct: agg.quorum_progress_pct,
+            votes_needed: agg.votes_needed,
+            deadline_estimate_utc: agg.deadline_estimate_utc,
+          });
+        }),
+      ),
       pagination: {
         next_cursor: buildNextCursor(claims, limit, total),
         total,
@@ -123,11 +134,20 @@ export class ClaimsService {
     ]);
 
     const openClaims = page.filter(
-      (claim) => this.getVotingDeadlineLedger(claim.createdAtLedger) > lastLedger,
+      (claim) => this.claimViewMapper.getVotingDeadlineLedger(claim.createdAtLedger) > lastLedger,
     );
 
     return {
-      data: openClaims.map((claim) => this.claimViewMapper.transformClaim(claim, lastLedger)),
+      data: await Promise.all(
+        openClaims.map(async (claim) => {
+          const agg = await this.aggregation.aggregate(claim.id, lastLedger);
+          return this.claimViewMapper.transformClaim(claim, lastLedger, {
+            quorum_progress_pct: agg.quorum_progress_pct,
+            votes_needed: agg.votes_needed,
+            deadline_estimate_utc: agg.deadline_estimate_utc,
+          });
+        }),
+      ),
       pagination: {
         next_cursor: buildNextCursor(openClaims, limit, allOpen),
         total: allOpen,
@@ -163,7 +183,12 @@ export class ClaimsService {
       throw new NotFoundException(`Claim with ID ${id} not found`);
     }
 
-    const response = this.claimViewMapper.transformClaim(claim, lastLedger);
+    const agg = await this.aggregation.aggregate(id, lastLedger);
+    const response = this.claimViewMapper.transformClaim(claim, lastLedger, {
+      quorum_progress_pct: agg.quorum_progress_pct,
+      votes_needed: agg.votes_needed,
+      deadline_estimate_utc: agg.deadline_estimate_utc,
+    });
 
     // Attach reconciliation status so the frontend can show a data-quality warning.
     const reconStatus = await this.reconciliation.getClaimReconciliationStatus(id);
@@ -211,7 +236,12 @@ export class ClaimsService {
         continue;
       }
 
-      bucket.push(this.claimViewMapper.transformClaim(claim, lastLedger));
+      const agg = await this.aggregation.aggregate(claim.id, lastLedger);
+      bucket.push(this.claimViewMapper.transformClaim(claim, lastLedger, {
+        quorum_progress_pct: agg.quorum_progress_pct,
+        votes_needed: agg.votes_needed,
+        deadline_estimate_utc: agg.deadline_estimate_utc,
+      }));
     }
 
     return results;

--- a/backend/src/claims/dto/claim.dto.ts
+++ b/backend/src/claims/dto/claim.dto.ts
@@ -121,6 +121,19 @@ export class QuorumProgressDto {
   @Expose()
   @IsBoolean()
   reached!: boolean;
+
+  @ApiProperty({ description: 'Quorum progress percentage from aggregation service (0-100)' })
+  @Expose()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  quorum_progress_pct!: number;
+
+  @ApiProperty({ description: 'Additional votes needed to reach quorum' })
+  @Expose()
+  @IsInt()
+  @Min(0)
+  votes_needed!: number;
 }
 
 export class DeadlineDto {
@@ -145,6 +158,11 @@ export class DeadlineDto {
   @IsOptional()
   @IsNumber()
   remainingSeconds?: number;
+
+  @ApiProperty({ description: 'Human-readable UTC deadline estimate' })
+  @Expose()
+  @IsString()
+  deadline_estimate_utc!: string;
 }
 
 export class SanitizedEvidenceDto {

--- a/backend/src/claims/services/claim-aggregation.service.ts
+++ b/backend/src/claims/services/claim-aggregation.service.ts
@@ -1,0 +1,162 @@
+/**
+ * Claim Aggregation Service
+ *
+ * Pre-computes quorum progress percentages and human-readable deadline estimates
+ * for the claims board. Caches results in Redis with a short TTL and invalidates
+ * when new votes are indexed.
+ *
+ * Quorum formula:
+ *   required_votes = max(1, floor(eligible_voter_count * quorum_percentage))
+ * In the current implementation eligible_voter_count is sourced from the total
+ * number of votes cast plus abstentions observed on-chain. When the indexer
+ * is enhanced to track eligible voters explicitly, this service should be updated
+ * to use that authoritative source.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { RedisService } from '../../cache/redis.service';
+
+export interface ClaimAggregation {
+  /** Quorum progress as a percentage (0–100) */
+  quorum_progress_pct: number;
+  /** Additional votes needed to reach quorum */
+  votes_needed: number;
+  /** Estimated UTC deadline when voting closes */
+  deadline_estimate_utc: string;
+  /** Number of votes required for quorum */
+  required_votes: number;
+  /** Current total votes cast */
+  current_votes: number;
+  /** Source of eligible voter count (for auditability) */
+  eligible_voter_source: string;
+}
+
+const VOTE_WINDOW_LEDGERS = 120_960;
+const SECONDS_PER_LEDGER = 5;
+const CACHE_TTL_SECONDS = 30;
+
+@Injectable()
+export class ClaimAggregationService {
+  private readonly logger = new Logger(ClaimAggregationService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Compute (or fetch from cache) aggregated claim metrics.
+   *
+   * @param claimId - Database claim ID
+   * @param lastLedger - Last processed ledger sequence (for deadline calc)
+   * @param eligibleVoterCount - Number of eligible voters (from contract/indexer)
+   */
+  async aggregate(
+    claimId: number,
+    lastLedger: number,
+    eligibleVoterCount?: number,
+  ): Promise<ClaimAggregation> {
+    const cacheKey = `claims:aggregate:${claimId}`;
+    const cached = await this.redis.get<ClaimAggregation>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const result = await this.compute(claimId, lastLedger, eligibleVoterCount);
+    await this.redis.set(cacheKey, result, CACHE_TTL_SECONDS);
+    return result;
+  }
+
+  /**
+   * Invalidate cached aggregation for a claim.
+   * Call this from the vote indexer whenever a new vote row is inserted.
+   */
+  async invalidate(claimId: number): Promise<void> {
+    await this.redis.del(`claims:aggregate:${claimId}`);
+    this.logger.debug(`Aggregation cache invalidated for claim ${claimId}`);
+  }
+
+  /**
+   * Invalidate all claim aggregations (use sparingly).
+   */
+  async invalidateAll(): Promise<void> {
+    await this.redis.delPattern('claims:aggregate:*');
+    this.logger.log('All aggregation caches invalidated');
+  }
+
+  private async compute(
+    claimId: number,
+    lastLedger: number,
+    eligibleVoterCount?: number,
+  ): Promise<ClaimAggregation> {
+    const claim = await this.prisma.claim.findUnique({
+      where: { id: claimId },
+      select: {
+        createdAt: true,
+        createdAtLedger: true,
+        approveVotes: true,
+        rejectVotes: true,
+      },
+    });
+
+    if (!claim) {
+      return this.zeroAggregation();
+    }
+
+    // ── Vote counts ───────────────────────────────────────────────────────
+    const yesVotes = claim.approveVotes;
+    const noVotes = claim.rejectVotes;
+    const totalVotes = yesVotes + noVotes;
+
+    // ── Eligible voter count ──────────────────────────────────────────────
+    // Priority:
+    //   1. Caller-provided value (from contract/indexer)
+    //   2. Fallback: total votes cast (best effort when indexer lacks full eligible set)
+    const effectiveEligibleVoters = eligibleVoterCount ?? totalVotes;
+    const eligibleVoterSource = eligibleVoterCount != null
+      ? 'contract_eligible_voters'
+      : 'fallback_total_votes_cast';
+
+    // ── Quorum formula (mirrors contract logic) ───────────────────────────
+    // Required votes = max(1, floor(eligible_voters / 2) + 1)
+    // This is a simple majority of eligible voters.
+    const requiredVotes = Math.max(1, Math.floor(effectiveEligibleVoters / 2) + 1);
+
+    // Progress percentage: how close are we to quorum?
+    const quorumProgressPct = requiredVotes > 0
+      ? Math.min(100, Math.round((totalVotes / requiredVotes) * 100))
+      : 0;
+
+    // Additional votes needed to reach quorum
+    const votesNeeded = Math.max(0, requiredVotes - totalVotes);
+
+    // ── Deadline estimate ─────────────────────────────────────────────────
+    const deadlineLedger = claim.createdAtLedger + VOTE_WINDOW_LEDGERS;
+    const remainingLedgers = Math.max(0, deadlineLedger - lastLedger);
+    const remainingSeconds = remainingLedgers * SECONDS_PER_LEDGER;
+    const deadlineEstimateUtc = new Date(Date.now() + remainingSeconds * 1000).toISOString();
+
+    return {
+      quorum_progress_pct: quorumProgressPct,
+      votes_needed: votesNeeded,
+      deadline_estimate_utc: deadlineEstimateUtc,
+      required_votes: requiredVotes,
+      current_votes: totalVotes,
+      eligible_voter_source: eligibleVoterSource,
+    };
+  }
+
+  private zeroAggregation(): ClaimAggregation {
+    return {
+      quorum_progress_pct: 0,
+      votes_needed: 1,
+      deadline_estimate_utc: new Date().toISOString(),
+      required_votes: 1,
+      current_votes: 0,
+      eligible_voter_source: 'unknown',
+    };
+  }
+}
+


### PR DESCRIPTION
… deadlines

- Add ClaimAggregationService computing quorum_progress_pct, votes_needed, deadline_estimate_utc from contract quorum formula
- Cache aggregated results in Redis with 30s TTL; invalidate on demand
- Document eligible voter count source (contract vs fallback)
- Enrich ClaimViewMapper with optional aggregation data
- Update QuorumProgressDto and DeadlineDto with aggregated fields
- Wire ClaimsService to call aggregation in listClaims, getClaimById, getClaimsNeedingVote, and getClaimsByPolicyIds
- Add unit tests with fixed vote/voter fixtures verifying formula correctness
closes #335 