### PR TITLE
Ops: automate recovery drill ticket filing

### DIFF
--- a/.github/workflows/recovery-drill.yml
+++ b/.github/workflows/recovery-drill.yml
@@ -28,10 +28,16 @@ on:
         description: 'Optional replay anchor ledger; defaults to DRILL_REINDEX_FROM_LEDGER'
         required: false
         type: string
+      create_ticket:
+        description: 'Create a GitHub issue with drill evidence and follow-ups'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
   id-token: write
+  issues: write
 
 concurrency:
   group: recovery-drill-${{ vars.BACKUP_ENVIRONMENT || 'production' }}
@@ -80,6 +86,7 @@ jobs:
       SOROBAN_RPC_URL: ${{ vars.DRILL_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org' }}
       CONTRACT_ID: ${{ vars.DRILL_CONTRACT_ID }}
       DRILL_REINDEX_FROM_LEDGER: ${{ github.event.inputs.from_ledger || vars.DRILL_REINDEX_FROM_LEDGER }}
+      CREATE_DRILL_TICKET: ${{ github.event_name == 'schedule' || github.event.inputs.create_ticket == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -129,6 +136,36 @@ jobs:
             --network "${STELLAR_NETWORK}" \
             --output "${DRILL_OUTPUT_DIR}/indexer-replay.json"
 
+      - name: Write recovery drill ticket
+        if: always()
+        run: |
+          mkdir -p "$DRILL_OUTPUT_DIR"
+          cat > "$DRILL_OUTPUT_DIR/recovery-drill-ticket.md" <<EOF
+          # Recovery Drill Ticket
+
+          ## Metadata
+
+          - Environment: ${RESTORE_ENVIRONMENT}
+          - Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          - Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Backup object key: ${BACKUP_OBJECT_KEY:-latest under ${BACKUP_PREFIX}/${RESTORE_ENVIRONMENT}}
+          - Restore database target: ${RESTORE_DATABASE_URL}
+          - Replay anchor ledger N: ${DRILL_REINDEX_FROM_LEDGER}
+
+          ## Validation
+
+          - Restore job status: ${{ job.status }}
+          - Evidence artifact: recovery-drill-${GITHUB_RUN_ID}
+          - Replay output: indexer-replay.json
+
+          ## Follow-up actions
+
+          - File any failed validation, IAM, replay, or timing gaps as follow-up issues within 48 hours.
+          - Update docs/ops/recovery-drill-log.md with observed RTO/RPO after reviewing this artifact.
+          EOF
+
+          cat "$DRILL_OUTPUT_DIR/recovery-drill-ticket.md" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload drill evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -136,6 +173,17 @@ jobs:
           name: recovery-drill-${{ github.run_id }}
           path: drill-evidence/
           retention-days: 365
+
+      - name: File recovery drill ticket
+        if: always() && env.CREATE_DRILL_TICKET == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Recovery drill ${RESTORE_ENVIRONMENT} ${GITHUB_RUN_ID} - ${{ job.status }}"
+          gh issue create \
+            --title "$title" \
+            --label "Stellar Wave" \
+            --body-file "$DRILL_OUTPUT_DIR/recovery-drill-ticket.md"
 
       - name: Notify ops on drill failure
         if: failure() && secrets.OPS_ALERT_WEBHOOK_URL != ''

--- a/docs/ops/disaster-recovery-runbook.md
+++ b/docs/ops/disaster-recovery-runbook.md
@@ -41,6 +41,18 @@
 - Verifies required tables and captures row-count evidence
 - Replays the indexer from `DRILL_REINDEX_FROM_LEDGER` using [`backend/scripts/replay-indexer.ts`](../../backend/scripts/replay-indexer.ts)
 - Uploads evidence artifacts for 365 days
+- Files a GitHub issue from the drill ticket template on scheduled runs and on manual runs unless `create_ticket` is disabled
+
+### Quarterly owner rotation
+
+| Quarter | Primary owner | Secondary owner | Required filing |
+|---|---|---|---|
+| Q1 | Backend on-call lead | DBA/Ops lead | GitHub issue from workflow + drill log row |
+| Q2 | DBA/Ops lead | Backend on-call lead | GitHub issue from workflow + drill log row |
+| Q3 | Platform Engineering lead | Incident Commander delegate | GitHub issue from workflow + drill log row |
+| Q4 | Incident Commander delegate | Platform Engineering lead | GitHub issue from workflow + drill log row |
+
+The primary owner reviews the uploaded artifact, records observed RTO/RPO in [`recovery-drill-log.md`](./recovery-drill-log.md), and opens follow-up issues for any access, restore, replay, or smoke-test gaps within 48 hours.
 
 ## IAM and access-path requirements
 

--- a/docs/ops/recovery-drill-log.md
+++ b/docs/ops/recovery-drill-log.md
@@ -5,4 +5,4 @@ Track quarterly restore drills here after filing the full ticket from [`recovery
 | Date | Environment | Backup object | Replay ledger | Outcome | Evidence | Notes |
 |---|---|---|---|---|---|---|
 | 2026-03-29 | local repo | _N/A_ | _N/A_ | Implementation prepared | PR / local workspace | Backup, restore, and replay automation added; live restore not executed in this sandbox because `pg_dump`, `pg_restore`, `psql`, and Docker were unavailable |
-| _Pending first quarterly drill_ | production or staging | _TBD_ | _TBD_ | _TBD_ | GitHub Actions artifact + ticket | Record the first end-to-end restore and replay timestamps here |
+| _Pending first quarterly drill_ | staging | _TBD_ | _TBD_ | _TBD_ | GitHub Actions artifact + auto-filed issue | Primary owner records observed RTO/RPO here after reviewing the workflow artifact |


### PR DESCRIPTION
## Summary
- create recovery drill ticket markdown during scheduled/manual workflow runs
- auto-file a GitHub issue with drill evidence unless disabled for manual runs
- document quarterly owner rotation and update the drill log placeholder

Closes #396

## Validation
- Inspected workflow diff locally
- Not executed: recovery drill requires configured staging AWS/GitHub variables and restore credentials