### PR TITLE
fix(get_policies_batch): use PolicyBatchTooLarge (50) not VotingDurat…

### DIFF
--- a/backend/src/rpc/soroban.service.ts
+++ b/backend/src/rpc/soroban.service.ts
@@ -200,8 +200,8 @@ export class SorobanService {
     return (
       e.includes('policybatch') ||
       e.includes('policy_batch') ||
-      // ContractError tag 49 = VotingDurationOutOfBounds (also used for get_policies_batch over cap)
-      /\b49\b/.test(error)
+      // ContractError tag 50 = PolicyBatchTooLarge
+      /\b50\b/.test(error)
     );
   }
 

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -169,6 +169,7 @@ impl NiffyInsure {
             41 => validate::Error::NotEligibleVoter,
             42 => validate::Error::RateLimitExceeded,
             49 => validate::Error::VotingDurationOutOfBounds,
+            50 => validate::Error::PolicyBatchTooLarge,
             51 => validate::Error::VoterSnapshotExpired,
             52 => validate::Error::NonceMismatch,
             _ => validate::Error::ClaimNotApproved,
@@ -518,7 +519,7 @@ impl NiffyInsure {
     /// Matches [`types::PAGE_SIZE_MAX`]: each entry is an independent storage read, so
     /// large batches multiply metered reads and can exceed the default Soroban
     /// instruction budget during simulation. Dashboards and indexers must chunk
-    /// requests. **More than 20 keys reverts** with [`validate::Error::VotingDurationOutOfBounds`]
+    /// requests. **More than 20 keys reverts** with [`validate::Error::PolicyBatchTooLarge`]
     /// (unlike `list_policies`, which clamps `limit` instead of erroring).
     ///
     /// The cap is checked **before** any policy storage access (no unbounded iteration).
@@ -527,7 +528,7 @@ impl NiffyInsure {
         ids: Vec<types::PolicyLookupKey>,
     ) -> Vec<Option<types::Policy>> {
         if ids.len() > types::POLICY_BATCH_GET_MAX {
-            panic_with_error!(&env, validate::Error::VotingDurationOutOfBounds);
+            panic_with_error!(&env, validate::Error::PolicyBatchTooLarge);
         }
         let mut out: Vec<Option<types::Policy>> = Vec::new(&env);
         for i in 0..ids.len() {

--- a/contracts/niffyinsure/tests/get_policies_batch.rs
+++ b/contracts/niffyinsure/tests/get_policies_batch.rs
@@ -89,5 +89,5 @@ fn get_policies_batch_over_cap_reverts() {
         });
     }
     let err = client.try_get_policies_batch(&ids).err().unwrap().unwrap();
-    assert_eq!(err, ValidateError::VotingDurationOutOfBounds.into());
+    assert_eq!(err, ValidateError::PolicyBatchTooLarge.into());
 }


### PR DESCRIPTION
…ionOutOfBounds (49)

- panic_with_error! in get_policies_batch now emits PolicyBatchTooLarge (50), the dedicated error variant, instead of reusing VotingDurationOutOfBounds (49)
- Update doc comment to reference the correct error
- Add missing code 50 mapping in quote_error_message
- Fix over-cap test assertion to expect PolicyBatchTooLarge
- Fix backend isPolicyBatchTooLargeSimulation regex from 49 to 50
closes #316