### PR TITLE
feat(quote): wire quote simulation cache invalidation on tbl_upd

### DIFF
--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -7,11 +7,11 @@ import { ReindexWorkerService } from './reindex.worker';
 import { ReconciliationService } from './reconciliation.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RpcModule } from '../rpc/rpc.module';
-import { QuoteModule } from '../quote/quote.module';
 import { MetricsModule } from '../metrics/metrics.module';
+import { QuoteModule } from '../quote/quote.module';
 
 @Module({
-  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forFeature()],
+  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forFeature(), QuoteModule],
   providers: [IndexerService, IndexerWorker, ReindexWorkerService, ReconciliationService],
   exports: [IndexerService, ReconciliationService],
 })

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -10,6 +10,7 @@ import {
   initDeploymentRegistry,
   isWarningRow,
 } from '../events/parser-registry';
+import { QuoteSimulationCacheService } from '../quote/quote-simulation-cache.service';
 import { rpc as SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
 import { tryNormalizeAddress } from '../common/utils/normalize-address';
 
@@ -92,6 +93,7 @@ export class IndexerService {
     private readonly soroban: SorobanService,
     private readonly config: ConfigService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly quoteSimulationCache?: QuoteSimulationCacheService,
   ) {
     this.networkId = this.config.get<string>('STELLAR_NETWORK', 'testnet');
     this.gapThresholdLedgers = this.config.get<number>('INDEXER_GAP_ALERT_THRESHOLD_LEDGERS', 100);
@@ -321,6 +323,8 @@ export class IndexerService {
         (mainTopic === 'niffyinsure' && subTopic === 'claim_paid')
       ) {
         await this.handleClaimProcessed(tx, dataNative, event);
+      } else if (mainTopic === 'niffyins' && subTopic === 'tbl_upd') {
+        await this.handlePremiumTableUpdated();
       }
 
       await this.advanceCursorInTx(tx, network, event.ledger);
@@ -452,5 +456,15 @@ export class IndexerService {
         updatedAtLedger: event.ledger,
       },
     });
+  }
+
+  /**
+   * On-chain `tbl_upd` means the premium multiplier table was updated.
+   * Flush the entire quote simulation cache so subsequent requests
+   * re-simulate against the new on-chain multipliers.
+   */
+  private async handlePremiumTableUpdated(): Promise<void> {
+    await this.quoteSimulationCache?.invalidateAll();
+    this.logger.log('Quote simulation cache invalidated after tbl_upd event');
   }
 }


### PR DESCRIPTION
- Inject QuoteSimulationCacheService (@Optional) into IndexerService
- Handle niffyins:tbl_upd event by calling invalidateAll() so stale premiums are not served after on-chain multiplier table updates
- Import QuoteModule into IndexerModule for DI

Cache read/write, SHA-256 key, no-cache bypass, and hit/miss/bypass metrics are already implemented in QuoteService and QuoteSimulationCacheService.

closes #333 