### PR TITLE
Ops: verify Postgres backups with restore drill

### DIFF
--- a/.github/workflows/postgres-backup.yml
+++ b/.github/workflows/postgres-backup.yml
@@ -40,7 +40,21 @@ jobs:
   backup:
     name: Encrypted pg_dump to S3
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: restore_drill
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d restore_drill"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       AWS_REGION: ${{ vars.BACKUP_AWS_REGION }}
       BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
@@ -50,6 +64,10 @@ jobs:
       BACKUP_SKIP_PRUNE: ${{ github.event.inputs.skip_prune == 'true' && '1' || '0' }}
       BACKUP_OUTPUT_DIR: ${{ github.workspace }}/backup-artifacts
       DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+      RESTORE_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/restore_drill
+      RESTORE_ENVIRONMENT: ${{ vars.BACKUP_ENVIRONMENT || 'production' }}
+      DRILL_OUTPUT_DIR: ${{ github.workspace }}/backup-artifacts/restore-drill
+      RESTORE_MAX_ROW_COUNT_DELTA: ${{ vars.BACKUP_RESTORE_MAX_ROW_COUNT_DELTA || '0' }}
       BACKUP_KMS_KEY_ID: ${{ secrets.BACKUP_KMS_KEY_ID }}
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +94,13 @@ jobs:
 
       - name: Run backup
         run: ./scripts/ops/postgres-backup.sh
+
+      - name: Select backup object for restore verification
+        run: |
+          echo "BACKUP_OBJECT_KEY=$(jq -r '.dumpObjectKey' backup-artifacts/postgres.metadata.json)" >> "$GITHUB_ENV"
+
+      - name: Verify backup with restore drill
+        run: ./scripts/ops/postgres-restore-drill.sh
 
       - name: Upload backup metadata artifact
         if: always()

--- a/docs/ops/disaster-recovery-runbook.md
+++ b/docs/ops/disaster-recovery-runbook.md
@@ -30,7 +30,9 @@
 - Method: `pg_dump --format=custom --compress=9`
 - Encryption at rest: S3 `SSE-KMS` using `BACKUP_KMS_KEY_ID`
 - Retention: repo variable `BACKUP_RETENTION_DAYS` plus per-run pruning
+- Storage location: `s3://$BACKUP_BUCKET/$BACKUP_PREFIX/$BACKUP_ENVIRONMENT/postgres-<timestamp>.dump` with adjacent `.metadata.json`
 - Evidence: uploaded metadata artifact and S3-side metadata JSON
+- Restore verification: every successful backup is restored into an ephemeral PostgreSQL service and checked against metadata row counts
 - Failure alert: optional `OPS_ALERT_WEBHOOK_URL` webhook
 
 ### Quarterly restore drill

--- a/scripts/ops/postgres-backup.sh
+++ b/scripts/ops/postgres-backup.sh
@@ -25,6 +25,7 @@ require_env "BACKUP_KMS_KEY_ID"
 require_cmd "aws"
 require_cmd "jq"
 require_cmd "pg_dump"
+require_cmd "psql"
 require_cmd "sha256sum"
 
 backup_environment="${BACKUP_ENVIRONMENT:-production}"
@@ -47,7 +48,17 @@ dump_file="${tmpdir}/postgres.dump"
 metadata_file="${tmpdir}/postgres.metadata.json"
 inventory_file="${tmpdir}/inventory.json"
 
+count_table() {
+  local table_name="$1"
+  psql "${DATABASE_URL}" -Atqc \
+    "SELECT CASE WHEN to_regclass('public.${table_name}') IS NULL THEN 0 ELSE (SELECT COUNT(*) FROM public.${table_name}) END;"
+}
+
 echo "Creating PostgreSQL backup for ${backup_environment} at ${timestamp_iso}"
+policy_count="$(count_table "policies")"
+claim_count="$(count_table "claims")"
+raw_event_count="$(count_table "raw_events")"
+
 pg_dump \
   --dbname="${DATABASE_URL}" \
   --format=custom \
@@ -78,6 +89,9 @@ jq -n \
   --arg kmsKeyId "${BACKUP_KMS_KEY_ID}" \
   --argjson retentionDays "${retention_days}" \
   --argjson sizeBytes "${dump_size_bytes}" \
+  --argjson policyCount "${policy_count}" \
+  --argjson claimCount "${claim_count}" \
+  --argjson rawEventCount "${raw_event_count}" \
   '{
     backupBucket: $bucket,
     backupEnvironment: $environment,
@@ -88,7 +102,12 @@ jq -n \
     sha256: $sha256,
     kmsKeyId: $kmsKeyId,
     retentionDays: $retentionDays,
-    sizeBytes: $sizeBytes
+    sizeBytes: $sizeBytes,
+    rowCounts: {
+      policies: $policyCount,
+      claims: $claimCount,
+      rawEvents: $rawEventCount
+    }
   }' > "${metadata_file}"
 
 aws s3 cp "${metadata_file}" "s3://${BACKUP_BUCKET}/${metadata_key}" \
