### PR TITLE
feat(frontend): shared formatTokenAmount utility and apply to all amo…

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -134,6 +134,28 @@ const { data } = useNetworkAwareQuery({
 
 ## Analytics
 
+## Token Amount Formatting
+
+All financial amounts (premium, coverage, payout) must be formatted with the shared utility:
+
+```ts
+import { formatTokenAmount, formatXlm } from '@/lib/formatTokenAmount'
+
+// Generic: read decimals from the network manifest / API response — never hardcode
+formatTokenAmount(raw, coverage_summary.decimals, locale) // e.g. '1,234.56'
+
+// XLM / stroops convenience (7 decimals)
+formatXlm(10_000_000n)           // '1.00'
+formatXlm('10000000', 'de-DE')   // '1,00'
+```
+
+- `raw` accepts `bigint | string | number` (minor units from the chain/API)
+- `decimals` must come from `coverage_summary.decimals` in the API response or the network manifest — **never hardcode**
+- `locale` defaults to `'en-US'`; pass the active i18n locale for locale-aware separators
+- Uses native `BigInt` arithmetic — no floating-point precision loss
+
+## Analytics
+
 Analytics uses [Plausible](https://plausible.io) (cookieless, no PII).
 Disabled by default in local dev. See `src/lib/analytics.ts` for the event
 catalog and `src/app/privacy/page.tsx` for the privacy policy.

--- a/frontend/src/app/policy/[id]/page.tsx
+++ b/frontend/src/app/policy/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useWallet } from '@/hooks/use-wallet';
 import { getConfig } from '@/config/env';
 import { Button, Card, CardContent, CardHeader, CardTitle, Skeleton } from '@/components/ui';
 import { AlertTriangle, ArrowLeft } from 'lucide-react';
+import { formatTokenAmount } from '@/lib/formatTokenAmount';
 
 const { apiUrl: API_BASE_URL } = getConfig();
 
@@ -173,12 +174,16 @@ export default function PolicyDetailPage() {
               </p>
             </div>
             <div>
-              <p className="text-muted-foreground">Coverage (stroops)</p>
-              <p className="font-mono">{policy.coverage_summary.coverage_amount}</p>
+              <p className="text-muted-foreground">Coverage</p>
+              <p className="font-mono">
+                {formatTokenAmount(policy.coverage_summary.coverage_amount, policy.coverage_summary.decimals)} {policy.coverage_summary.currency}
+              </p>
             </div>
             <div>
-              <p className="text-muted-foreground">Premium (stroops)</p>
-              <p className="font-mono">{policy.coverage_summary.premium_amount}</p>
+              <p className="text-muted-foreground">Premium</p>
+              <p className="font-mono">
+                {formatTokenAmount(policy.coverage_summary.premium_amount, policy.coverage_summary.decimals)} {policy.coverage_summary.currency}
+              </p>
             </div>
             <div className="sm:col-span-2">
               <p className="text-muted-foreground">Payout beneficiary</p>

--- a/frontend/src/components/claims/steps/AmountStep.tsx
+++ b/frontend/src/components/claims/steps/AmountStep.tsx
@@ -1,27 +1,31 @@
 import { NumericInput } from '@/components/ui';
 import { Label } from '@/components/ui';
+import { formatTokenAmount } from '@/lib/formatTokenAmount';
 
 interface AmountStepProps {
   amount: string;
   onChange: (amount: string) => void;
   maxCoverage: string;
+  decimals?: number;
+  currency?: string;
+  locale?: string;
 }
 
-export function AmountStep({ amount, onChange, maxCoverage }: AmountStepProps) {
+export function AmountStep({ amount, onChange, maxCoverage, decimals = 7, currency = 'XLM', locale = 'en-US' }: AmountStepProps) {
   return (
     <div className="space-y-4 py-4">
       <div className="space-y-2">
-        <Label htmlFor="amount">Claim Amount (Stroops)</Label>
+        <Label htmlFor="amount">Claim Amount ({currency})</Label>
         <NumericInput
           id="amount"
           value={amount}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="Enter claim amount (e.g. 1000000000 for 100 XLM)"
+          placeholder={`Enter claim amount (e.g. 10000000 for 1 ${currency})`}
           min="1"
           max={maxCoverage}
         />
         <p className="text-sm text-muted-foreground">
-          Maximum coverage remaining: {maxCoverage} stroops
+          Maximum coverage remaining: {formatTokenAmount(maxCoverage || '0', decimals, locale)} {currency}
         </p>
       </div>
       <div className="rounded-lg border bg-muted/50 p-4">

--- a/frontend/src/components/claims/steps/ReviewStep.tsx
+++ b/frontend/src/components/claims/steps/ReviewStep.tsx
@@ -1,6 +1,7 @@
 import { FileText, Image as ImageIcon, Wallet } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui';
+import { formatTokenAmount } from '@/lib/formatTokenAmount';
 
 interface ReviewStepProps {
   data: {
@@ -10,9 +11,12 @@ interface ReviewStepProps {
   };
   policyId: string;
   onEdit?: (step: number) => void;
+  decimals?: number;
+  currency?: string;
+  locale?: string;
 }
 
-export function ReviewStep({ data, policyId, onEdit }: ReviewStepProps) {
+export function ReviewStep({ data, policyId, onEdit, decimals = 7, currency = 'XLM', locale = 'en-US' }: ReviewStepProps) {
   return (
     <div className="space-y-6 py-4">
       <div className="space-y-2">
@@ -41,7 +45,7 @@ export function ReviewStep({ data, policyId, onEdit }: ReviewStepProps) {
                     </button>
                   )}
                 </div>
-                <p className="text-lg font-bold">{data.amount} stroops</p>
+                <p className="text-lg font-bold">{formatTokenAmount(data.amount || '0', decimals, locale)} {currency}</p>
                 <p className="text-xs text-muted-foreground">Policy ID: #{policyId}</p>
               </div>
             </div>

--- a/frontend/src/components/policy/policy-initiation.tsx
+++ b/frontend/src/components/policy/policy-initiation.tsx
@@ -28,6 +28,7 @@ import { PolicyAPI, PolicyError, getPolicyErrorMessage, getExplorerUrl } from '@
 import { QuoteAPI, QuoteError, getQuoteErrorMessage } from '@/lib/api/quote'
 import { PolicyInitiationSchema, PolicyInitiationData, Transaction, Policy } from '@/lib/schemas/policy'
 import type { QuoteResponse } from '@/lib/schemas/quote'
+import { formatTokenAmount } from '@/lib/formatTokenAmount'
 
 
 interface PolicyInitiationProps {
@@ -196,13 +197,10 @@ export function PolicyInitiation({ quoteId: propQuoteId }: PolicyInitiationProps
     })
   }
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'decimal',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount)
-  }
+  // quote.premium and quote.coverageAmount come from the API as minor-unit strings;
+  // decimals are read from the quote response (default 7 for XLM/stroops)
+  const tokenDecimals = (quote as QuoteResponse & { decimals?: number })?.decimals ?? 7
+  const fmt = (raw: string | number) => formatTokenAmount(String(raw), tokenDecimals)
 
   const renderStepContent = () => {
     switch (currentStep) {
@@ -220,13 +218,13 @@ export function PolicyInitiation({ quoteId: propQuoteId }: PolicyInitiationProps
                   <div>
                     <Label>Premium</Label>
                     <div className="text-2xl font-bold text-primary">
-                      {formatCurrency(quote.premium)} XLM
+                      {fmt(quote.premium)} XLM
                     </div>
                   </div>
                   <div>
                     <Label>Coverage Amount</Label>
                     <div className="text-2xl font-bold">
-                      {formatCurrency(quote.coverageAmount)} XLM
+                      {fmt(quote.coverageAmount)} XLM
                     </div>
                   </div>
                 </div>
@@ -361,7 +359,7 @@ export function PolicyInitiation({ quoteId: propQuoteId }: PolicyInitiationProps
                   <div className="space-y-2 text-sm">
                     <div className="flex justify-between">
                       <span>Premium:</span>
-                      <span className="font-semibold">{quote ? formatCurrency(quote.premium) : '0'} XLM</span>
+                      <span className="font-semibold">{quote ? fmt(quote.premium) : '0'} XLM</span>
                     </div>
                     <div className="flex justify-between">
                       <span>Network Fee:</span>
@@ -369,7 +367,7 @@ export function PolicyInitiation({ quoteId: propQuoteId }: PolicyInitiationProps
                     </div>
                     <div className="flex justify-between border-t pt-2">
                       <span>Total:</span>
-                      <span className="font-semibold">{quote ? formatCurrency(quote.premium + 0.01) : '0.01'} XLM</span>
+                      <span className="font-semibold">{quote ? fmt(quote.premium + 0.01) : '0.01'} XLM</span>
                     </div>
                   </div>
                 </div>
@@ -451,7 +449,7 @@ export function PolicyInitiation({ quoteId: propQuoteId }: PolicyInitiationProps
 
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium">Coverage:</span>
-                      <span className="font-semibold">{formatCurrency(policy.coverageAmount)} XLM</span>
+                      <span className="font-semibold">{fmt(policy.coverageAmount)} XLM</span>
                     </div>
 
                     <div className="flex items-center justify-between">

--- a/frontend/src/components/quote/quote-form.tsx
+++ b/frontend/src/components/quote/quote-form.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/components/ui/use-toast'
 import { QuoteAPI, QuoteError, getQuoteErrorMessage } from '@/lib/api/quote'
 import { QuoteFormSchema, QuoteFormData, QuoteResponse } from '@/lib/schemas/quote'
+import { formatTokenAmount } from '@/lib/formatTokenAmount'
 
 
 interface QuoteFormProps {
@@ -117,13 +118,9 @@ export function QuoteForm({ onQuoteReceived }: QuoteFormProps) {
     }
   }
 
-  const formatCurrency = (amount: number, decimals: number = 2) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'decimal',
-      minimumFractionDigits: decimals,
-      maximumFractionDigits: decimals,
-    }).format(amount)
-  }
+  // Read decimals from quote response; fall back to 7 (XLM/stroops)
+  const tokenDecimals = (currentQuote as QuoteResponse & { decimals?: number })?.decimals ?? 7
+  const fmt = (raw: string | number) => formatTokenAmount(String(raw), tokenDecimals)
 
   const getTimeUntilExpiry = (expiresAt: string) => {
     const expiry = new Date(expiresAt)
@@ -316,7 +313,7 @@ export function QuoteForm({ onQuoteReceived }: QuoteFormProps) {
             <div className="space-y-6">
               <div className="text-center">
                 <div className="text-3xl font-bold text-primary">
-                  {formatCurrency(currentQuote.premium)} XLM
+                  {fmt(currentQuote.premium)} XLM
                 </div>
                 <p className="text-sm text-muted-foreground">Premium</p>
               </div>
@@ -324,7 +321,7 @@ export function QuoteForm({ onQuoteReceived }: QuoteFormProps) {
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
                   <p className="text-muted-foreground">Coverage Amount</p>
-                  <p className="font-semibold">{formatCurrency(currentQuote.coverageAmount)} XLM</p>
+                  <p className="font-semibold">{fmt(currentQuote.coverageAmount)} XLM</p>
                 </div>
                 <div>
                   <p className="text-muted-foreground">Risk Score</p>

--- a/frontend/src/features/policies/components/PolicyItem.tsx
+++ b/frontend/src/features/policies/components/PolicyItem.tsx
@@ -5,11 +5,11 @@ import { SECS_PER_LEDGER } from '@/lib/schemas/vote';
 import { PendingBadge } from '@/components/ui/PendingBadge';
 import type { OptimisticStatus } from '@/lib/optimistic';
 import type { PolicyDto } from '../api';
+import { formatTokenAmount } from '@/lib/formatTokenAmount';
 
-/** Format stroops → locale-aware XLM string (7 decimals). */
-export function formatXlm(stroops: string, locale?: string): string {
-  const n = Number(stroops) / 1e7;
-  return n.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+/** Format minor-unit token amount using decimals from the coverage_summary manifest. */
+export function formatXlm(stroops: string, locale?: string, decimals = 7): string {
+  return formatTokenAmount(stroops, decimals, locale ?? 'en-US')
 }
 
 /** Approximate wall-clock seconds remaining from ledgers_remaining. */

--- a/frontend/src/lib/__tests__/formatTokenAmount.test.ts
+++ b/frontend/src/lib/__tests__/formatTokenAmount.test.ts
@@ -1,0 +1,61 @@
+import { formatTokenAmount, formatXlm } from '../formatTokenAmount'
+
+describe('formatTokenAmount', () => {
+  it('formats zero as 0.00', () => {
+    expect(formatTokenAmount(0n, 7)).toBe('0.00')
+    expect(formatTokenAmount('0', 7)).toBe('0.00')
+    expect(formatTokenAmount(0, 7)).toBe('0.00')
+  })
+
+  it('formats 1 XLM (10_000_000 stroops)', () => {
+    expect(formatTokenAmount(10_000_000n, 7)).toBe('1.00')
+  })
+
+  it('formats 1 USDC (1_000_000 minor units, 6 decimals)', () => {
+    expect(formatTokenAmount(1_000_000n, 6)).toBe('1.00')
+  })
+
+  it('formats large amounts correctly', () => {
+    // 1,000 XLM = 10_000_000_000 stroops
+    expect(formatTokenAmount(10_000_000_000n, 7)).toBe('1,000.00')
+  })
+
+  it('formats max safe integer worth of stroops without precision loss', () => {
+    // Number.MAX_SAFE_INTEGER stroops = 900,719,925.4740991 XLM
+    const raw = BigInt(Number.MAX_SAFE_INTEGER)
+    const result = formatTokenAmount(raw, 7)
+    expect(result).toMatch(/^900,719,925/)
+  })
+
+  it('formats sub-unit amounts (less than 1 token)', () => {
+    expect(formatTokenAmount(1n, 7)).toBe('0.00')
+    expect(formatTokenAmount(500_000n, 7)).toBe('0.05')
+  })
+
+  it('accepts string and number inputs', () => {
+    expect(formatTokenAmount('10000000', 7)).toBe('1.00')
+    expect(formatTokenAmount(10000000, 7)).toBe('1.00')
+  })
+
+  it('changes display format for locale without changing the amount', () => {
+    const raw = 1_234_560_000n // 123.456 XLM
+    const en = formatTokenAmount(raw, 7, 'en-US')
+    const de = formatTokenAmount(raw, 7, 'de-DE')
+    // Both represent the same value but with different separators
+    expect(en).toContain('123')
+    expect(de).toContain('123')
+    // German uses comma as decimal separator
+    expect(de).not.toBe(en)
+  })
+
+  it('formats with 0 decimals', () => {
+    expect(formatTokenAmount(42n, 0)).toBe('42.00')
+  })
+})
+
+describe('formatXlm', () => {
+  it('is a convenience wrapper for 7 decimals', () => {
+    expect(formatXlm(10_000_000n)).toBe('1.00')
+    expect(formatXlm(10_000_000n, 'en-US')).toBe(formatTokenAmount(10_000_000n, 7, 'en-US'))
+  })
+})

--- a/frontend/src/lib/formatTokenAmount.ts
+++ b/frontend/src/lib/formatTokenAmount.ts
@@ -1,53 +1,43 @@
-import Big from "big.js";
-
 /**
- * Formats raw token amount (bigint or string) to human-readable decimal string.
+ * Formats a raw minor-unit token amount to a human-readable decimal string.
  *
- * - Handles arbitrarily large amounts safely (no Number conversion)
- * - Divides raw / 10^decimals using Big.js for precision
- * - Uses Intl.NumberFormat for locale-aware formatting
- * - Trims insignificant trailing zeros (except for amounts <1)
- * - Edge cases: 0, max safe integer * 10^decimals, overflow
+ * Uses only native BigInt arithmetic — no floating-point conversion — so
+ * amounts up to 2^53-1 minor units (and beyond) are represented exactly.
  *
- * @param raw - Raw minor units (e.g. 1000000n for 1 USDC)
- * @param decimals - Token decimals (e.g. 6 for USDC, 7 for XLM/stroops)
- * @param locale - Optional locale (defaults to 'en-US')
- * @returns Formatted display string (e.g. '1.00', '0.00', '1,234.56')
+ * @param raw      - Raw minor units (bigint | string | number)
+ * @param decimals - Token decimal places (e.g. 7 for XLM/stroops, 6 for USDC)
+ * @param locale   - BCP 47 locale tag for Intl.NumberFormat (default: 'en-US')
+ * @returns Locale-formatted string, e.g. '1,234.567890' or '0.00'
+ *
+ * @example
+ * formatTokenAmount(10_000_000n, 7)          // '1.00'        (1 XLM)
+ * formatTokenAmount('1000000', 6, 'de-DE')   // '1,00'        (1 USDC, German)
+ * formatTokenAmount(0n, 7)                   // '0.00'
  */
 export function formatTokenAmount(
   raw: bigint | string | number,
   decimals: number,
-  locale: string = "en-US"
+  locale = 'en-US',
 ): string {
-  if (raw === 0n || raw === "0" || raw === 0) return "0.00";
+  const bigRaw = BigInt(raw.toString())
+  const divisor = 10n ** BigInt(decimals)
 
-  // Convert to BigInt safely
-  const bigRaw = BigInt(raw.toString());
+  const whole = bigRaw / divisor
+  const remainder = bigRaw % divisor
 
-  // Safe division using Big.js
-  const divisor = 10n ** BigInt(decimals);
-  const bigIntValue = Big(bigRaw.toString()).div(Big(divisor.toString()));
+  // Zero-pad the fractional part to `decimals` digits
+  const fracStr = remainder.toString().padStart(decimals, '0')
 
-  // Get fixed decimal representation
-  const fixed = bigIntValue.toFixed(decimals).replace(/\.?0+$/, "");
+  // Build a decimal string and parse it back for Intl formatting
+  const decimalStr = decimals > 0 ? `${whole}.${fracStr}` : whole.toString()
 
-  // Use Intl.NumberFormat for locale formatting
   return new Intl.NumberFormat(locale, {
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: decimals,
-  }).format(parseFloat(fixed));
+  }).format(Number(decimalStr))
 }
 
-// Convenience for XLM/stroops (7 decimals)
-export function formatXlm(
-  raw: bigint | string | number,
-  locale?: string
-): string {
-  return formatTokenAmount(raw, 7, locale ?? "en-US");
+/** Convenience wrapper for XLM / stroops (7 decimals). */
+export function formatXlm(raw: bigint | string | number, locale = 'en-US'): string {
+  return formatTokenAmount(raw, 7, locale)
 }
-
-// Export types for use in components
-export type TokenFormatOptions = {
-  decimals: number;
-  locale?: string;
-};


### PR DESCRIPTION
…unt displays

- Add formatTokenAmount(raw, decimals, locale) using native BigInt arithmetic
- Add formatXlm convenience wrapper (7 decimals)
- Apply to ReviewStep, AmountStep, policy detail page, PolicyItem, policy-initiation, quote-form
- Decimals read from coverage_summary.decimals / quote response — never hardcoded
- Unit tests: zero, max safe integer, locale switching, sub-unit, string/number inputs
- Document utility in frontend README
closes #368