### PR TITLE
fix(#421): add boundary value tests for all validated fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,10 @@ Thumbs.db
 
 # Test artifacts
 **/test_snapshots/
+**/__snapshots__/
 proptest-regressions/
+*.snap
+*.snap.new
 
 # Logs
 *.log

--- a/contracts/niffyinsure/tests/types_validate.rs
+++ b/contracts/niffyinsure/tests/types_validate.rs
@@ -2,10 +2,14 @@
 
 use niffyinsure::{
     types::{
-        Claim, ClaimEvidenceEntry, ClaimStatus, Policy, PolicyType, RegionTier, TerminationReason,
-        VoteOption, DETAILS_MAX_LEN, IMAGE_URLS_MAX, IMAGE_URL_MAX_LEN,
+        AgeBand, Claim, ClaimEvidenceEntry, ClaimStatus, CoverageTier, Policy, PolicyType,
+        RegionTier, RiskInput, TerminationReason, VoteOption, DETAILS_MAX_LEN, IMAGE_URLS_MAX,
+        IMAGE_URL_MAX_LEN, REASON_MAX_LEN, SAFETY_SCORE_MAX,
     },
-    validate::{check_claim_fields, check_claim_open, check_policy, check_policy_active, Error},
+    validate::{
+        check_claim_fields, check_claim_open, check_policy, check_policy_active, check_reason,
+        check_risk_input, Error,
+    },
 };
 use soroban_sdk::{testutils::Address as _, BytesN, Address, Env, String, Vec};
 
@@ -328,4 +332,98 @@ fn claim_status_terminal_flags() {
     assert!(ClaimStatus::Paid.is_terminal());
     assert!(ClaimStatus::Rejected.is_terminal());
     assert!(ClaimStatus::Withdrawn.is_terminal());
+}
+
+// ── image_url boundary (at max len passes) ────────────────────────────────────
+
+#[test]
+fn image_url_at_max_len_passes() {
+    let env = Env::default();
+    let details = String::from_str(&env, "x");
+    let url_at_max = String::from_str(&env, &"u".repeat(IMAGE_URL_MAX_LEN as usize));
+    let mut ev = Vec::new(&env);
+    ev.push_back(ClaimEvidenceEntry {
+        url: url_at_max,
+        hash: non_zero_hash(&env),
+    });
+    assert_eq!(check_claim_fields(&env, 1, 100, &details, &ev), Ok(()));
+}
+
+// ── safety_score boundary tests ───────────────────────────────────────────────
+
+fn dummy_risk_input(safety_score: u32) -> RiskInput {
+    RiskInput {
+        region: RegionTier::Medium,
+        age_band: AgeBand::Adult,
+        coverage: CoverageTier::Standard,
+        safety_score,
+    }
+}
+
+#[test]
+fn safety_score_zero_passes() {
+    assert_eq!(check_risk_input(&dummy_risk_input(0)), Ok(()));
+}
+
+#[test]
+fn safety_score_at_max_passes() {
+    assert_eq!(check_risk_input(&dummy_risk_input(SAFETY_SCORE_MAX)), Ok(()));
+}
+
+#[test]
+fn safety_score_over_max_rejected() {
+    assert_eq!(
+        check_risk_input(&dummy_risk_input(SAFETY_SCORE_MAX + 1)),
+        Err(Error::SafetyScoreOutOfRange)
+    );
+}
+
+// ── reason length boundary tests ──────────────────────────────────────────────
+
+#[test]
+fn reason_at_max_len_passes() {
+    let env = Env::default();
+    let r = String::from_str(&env, &"r".repeat(REASON_MAX_LEN as usize));
+    assert_eq!(check_reason(&r), Ok(()));
+}
+
+#[test]
+fn reason_over_max_len_rejected() {
+    let env = Env::default();
+    let r = String::from_str(&env, &"r".repeat(REASON_MAX_LEN as usize + 1));
+    assert_eq!(check_reason(&r), Err(Error::ReasonTooLong));
+}
+
+#[test]
+fn reason_empty_passes() {
+    let env = Env::default();
+    let r = String::from_str(&env, "");
+    assert_eq!(check_reason(&r), Ok(()));
+}
+
+// ── details boundary (empty passes) ──────────────────────────────────────────
+
+#[test]
+fn details_empty_passes() {
+    let env = Env::default();
+    let s = String::from_str(&env, "");
+    let ev = empty_evidence(&env);
+    assert_eq!(check_claim_fields(&env, 1, 100, &s, &ev), Ok(()));
+}
+
+// ── evidence count at max passes ──────────────────────────────────────────────
+
+#[test]
+fn evidence_at_max_count_passes() {
+    let env = Env::default();
+    let details = String::from_str(&env, "x");
+    let url = String::from_str(&env, "ipfs://Qm1");
+    let mut ev = Vec::new(&env);
+    for _ in 0..IMAGE_URLS_MAX {
+        ev.push_back(ClaimEvidenceEntry {
+            url: url.clone(),
+            hash: non_zero_hash(&env),
+        });
+    }
+    assert_eq!(check_claim_fields(&env, 1, 100, &details, &ev), Ok(()));
 }


### PR DESCRIPTION
- Add safety_score boundary tests: 0, SAFETY_SCORE_MAX, SAFETY_SCORE_MAX+1
- Add image_url at-max-len passes test
- Add reason length boundary tests: empty, at max, over max
- Add details empty passes test
- Add evidence count at-max passes test
- Update imports to include check_reason, check_risk_input, and missing constants
- Update .gitignore to cover test snapshots and snap files

closes #421 