### PR TITLE
feat: policy expiry event emission

### DIFF
--- a/contracts/niffyinsure/src/events.rs
+++ b/contracts/niffyinsure/src/events.rs
@@ -267,6 +267,36 @@ pub fn emit_claim_paid(
     .publish(env);
 }
 
+// ── Policy lifecycle events ─────────────────────────────────────────────────
+
+/// Emitted at most once per `(holder, policy_id, expiry_ledger)` policy term.
+#[contractevent(topics = ["niffyinsure", "policy_expired"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyExpiredData {
+    #[topic]
+    pub holder: Address,
+    #[topic]
+    pub policy_id: u32,
+    pub expiry_ledger: u32,
+    pub reported_at_ledger: u32,
+}
+
+pub fn emit_policy_expired(
+    env: &Env,
+    holder: &Address,
+    policy_id: u32,
+    expiry_ledger: u32,
+    reported_at_ledger: u32,
+) {
+    PolicyExpiredData {
+        holder: holder.clone(),
+        policy_id,
+        expiry_ledger,
+        reported_at_ledger,
+    }
+    .publish(env);
+}
+
 // ── Admin / config events ─────────────────────────────────────────────────────
 
 /// Emitted by `update_multiplier_table`.

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ledger, premium, storage, token,
+    events, ledger, premium, storage, token,
     types::{AgeBand, CoverageTier, Policy, PolicyType, PremiumQuote, RegionTier, RiskInput},
     validate::{self, Error},
 };
@@ -116,17 +116,6 @@ pub struct PolicyRenewed {
 ///
 /// **`renew_policy` on an expired policy:** the call returns [`crate::types::RenewPolicyOutcome::Lapsed`]
 /// in **`Ok`** (not `Err`) so this event and idempotency storage are not rolled back.
-#[contractevent(topics = ["niffyinsure", "policy_expired"])]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PolicyExpired {
-    #[topic]
-    pub holder: Address,
-    #[topic]
-    pub policy_id: u32,
-    pub expiry_ledger: u32,
-    pub reported_at_ledger: u32,
-}
-
 pub fn generate_premium(
     env: &Env,
     region: RegionTier,
@@ -590,13 +579,7 @@ pub fn publish_policy_expired_if_due(env: &Env, policy: &Policy, now: u32) {
     {
         return;
     }
-    PolicyExpired {
-        holder: policy.holder.clone(),
-        policy_id: policy.policy_id,
-        expiry_ledger: policy.end_ledger,
-        reported_at_ledger: now,
-    }
-    .publish(env);
+    events::emit_policy_expired(env, &policy.holder, policy.policy_id, policy.end_ledger, now);
     storage::set_policy_expired_event_end_ledger(
         env,
         &policy.holder,

--- a/contracts/niffyinsure/src/policy_lifecycle.rs
+++ b/contracts/niffyinsure/src/policy_lifecycle.rs
@@ -165,6 +165,8 @@ pub fn process_expired(env: &Env, holder: Address, policy_id: u32) -> Result<(),
         return Err(PolicyError::OpenClaimsMustFinalize);
     }
 
+    crate::policy::publish_policy_expired_if_due(env, &policy, now);
+
     policy.is_active = false;
     policy.terminated_at_ledger = now;
     policy.termination_reason = TerminationReason::LapsedNonPayment;
@@ -176,24 +178,7 @@ pub fn process_expired(env: &Env, holder: Address, policy_id: u32) -> Result<(),
         storage::voters_remove_holder(env, &holder);
     }
 
-    PolicyExpired {
-        holder: holder.clone(),
-        policy_id,
-        at_ledger: now,
-    }
-    .publish(env);
-
     Ok(())
-}
-
-#[contractevent(topics = ["niffyinsure", "policy_expired"])]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PolicyExpired {
-    #[topic]
-    pub holder: Address,
-    #[topic]
-    pub policy_id: u32,
-    pub at_ledger: u32,
 }
 
 fn terminate_inner(

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -62,6 +62,8 @@ pub enum DataKey {
     /// Admin-configurable max evidence entries per claim (u32).
     /// Falls back to [`IMAGE_URLS_MAX`] when unset.
     MaxEvidenceCount,
+    /// Last `end_ledger` for which a PolicyExpired event was emitted for this policy term.
+    PolicyExpiredEventEndLedger(Address, u32),
     // ── Reserved: future governance token (`governance_token` module) ────────
     /// Runtime toggle: only meaningful when crate is built with `governance-token`.
     /// Unset or `false` in MVP; no token logic runs unless feature + flag align.


### PR DESCRIPTION
Closes #324

Introduces a reliable on-chain expiry signal for notification pipelines.

Notes:
- Centralizes the policy_expired event payload in events.rs.
- Records the expiry end_ledger in storage so each policy term is emitted once.
- Wires the lifecycle lapse path through the same expiry helper.

Checks:
- cargo test -p niffyinsure --test policy_expired currently blocked by existing compile errors on main