### PR TITLE
feat: admin configurable evidence count

### DIFF
--- a/contracts/niffyinsure/src/admin.rs
+++ b/contracts/niffyinsure/src/admin.rs
@@ -51,6 +51,8 @@ pub enum AdminError {
     InvalidAdminActionWindow = 115,
     /// Sweep notice period has not elapsed since the proposal.
     SweepNoticePeriodActive = 116,
+    /// Max evidence count outside the absolute hard bound.
+    MaxEvidenceCountOutOfBounds = 117,
 }
 
 /// Payload for a treasury-rotation proposal.
@@ -558,7 +560,7 @@ pub struct MaxEvidenceCountUpdated {
 pub fn set_max_evidence_count(env: &Env, new_count: u32) -> Result<(), AdminError> {
     let _admin = require_admin(env);
     if new_count > storage::MAX_EVIDENCE_COUNT_HARD_MAX {
-        return Err(AdminError::InvalidAddress); // reuse closest available error
+        return Err(AdminError::MaxEvidenceCountOutOfBounds);
     }
     let old_count = storage::get_max_evidence_count(env);
     storage::set_max_evidence_count(env, new_count);

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contractevent, contracttype, Address, Bytes, BytesN, Map, Stri
 // ── Field size limits ─────────────────────────────────────────────────────────
 pub const DETAILS_MAX_LEN: u32 = 256;
 pub const IMAGE_URL_MAX_LEN: u32 = 128;
-/// Max evidence attachments per claim (URL + SHA-256 commitment each).
+/// Default evidence attachment limit when admin config is unset.
 pub const IMAGE_URLS_MAX: u32 = 5;
 pub const REASON_MAX_LEN: u32 = 128;
 pub const SAFETY_SCORE_MAX: u32 = 100;

--- a/contracts/niffyinsure/tests/max_evidence_count.rs
+++ b/contracts/niffyinsure/tests/max_evidence_count.rs
@@ -1,4 +1,4 @@
-//! Tests for #199: admin-configurable max evidence count per claim.
+//! Tests for #323: admin-configurable max evidence count per claim.
 //!
 //! Verifies:
 //! - Default falls back to compile-time IMAGE_URLS_MAX (5)
@@ -79,9 +79,12 @@ fn setter_emits_max_evidence_count_updated_event() {
 #[test]
 fn setter_rejects_value_above_hard_max() {
     let (_env, client, _, _) = setup();
-    assert!(client
-        .try_admin_set_max_evidence_count(&(MAX_EVIDENCE_COUNT_HARD_MAX + 1))
-        .is_err());
+    let result = client.try_admin_set_max_evidence_count(&(MAX_EVIDENCE_COUNT_HARD_MAX + 1));
+    assert!(result.is_err());
+    assert!(
+        soroban_sdk::testutils::arbitrary::std::format!("{:?}", result)
+            .contains("MaxEvidenceCountOutOfBounds")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #323

Moves evidence limit to storage with admin control and safe backward compatibility.

Notes:
- Main already had the storage-backed evidence count path; this PR completes the issue with clearer default-limit docs and a dedicated admin out-of-bounds error.

Checks:
- cargo test -p niffyinsure --test max_evidence_count currently blocked by existing compile errors on main