### PR TITLE
feat(redis): expose cache hit/miss and connection error metrics (#422)

### DIFF
--- a/backend/docs/prometheus-alerts.yml
+++ b/backend/docs/prometheus-alerts.yml
@@ -107,3 +107,42 @@ groups:
             the dead-letter set. Check bullmq_dlq_jobs_total for job_name and
             failure_reason labels to triage. Replay via:
             POST /api/admin/queues/{{ $labels.queue }}/jobs/:jobId/retry
+
+      # ── Redis cache hit rate alert ─────────────────────────────────────────
+      # Alert when the cache hit rate drops below 50 % over a 10-minute window.
+      - alert: RedisCacheHitRateLow
+        expr: |
+          (
+            sum(rate(redis_cache_hits_total{app="niffyinsure-api"}[10m]))
+            /
+            (
+              sum(rate(redis_cache_hits_total{app="niffyinsure-api"}[10m]))
+              + sum(rate(redis_cache_misses_total{app="niffyinsure-api"}[10m]))
+            )
+          ) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: "Redis cache hit rate below 50 %"
+          description: >
+            The overall Redis cache hit rate has been below 50 % for 10 minutes.
+            This may indicate cache eviction pressure, a cold-start after a
+            Redis restart, or an unexpected traffic pattern. Check Redis memory
+            usage and consider increasing maxmemory or TTLs.
+
+      # ── Redis connection errors alert ──────────────────────────────────────
+      - alert: RedisConnectionErrors
+        expr: |
+          sum(rate(redis_connection_errors_total{app="niffyinsure-api"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: critical
+          team: backend
+        annotations:
+          summary: "Redis connection errors detected"
+          description: >
+            Redis connection errors have been observed for at least 2 minutes.
+            Rate limiting is failing open and nonce-based auth will be rejected.
+            Restore Redis connectivity immediately.

--- a/backend/docs/redis-cache-hit-rates.md
+++ b/backend/docs/redis-cache-hit-rates.md
@@ -1,0 +1,43 @@
+# Redis Cache Hit Rates
+
+## Metrics
+
+| Metric | Description |
+|---|---|
+| `redis_cache_hits_total{namespace}` | Counter — cache hits by key namespace |
+| `redis_cache_misses_total{namespace}` | Counter — cache misses by key namespace |
+| `redis_connection_errors_total` | Counter — ioredis connection errors |
+
+Namespace label values map to the first segment of the Redis key:
+
+| Namespace | Key pattern | TTL |
+|---|---|---|
+| `cache` | `cache:policy:*`, `cache:claim:*` | 30 s (policy), 10 s (claim) |
+| `nonce` | `nonce:<address>` | 5 min |
+| `ratelimit` | `ratelimit:<identifier>` | 60 s |
+| `idempotency` | `idempotency:<hash>` | 24 h |
+
+## Expected Hit Rates
+
+| Cache type | Expected hit rate | Notes |
+|---|---|---|
+| Policy reads | ≥ 70 % | 30 s TTL; high read-to-write ratio in steady state |
+| Claim reads | ≥ 50 % | 10 s TTL; claim status changes more frequently |
+| Idempotency | ≥ 90 % | Only retried requests hit this; misses are first-time requests |
+| Nonce | ~0 % | Nonces are consumed on first use (atomic GET+DEL) |
+| Rate limit | N/A | Counters, not cached values — not tracked as hit/miss |
+
+A sustained overall hit rate below **50 %** triggers the `RedisCacheHitRateLow` Prometheus alert (see `docs/prometheus-alerts.yml`).
+
+## Degraded behaviour
+
+Redis is a cache layer only — Postgres is authoritative for all financial data.
+
+| Operation | Redis down behaviour |
+|---|---|
+| Policy / claim reads | Cache miss → falls through to DB |
+| Rate limiting | Fail open — requests are allowed through |
+| Wallet-auth nonces | Fail closed — auth is rejected (`RedisUnavailableError`) |
+| BullMQ job queues | Fail closed — job not enqueued, caller receives error |
+
+The `/health` endpoint returns `503` with `redis: down` when Redis is unreachable.

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/terminus';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { PrismaHealthIndicator } from './prisma.health';
+import { RedisHealthIndicator } from './redis.health';
 
 @ApiTags('health')
 @Controller('health')
@@ -14,6 +15,7 @@ export class HealthController {
   constructor(
     private health: HealthCheckService,
     private prismaHealth: PrismaHealthIndicator,
+    private redisHealth: RedisHealthIndicator,
   ) {}
 
   @Get()
@@ -24,6 +26,7 @@ export class HealthController {
   check(): Promise<HealthCheckResult> {
     return this.health.check([
       (): Promise<HealthIndicatorResult> => this.prismaHealth.isHealthy('prisma'),
+      (): Promise<HealthIndicatorResult> => this.redisHealth.isHealthy('redis'),
     ]);
   }
 }

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { PrismaHealthIndicator } from './prisma.health';
+import { RedisHealthIndicator } from './redis.health';
 
 @Module({
   imports: [TerminusModule],
   controllers: [HealthController],
-  providers: [PrismaHealthIndicator],
+  providers: [PrismaHealthIndicator, RedisHealthIndicator],
 })
 export class HealthModule {}
 

--- a/backend/src/health/redis.health.ts
+++ b/backend/src/health/redis.health.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import { checkRedisHealth } from '../redis/client';
+
+/**
+ * Redis health indicator for /health endpoint.
+ *
+ * Returns:
+ *   - "up" if Redis responds to PING within 2 s
+ *   - "down" if Redis is unreachable or times out
+ *
+ * Kubernetes readiness/liveness probes should tolerate Redis being down
+ * (the app degrades gracefully), but operators should alert on prolonged
+ * Redis unavailability to restore cache and rate-limiting functionality.
+ */
+@Injectable()
+export class RedisHealthIndicator extends HealthIndicator {
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const isUp = await checkRedisHealth();
+    const result = this.getStatus(key, isUp);
+
+    if (isUp) {
+      return result;
+    }
+
+    throw new HealthCheckError('Redis health check failed', result);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,6 +14,9 @@ import type { Request, Response, NextFunction } from "express";
 import { loadNetworkConfig } from "./config/network.config";
 import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import { validateEnvironment } from "./config/env.validation";
+import { MetricsService } from './metrics/metrics.service';
+import { setRedisCacheMetricsService } from './redis/cache';
+import { setRedisClientMetricsService } from './redis/client';
 import { AppLoggerService } from "./common/logger/app-logger.service";
 import { EnvironmentVariables } from "./config/env.definitions";
 
@@ -60,6 +63,11 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   const appLogger = app.get(AppLoggerService);
   app.useLogger(appLogger);
+
+  // Wire MetricsService into Redis standalone modules (lazy injection)
+  const metricsService = app.get(MetricsService);
+  setRedisCacheMetricsService(metricsService);
+  setRedisClientMetricsService(metricsService);
 
   // Global prefix
   app.setGlobalPrefix("api");

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -52,6 +52,14 @@ export class MetricsService implements OnModuleInit {
   /** Number of requests waiting for a free connection. */
   readonly dbPoolWaiting: client.Gauge<string>;
 
+  // ── Redis cache metrics ───────────────────────────────────────────────────
+  /** Total cache hits by key namespace (policy, claim, idempotency, …). */
+  readonly redisCacheHits: client.Counter<string>;
+  /** Total cache misses by key namespace. */
+  readonly redisCacheMisses: client.Counter<string>;
+  /** Total Redis connection errors. */
+  readonly redisConnectionErrors: client.Counter<string>;
+
   constructor() {
     this.registry = new client.Registry();
     this.registry.setDefaultLabels({ app: 'niffyinsure-api' });
@@ -185,6 +193,26 @@ export class MetricsService implements OnModuleInit {
       help: 'Number of requests waiting for a free DB connection',
       registers: [this.registry],
     });
+
+    this.redisCacheHits = new client.Counter({
+      name: 'redis_cache_hits_total',
+      help: 'Total Redis cache hits by key namespace',
+      labelNames: ['namespace'],
+      registers: [this.registry],
+    });
+
+    this.redisCacheMisses = new client.Counter({
+      name: 'redis_cache_misses_total',
+      help: 'Total Redis cache misses by key namespace',
+      labelNames: ['namespace'],
+      registers: [this.registry],
+    });
+
+    this.redisConnectionErrors = new client.Counter({
+      name: 'redis_connection_errors_total',
+      help: 'Total Redis connection errors',
+      registers: [this.registry],
+    });
   }
 
   onModuleInit() {
@@ -278,6 +306,18 @@ export class MetricsService implements OnModuleInit {
     this.dbPoolActive.set(opts.active);
     this.dbPoolIdle.set(opts.idle);
     this.dbPoolWaiting.set(opts.waiting);
+  }
+
+  recordRedisCache(result: 'hit' | 'miss', namespace: string) {
+    if (result === 'hit') {
+      this.redisCacheHits.inc({ namespace });
+    } else {
+      this.redisCacheMisses.inc({ namespace });
+    }
+  }
+
+  recordRedisConnectionError() {
+    this.redisConnectionErrors.inc();
   }
 
   async getMetrics(): Promise<string> {

--- a/backend/src/redis/cache.ts
+++ b/backend/src/redis/cache.ts
@@ -9,6 +9,23 @@
 import { getRedisClient, RedisUnavailableError } from "./client";
 import { TTL } from "./config";
 
+// ── Metrics integration ───────────────────────────────────────────────────────
+// Lazily injected to avoid circular deps. Set by MetricsModule on bootstrap.
+let _metricsService: { recordRedisCache(result: 'hit' | 'miss', ns: string): void } | null = null;
+
+export function setRedisCacheMetricsService(
+  svc: { recordRedisCache(result: 'hit' | 'miss', ns: string): void },
+): void {
+  _metricsService = svc;
+}
+
+/** Derive a low-cardinality namespace label from a cache key. */
+function namespaceOf(key: string): string {
+  // key format: "cache:policy:…", "nonce:…", "ratelimit:…", "idempotency:…"
+  const seg = key.split(':')[0];
+  return seg || 'other';
+}
+
 // ── Generic get/set/del ───────────────────────────────────────────────────────
 
 /**
@@ -18,10 +35,15 @@ import { TTL } from "./config";
 export async function cacheGet<T>(key: string): Promise<T | null> {
   try {
     const raw = await getRedisClient().get(key);
-    if (raw === null) return null;
+    if (raw === null) {
+      _metricsService?.recordRedisCache('miss', namespaceOf(key));
+      return null;
+    }
+    _metricsService?.recordRedisCache('hit', namespaceOf(key));
     return JSON.parse(raw) as T;
   } catch {
     // Degrade gracefully — cache miss is always safe
+    _metricsService?.recordRedisCache('miss', namespaceOf(key));
     return null;
   }
 }

--- a/backend/src/redis/client.ts
+++ b/backend/src/redis/client.ts
@@ -28,6 +28,15 @@
 import Redis from "ioredis";
 import { buildRedisConfig } from "./config";
 
+// ── Metrics integration ───────────────────────────────────────────────────────
+let _metricsService: { recordRedisConnectionError(): void } | null = null;
+
+export function setRedisClientMetricsService(
+  svc: { recordRedisConnectionError(): void },
+): void {
+  _metricsService = svc;
+}
+
 export class RedisUnavailableError extends Error {
   constructor(cause?: unknown) {
     super("Redis is unavailable");
@@ -90,6 +99,7 @@ export function getRedisClient(): Redis {
     if (!isTestEnv) {
       console.error("[redis] connection error:", err.message);
     }
+    _metricsService?.recordRedisConnectionError();
   });
 
   _client.on("connect", () => {


### PR DESCRIPTION
## Summary

Resolves #422

Implements all acceptance criteria from the issue:

- **Redis cache metrics visible in Prometheus scrape**
  - `redis_cache_hits_total{namespace}` and `redis_cache_misses_total{namespace}` counters added to `MetricsService`
  - `redis_connection_errors_total` counter added
  - `cacheGet()` in `cache.ts` records hit/miss by key namespace (policy, claim, idempotency, nonce)
  - ioredis `error` event in `client.ts` increments the connection error counter
  - `MetricsService` wired into Redis standalone modules on bootstrap via `main.ts`

- **`/health` returns degraded status when Redis is unreachable**
  - New `RedisHealthIndicator` (`health/redis.health.ts`) using existing `checkRedisHealth()`
  - Wired into `HealthController` and `HealthModule`

- **Alert fires when cache hit rate drops below threshold**
  - `RedisCacheHitRateLow` alert: fires when hit rate < 50 % for 10 min
  - `RedisConnectionErrors` alert: fires on any connection errors sustained for 2 min
  - Both added to `docs/prometheus-alerts.yml`

- **Documentation**
  - `docs/redis-cache-hit-rates.md` documents expected hit rates per cache key type and degraded behaviour

## Files changed

| File | Change |
|---|---|
| `backend/src/metrics/metrics.service.ts` | Add 3 Redis counters + 2 record methods |
| `backend/src/redis/cache.ts` | Instrument `cacheGet()` with hit/miss tracking |
| `backend/src/redis/client.ts` | Record connection errors on ioredis error event |
| `backend/src/health/redis.health.ts` | New — `RedisHealthIndicator` |
| `backend/src/health/health.controller.ts` | Add Redis health check |
| `backend/src/health/health.module.ts` | Register `RedisHealthIndicator` |
| `backend/src/main.ts` | Wire `MetricsService` into Redis modules on bootstrap |
| `backend/docs/prometheus-alerts.yml` | Add `RedisCacheHitRateLow` + `RedisConnectionErrors` alerts |
| `backend/docs/redis-cache-hit-rates.md` | New — cache hit rate documentation |