### PR TITLE
feat: treasury balance read entrypoint

### DIFF
--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -103,7 +103,7 @@ impl NiffyInsure {
     /// Matches funds available for `process_claim` for the configured default asset.
     pub fn get_treasury_balance(env: Env) -> i128 {
         let token_addr = storage::get_token(&env);
-        crate::token::get_balance(&env, &token_addr)
+        crate::token::get_treasury_balance(&env, &token_addr)
     }
 
     /// Pure quote path: reads config and computes premium only.

--- a/contracts/niffyinsure/src/token.rs
+++ b/contracts/niffyinsure/src/token.rs
@@ -55,6 +55,13 @@ pub fn get_balance(env: &Env, asset: &Address) -> i128 {
     client.balance(&env.current_contract_address())
 }
 
+/// Get the current balance of `asset` held by the configured treasury address.
+pub fn get_treasury_balance(env: &Env, asset: &Address) -> i128 {
+    let treasury = storage::get_treasury(env);
+    let client = token::TokenClient::new(env, asset);
+    client.balance(&treasury)
+}
+
 /// Emergency sweep: transfer `amount` of `asset` from contract to `recipient`.
 /// Used only by admin sweep_token() function with strict validation.
 /// Defence-in-depth: caller must have already validated asset allowlist.

--- a/contracts/niffyinsure/tests/treasury_balance.rs
+++ b/contracts/niffyinsure/tests/treasury_balance.rs
@@ -1,0 +1,38 @@
+//! Treasury balance read endpoint.
+
+#![cfg(test)]
+
+use niffyinsure::NiffyInsureClient;
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
+
+fn setup() -> (Env, Address, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(issuer).address();
+    client.initialize(&admin, &token);
+    (env, contract_id, client, admin, token)
+}
+
+#[test]
+fn get_treasury_balance_returns_default_contract_balance() {
+    let (env, contract_id, client, _, token_id) = setup();
+    token::StellarAssetClient::new(&env, &token_id).mint(&contract_id, &123_456i128);
+
+    assert_eq!(client.get_treasury_balance(), 123_456i128);
+}
+
+#[test]
+fn get_treasury_balance_tracks_configured_treasury() {
+    let (env, contract_id, client, _, token_id) = setup();
+    let treasury = Address::generate(&env);
+    client.set_treasury(&treasury);
+
+    token::StellarAssetClient::new(&env, &token_id).mint(&contract_id, &111i128);
+    token::StellarAssetClient::new(&env, &token_id).mint(&treasury, &222_333i128);
+
+    assert_eq!(client.get_treasury_balance(), 222_333i128);
+}


### PR DESCRIPTION
Closes #322

Adds a safe read-only balance endpoint for backend solvency monitoring.

Notes:
- Uses the configured treasury address for the default token balance.
- Adds token mock coverage for default and rotated treasury balances.

Checks:
- cargo fmt ran, then unrelated pre-existing formatting churn was reverted to keep this PR scoped
- cargo test -p niffyinsure --test treasury_balance currently blocked by existing compile errors on main