### PR TITLE
feat(events): wire SSE claim push via Redis pub/sub from indexer

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { MetricsModule } from './metrics/metrics.module';
 import { TenantModule } from './tenant/tenant.module';
 import { GraphqlApiModule } from './graphql/graphql.module';
 import { MaintenanceModule } from './maintenance/maintenance.module';
+import { EventsModule } from './events/events.module';
 import { RequestContextMiddleware } from './common/middleware/request-context.middleware';
 import { AppLoggerService } from './common/logger/app-logger.service';
 import { OracleHooksController } from './experimental/oracle-hooks.controller';
@@ -79,6 +80,7 @@ const IDEMPOTENCY_ROUTES = [
     TenantModule,
     GraphqlApiModule,
     MaintenanceModule,
+    EventsModule,
   ],
   controllers: [OracleHooksController, BetaCalculatorsController],
   providers: [RequestContextMiddleware, AppLoggerService],

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -7,11 +7,11 @@ import { ReindexWorkerService } from './reindex.worker';
 import { ReconciliationService } from './reconciliation.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RpcModule } from '../rpc/rpc.module';
-import { QuoteModule } from '../quote/quote.module';
 import { MetricsModule } from '../metrics/metrics.module';
+import { EventsModule } from '../events/events.module';
 
 @Module({
-  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forFeature()],
+  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forFeature(), EventsModule],
   providers: [IndexerService, IndexerWorker, ReindexWorkerService, ReconciliationService],
   exports: [IndexerService, ReconciliationService],
 })

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -10,6 +10,7 @@ import {
   initDeploymentRegistry,
   isWarningRow,
 } from '../events/parser-registry';
+import { ClaimEventsService } from '../events/claim-events.service';
 import { rpc as SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
 import { tryNormalizeAddress } from '../common/utils/normalize-address';
 
@@ -92,6 +93,7 @@ export class IndexerService {
     private readonly soroban: SorobanService,
     private readonly config: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly claimEvents?: ClaimEventsService,
   ) {
     this.networkId = this.config.get<string>('STELLAR_NETWORK', 'testnet');
     this.gapThresholdLedgers = this.config.get<number>('INDEXER_GAP_ALERT_THRESHOLD_LEDGERS', 100);
@@ -400,6 +402,13 @@ export class IndexerService {
         imageUrls: getStringArray(data.image_urls),
       },
     });
+
+    await this.claimEvents?.publish({
+      claimId: String(claimId),
+      status: 'PENDING',
+      updatedAt: new Date().toISOString(),
+      ledger: event.ledger,
+    });
   }
 
   private async handleVoteCast(
@@ -440,6 +449,13 @@ export class IndexerService {
         rejectVotes: getNumberValue(data.reject_votes),
       },
     });
+
+    await this.claimEvents?.publish({
+      claimId: String(claimId),
+      status: 'VOTING',
+      updatedAt: new Date().toISOString(),
+      ledger: event.ledger,
+    });
   }
 
   private async handleClaimProcessed(tx: IndexerTx, data: EventPayload, event: SorobanEvent) {
@@ -451,6 +467,13 @@ export class IndexerService {
         paidAt: new Date(event.ledgerClosedAt),
         updatedAtLedger: event.ledger,
       },
+    });
+
+    await this.claimEvents?.publish({
+      claimId: String(claimId),
+      status: 'PAID',
+      updatedAt: new Date(event.ledgerClosedAt).toISOString(),
+      ledger: event.ledger,
     });
   }
 }


### PR DESCRIPTION
- Inject ClaimEventsService (@Optional) into IndexerService
- Call publish() after handleClaimFiled (PENDING), handleVoteCast (VOTING), and handleClaimProcessed (PAID) — after Prisma tx commits
- Import EventsModule into IndexerModule for DI
- Register EventsModule in AppModule to bootstrap SSE controller and ClaimEventsService Redis subscriber on startup
closes #332 