@@ -132,6 +151,9 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "- Metadata object: \`s3://${BACKUP_BUCKET}/${metadata_key}\`"
     echo "- SHA-256: \`${dump_sha256}\`"
     echo "- Size (bytes): \`${dump_size_bytes}\`"
+    echo "- Policies: \`${policy_count}\`"
+    echo "- Claims: \`${claim_count}\`"
+    echo "- Raw events: \`${raw_event_count}\`"
     echo "- Retention days: \`${retention_days}\`"
     echo "- Pruned objects this run: \`${deleted_count}\`"
   } >> "${GITHUB_STEP_SUMMARY}"

--- a/scripts/ops/postgres-restore-drill.sh
+++ b/scripts/ops/postgres-restore-drill.sh
@@ -29,6 +29,7 @@ require_cmd "sha256sum"
 
 restore_environment="${RESTORE_ENVIRONMENT:-production}"
 output_dir="${DRILL_OUTPUT_DIR:-drill-evidence}"
+max_row_count_delta="${RESTORE_MAX_ROW_COUNT_DELTA:-0}"
 prefix="${BACKUP_PREFIX#/}"
 prefix="${prefix%/}"
 requested_object_key="${BACKUP_OBJECT_KEY:-}"
@@ -128,6 +129,33 @@ latest_cursor_json="$(
     "SELECT COALESCE(json_agg(row_to_json(t))::text, '[]') FROM (SELECT network, last_processed_ledger FROM ledger_cursors ORDER BY network) t;"
 )"
 
+row_count_status="not_checked"
+if [[ -s "${metadata_file}" ]]; then
+  expected_policy_count="$(jq -r '.rowCounts.policies // empty' "${metadata_file}")"
+  expected_claim_count="$(jq -r '.rowCounts.claims // empty' "${metadata_file}")"
+  expected_raw_event_count="$(jq -r '.rowCounts.rawEvents // empty' "${metadata_file}")"
+
+  if [[ -n "${expected_policy_count}" && -n "${expected_claim_count}" && -n "${expected_raw_event_count}" ]]; then
+    row_count_status="matched"
+    for pair in \
+      "policies:${expected_policy_count}:${policy_count}" \
+      "claims:${expected_claim_count}:${claim_count}" \
+      "raw_events:${expected_raw_event_count}:${raw_event_count}"
+    do
+      IFS=":" read -r table_name expected actual <<< "${pair}"
+      delta=$(( actual - expected ))
+      if (( delta < 0 )); then
+        delta=$(( -delta ))
+      fi
+      if (( delta > max_row_count_delta )); then
+        echo "error: ${table_name} row count delta ${delta} exceeds threshold ${max_row_count_delta} (expected ${expected}, restored ${actual})" >&2
+        row_count_status="diverged"
+        exit 1
+      fi
+    done
+  fi
+fi
+
 completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 jq -n \
@@ -142,6 +170,8 @@ jq -n \
   --argjson rawEventCount "${raw_event_count}" \
   --argjson latestRawEventLedger "${latest_raw_event_ledger}" \
   --argjson ledgerCursors "${latest_cursor_json}" \
+  --arg rowCountStatus "${row_count_status}" \
+  --argjson maxRowCountDelta "${max_row_count_delta}" \
   '{
     startedAt: $startedAt,
     completedAt: $completedAt,
@@ -153,7 +183,9 @@ jq -n \
     claimCount: $claimCount,
     rawEventCount: $rawEventCount,
     latestRawEventLedger: $latestRawEventLedger,
-    ledgerCursors: $ledgerCursors
+    ledgerCursors: $ledgerCursors,
+    rowCountStatus: $rowCountStatus,
+    maxRowCountDelta: $maxRowCountDelta
   }' > "${evidence_file}"
 
 cp "${metadata_file}" "${output_dir}/$(basename "${metadata_file}")" 2>/dev/null || true
@@ -170,6 +202,7 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "- Claims: \`${claim_count}\`"
     echo "- Raw events: \`${raw_event_count}\`"
     echo "- Latest raw-event ledger: \`${latest_raw_event_ledger}\`"
+    echo "- Row-count verification: \`${row_count_status}\`"
   } >> "${GITHUB_STEP_SUMMARY}"
 fi
 


### PR DESCRIPTION
## Summary
- run the restore drill automatically after each backup
- record backup row counts in metadata and compare restored counts against a configurable threshold
- document backup storage location and restore verification in the disaster recovery runbook

Closes #397

## Validation
- bash -n scripts/ops/postgres-backup.sh
- bash -n scripts/ops/postgres-restore-drill.sh
- Not executed end-to-end: requires configured AWS OIDC role, S3 bucket, KMS key, and backup database secret