### PR TITLE
fix(policy-beneficiary): add beneficiary display+warning to chain-rea…

### DIFF
--- a/contracts/niffyinsure/tests/policy_beneficiary.rs
+++ b/contracts/niffyinsure/tests/policy_beneficiary.rs
@@ -201,3 +201,56 @@ fn set_beneficiary_requires_holder_authorization() {
         .try_set_beneficiary(&holder, &policy.policy_id, &None)
         .is_err());
 }
+
+#[test]
+fn set_beneficiary_no_op_when_value_unchanged() {
+    // Setting the same beneficiary twice must not revert and must leave the
+    // stored value identical (idempotent).
+    let (env, client, _contract_id, token_addr, token_admin) = setup();
+    let holder = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    fund_and_approve(&env, &client, &token_addr, &token_admin, &holder);
+
+    let policy = initiate(&client, &holder, &token_addr, Some(beneficiary.clone()));
+    // Call set_beneficiary with the same address — must succeed silently.
+    client.set_beneficiary(&holder, &policy.policy_id, &Some(beneficiary.clone()));
+
+    let updated = client.get_policy(&holder, &policy.policy_id).unwrap();
+    assert_eq!(updated.beneficiary, Some(beneficiary));
+}
+
+#[test]
+fn set_beneficiary_can_clear_back_to_none() {
+    // After setting a beneficiary, clearing it (None) must route payouts back
+    // to the holder.
+    let (env, client, contract_id, token_addr, token_admin) = setup();
+    let holder = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    fund_and_approve(&env, &client, &token_addr, &token_admin, &holder);
+    token_admin.mint(&contract_id, &10_000_000i128);
+
+    let policy = initiate(&client, &holder, &token_addr, Some(beneficiary.clone()));
+    // Clear the beneficiary.
+    client.set_beneficiary(&holder, &policy.policy_id, &None);
+
+    let updated = client.get_policy(&holder, &policy.policy_id).unwrap();
+    assert!(updated.beneficiary.is_none());
+
+    // Payout must now go to holder, not the former beneficiary.
+    inject_approved_claim(
+        &env,
+        &contract_id,
+        1,
+        &updated,
+        &holder,
+        &token_addr,
+        4_000_000,
+    );
+
+    let tok = token::Client::new(&env, &token_addr);
+    let before_holder = tok.balance(&holder);
+    let before_ben = tok.balance(&beneficiary);
+    client.process_claim(&1u64);
+    assert_eq!(tok.balance(&holder), before_holder + 4_000_000i128);
+    assert_eq!(tok.balance(&beneficiary), before_ben, "former beneficiary must not receive payout after clear");
+}

--- a/frontend/src/app/policy/[holder]/[policyId]/page.tsx
+++ b/frontend/src/app/policy/[holder]/[policyId]/page.tsx
@@ -27,9 +27,17 @@ export default async function PolicyDetailPage({ params }: Props) {
     start_ledger: number;
     end_ledger: number;
     strike_count: number;
+    /** Optional beneficiary address set by the holder. Null/undefined = payouts go to holder. */
+    beneficiary?: string | null;
   };
 
   const statusLabel = p.is_active ? 'Active' : 'Inactive';
+  const decodedHolder = decodeURIComponent(holder);
+  const hasBeneficiary = Boolean(p.beneficiary?.trim());
+  // Warn when a beneficiary is set — the connected wallet is server-rendered so
+  // we always show the warning when any beneficiary is present; the client-side
+  // policy/[id]/page.tsx compares against the live wallet address.
+  const showBeneficiaryWarning = hasBeneficiary && p.beneficiary !== decodedHolder;
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-2xl space-y-6">
@@ -38,6 +46,27 @@ export default async function PolicyDetailPage({ params }: Props) {
         {' / '}
         <span>Policy #{p.policy_id}</span>
       </nav>
+
+      {showBeneficiaryWarning && (
+        <div
+          role="alert"
+          className="flex gap-3 rounded-lg border border-amber-400/60 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/30 dark:text-amber-200"
+        >
+          <span aria-hidden="true" className="mt-0.5 shrink-0 text-base">⚠️</span>
+          <div className="space-y-1">
+            <p className="font-semibold">Payout address differs from the policy holder</p>
+            <p>
+              Approved claims will be paid to the <strong>beneficiary</strong> address below, not
+              the holder. Verify this address on a second channel (hardware wallet screen, multisig
+              quorum, etc.) before signing any policy changes.
+            </p>
+            <p className="text-xs opacity-80">
+              Phishing risk: malicious interfaces can trick you into setting a beneficiary you do
+              not control.
+            </p>
+          </div>
+        </div>
+      )}
 
       <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-4 shadow-sm">
         <div className="flex items-center justify-between">
@@ -55,6 +84,18 @@ export default async function PolicyDetailPage({ params }: Props) {
           <Detail label="Start ledger" value={String(p.start_ledger)} />
           <Detail label="End ledger" value={String(p.end_ledger)} />
           <Detail label="Strike count" value={String(p.strike_count)} />
+          <div className="col-span-2">
+            <dt className="text-xs text-gray-500">Payout beneficiary</dt>
+            <dd className="font-mono text-xs break-all text-gray-900">
+              {hasBeneficiary ? (
+                <span className={showBeneficiaryWarning ? 'text-amber-700 dark:text-amber-300' : undefined}>
+                  {p.beneficiary}
+                </span>
+              ) : (
+                <span className="italic text-gray-400">Not set — payouts go to holder</span>
+              )}
+            </dd>
+          </div>
         </dl>
 
         <p className="text-xs text-gray-400">


### PR DESCRIPTION
…d page and missing tests

frontend/src/app/policy/[holder]/[policyId]/page.tsx:
- Add beneficiary field to the cast type (was missing entirely)
- Display payout beneficiary row in the detail card; italic fallback when unset
- Show amber warning banner when beneficiary differs from the holder address, matching the acceptance criterion for the frontend policy detail page

contracts/niffyinsure/tests/policy_beneficiary.rs:
- set_beneficiary_no_op_when_value_unchanged: idempotent call with same address must succeed without reverting
- set_beneficiary_can_clear_back_to_none: clearing beneficiary routes payout back to holder; former beneficiary receives nothing
closes #319 