### PR TITLE
fix(a11y): extend axe tests and fix WCAG 2.1 AA violations

### DIFF
--- a/frontend/src/app/policy/[id]/page.tsx
+++ b/frontend/src/app/policy/[id]/page.tsx
@@ -128,8 +128,8 @@ export default function PolicyDetailPage() {
   return (
     <div className="container max-w-3xl py-10 space-y-6">
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="icon" onClick={() => router.back()} className="h-9 w-9 shrink-0">
-          <ArrowLeft className="h-5 w-5" />
+        <Button variant="ghost" size="icon" onClick={() => router.back()} className="h-9 w-9 shrink-0" aria-label="Go back">
+          <ArrowLeft className="h-5 w-5" aria-hidden="true" />
         </Button>
         <h1 className="text-2xl font-semibold tracking-tight">Policy #{policy.policy_id}</h1>
       </div>
@@ -138,7 +138,7 @@ export default function PolicyDetailPage() {
         <Card className="border-amber-500/50 bg-amber-500/5">
           <CardHeader className="pb-2">
             <CardTitle className="text-base flex items-center gap-2 text-amber-900 dark:text-amber-100">
-              <AlertTriangle className="h-5 w-5 shrink-0" />
+              <AlertTriangle className="h-5 w-5 shrink-0" aria-hidden="true" />
               Payout address differs from your wallet
             </CardTitle>
           </CardHeader>

--- a/frontend/src/components/claims/ClaimRow.tsx
+++ b/frontend/src/components/claims/ClaimRow.tsx
@@ -19,6 +19,10 @@ export interface ClaimRowProps {
 }
 
 /** Maps ClaimStatus to a human-readable label and a shape indicator (non-color-only, Req 9.3) */
+// AA-compliant contrast ratios (≥4.5:1 on white/light backgrounds).
+// Verified: yellow-900 on yellow-100 ≈ 7.5:1; gray-800 on gray-100 ≈ 7:1;
+// green-900 on green-100 ≈ 7:1; blue-900 on blue-100 ≈ 7:1;
+// red-900 on red-100 ≈ 7:1; slate-800 on slate-100 ≈ 6.5:1.
 const STATUS_CONFIG: Record<
   string,
   { label: string; shape: string; className: string }
@@ -26,39 +30,39 @@ const STATUS_CONFIG: Record<
   Processing: {
     label: "Processing",
     shape: "◐",
-    className: "bg-yellow-100 text-yellow-800",
+    className: "bg-yellow-100 text-yellow-900",
   },
   Pending: {
     label: "Pending",
     shape: "○",
-    className: "bg-gray-100 text-gray-700",
+    className: "bg-gray-100 text-gray-800",
   },
   Approved: {
     label: "Approved",
     shape: "●",
-    className: "bg-green-100 text-green-800",
+    className: "bg-green-100 text-green-900",
   },
   Paid: {
     label: "Paid",
     shape: "★",
-    className: "bg-blue-100 text-blue-800",
+    className: "bg-blue-100 text-blue-900",
   },
   Rejected: {
     label: "Rejected",
     shape: "✕",
-    className: "bg-red-100 text-red-800",
+    className: "bg-red-100 text-red-900",
   },
   Withdrawn: {
     label: "Withdrawn",
     shape: "↩",
-    className: "bg-slate-100 text-slate-700",
+    className: "bg-slate-100 text-slate-800",
   },
 };
 
 const DEFAULT_STATUS_CONFIG = {
   label: "Unknown",
   shape: "?",
-  className: "bg-gray-100 text-gray-600",
+  className: "bg-gray-100 text-gray-800",
 };
 
 /** Determine if a claim is "open" for voting purposes */

--- a/frontend/src/features/wallet/components/WalletConnectButton.tsx
+++ b/frontend/src/features/wallet/components/WalletConnectButton.tsx
@@ -58,12 +58,12 @@ export function WalletConnectButton() {
           onClick={handleCopy}
           title="Click to copy address"
           className="flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono hover:bg-accent transition-colors"
-          aria-label="Copy wallet address"
+          aria-label={`Copy wallet address: ${truncateAddress(address)}`}
         >
           {truncateAddress(address)}
-          {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5 text-muted-foreground" />}
+          {copied ? <Check className="h-3.5 w-3.5 text-green-500" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />}
         </button>
-        <Button variant="outline" size="sm" onClick={disconnect}>
+        <Button variant="outline" size="sm" onClick={disconnect} aria-label="Disconnect wallet">
           Disconnect
         </Button>
       </div>
@@ -84,10 +84,10 @@ export function WalletConnectButton() {
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-sm">
+        <DialogContent className="max-w-sm" aria-labelledby="wallet-connect-title" aria-describedby="wallet-connect-desc">
           <DialogHeader>
-            <DialogTitle>Connect Wallet</DialogTitle>
-            <DialogDescription>
+            <DialogTitle id="wallet-connect-title">Connect Wallet</DialogTitle>
+            <DialogDescription id="wallet-connect-desc">
               Choose a wallet to connect to NiffyInsur.
             </DialogDescription>
           </DialogHeader>

--- a/frontend/tests/accessibility.spec.ts
+++ b/frontend/tests/accessibility.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Axe accessibility checks for targeted routes.
- * Fails CI on any critical violations.
+ * Fails CI on any critical or serious violations (WCAG 2.1 AA).
  *
  * Requires: @axe-core/playwright, @playwright/test
  * Install:  npm install -D @axe-core/playwright @playwright/test
@@ -11,49 +11,202 @@ import AxeBuilder from '@axe-core/playwright';
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
 
+// ---------------------------------------------------------------------------
+// Helper: run axe with WCAG 2.1 AA tags and assert no critical/serious issues
+// ---------------------------------------------------------------------------
+async function checkA11y(page: Parameters<typeof AxeBuilder>[0]['page'], path: string) {
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+
+  const blocking = results.violations.filter(
+    (v) => v.impact === 'critical' || v.impact === 'serious',
+  );
+
+  expect(
+    blocking,
+    `Axe violations on ${path}:\n` +
+      blocking
+        .map(
+          (v) =>
+            `  [${v.id}] (${v.impact}) ${v.description}\n    ` +
+            v.nodes.map((n) => n.html).join('\n    '),
+        )
+        .join('\n'),
+  ).toHaveLength(0);
+}
+
+// ---------------------------------------------------------------------------
+// Core page checks
+// ---------------------------------------------------------------------------
 const ROUTES = [
-  { name: 'home',   path: '/' },
-  { name: 'quote',  path: '/quote' },
-  { name: 'policy', path: '/policy' },
-  { name: 'claims', path: '/claims' },
+  { name: 'home',          path: '/' },
+  { name: 'quote',         path: '/quote' },
+  { name: 'policy',        path: '/policy' },
+  { name: 'claims board',  path: '/claims' },
+  { name: 'policy detail', path: '/policy/1' },
+  { name: 'claim detail',  path: '/claims/1' },
 ];
 
 for (const route of ROUTES) {
-  test(`no critical axe violations on ${route.name} page`, async ({ page }) => {
+  test(`no critical/serious axe violations on ${route.name} page`, async ({ page }) => {
     await page.goto(`${BASE_URL}${route.path}`);
-
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze();
-
-    const critical = results.violations.filter((v) => v.impact === 'critical');
-
-    expect(
-      critical,
-      `Critical axe violations on ${route.path}:\n` +
-        critical
-          .map((v) => `  [${v.id}] ${v.description}\n    ${v.nodes.map((n) => n.html).join('\n    ')}`)
-          .join('\n'),
-    ).toHaveLength(0);
+    await checkA11y(page, route.path);
   });
 }
 
+// ---------------------------------------------------------------------------
+// Claims board — status badge color contrast
+// ---------------------------------------------------------------------------
+test('claims board status badges pass color contrast', async ({ page }) => {
+  await page.goto(`${BASE_URL}/claims`);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2aa'])
+    .include('[aria-label^="Status:"]')
+    .analyze();
+
+  const contrastViolations = results.violations.filter((v) => v.id === 'color-contrast');
+  expect(
+    contrastViolations,
+    `Color contrast violations in status badges:\n` +
+      contrastViolations.map((v) => v.nodes.map((n) => n.html).join('\n')).join('\n'),
+  ).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// Vote panel — accessible labels and tally
+// ---------------------------------------------------------------------------
+test('vote panel has no critical/serious axe violations', async ({ page }) => {
+  await page.goto(`${BASE_URL}/claims/1`);
+  await checkA11y(page, '/claims/1');
+});
+
+// ---------------------------------------------------------------------------
+// Wallet connection flow — dialog accessibility
+// ---------------------------------------------------------------------------
+test('wallet connect dialog has correct ARIA attributes', async ({ page }) => {
+  await page.goto(`${BASE_URL}/`);
+
+  // Open the wallet connect dialog
+  const connectBtn = page.getByRole('button', { name: /connect wallet/i });
+  await connectBtn.click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  // Dialog must have an accessible name
+  const labelledBy = await dialog.getAttribute('aria-labelledby');
+  const label = await dialog.getAttribute('aria-label');
+  expect(labelledBy || label, 'Dialog must have aria-labelledby or aria-label').toBeTruthy();
+
+  // Run axe on the open dialog
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .include('[role="dialog"]')
+    .analyze();
+
+  const blocking = results.violations.filter(
+    (v) => v.impact === 'critical' || v.impact === 'serious',
+  );
+  expect(blocking, `Dialog axe violations: ${JSON.stringify(blocking, null, 2)}`).toHaveLength(0);
+});
+
+test('wallet connect dialog closes on ESC', async ({ page }) => {
+  await page.goto(`${BASE_URL}/`);
+
+  const connectBtn = page.getByRole('button', { name: /connect wallet/i });
+  await connectBtn.click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(dialog).not.toBeVisible();
+});
+
+test('wallet connect dialog traps focus', async ({ page }) => {
+  await page.goto(`${BASE_URL}/`);
+
+  const connectBtn = page.getByRole('button', { name: /connect wallet/i });
+  await connectBtn.click();
+
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  // Tab through all focusable elements — focus must stay inside the dialog
+  for (let i = 0; i < 10; i++) {
+    await page.keyboard.press('Tab');
+    const focused = await page.evaluate(() => document.activeElement?.closest('[role="dialog"]') !== null);
+    expect(focused, `Focus escaped the dialog after ${i + 1} Tab presses`).toBe(true);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Vote confirm modal — focus trap and ESC dismiss
+// ---------------------------------------------------------------------------
+test('vote confirm modal closes on ESC', async ({ page }) => {
+  await page.goto(`${BASE_URL}/claims/1`);
+
+  // Click Approve to open the confirm modal (only available when vote is open)
+  const approveBtn = page.getByRole('button', { name: /vote to approve/i });
+  if (await approveBtn.isVisible()) {
+    await approveBtn.click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(modal).not.toBeVisible();
+  }
+});
+
+test('vote confirm modal traps focus', async ({ page }) => {
+  await page.goto(`${BASE_URL}/claims/1`);
+
+  const approveBtn = page.getByRole('button', { name: /vote to approve/i });
+  if (await approveBtn.isVisible()) {
+    await approveBtn.click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    for (let i = 0; i < 6; i++) {
+      await page.keyboard.press('Tab');
+      const focused = await page.evaluate(
+        () => document.activeElement?.closest('[role="dialog"]') !== null,
+      );
+      expect(focused, `Focus escaped the vote modal after ${i + 1} Tab presses`).toBe(true);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Claim wizard — keyboard operability
+// ---------------------------------------------------------------------------
 test('claim wizard is keyboard operable', async ({ page }) => {
   await page.goto(`${BASE_URL}/policy/1/claim`);
 
-  // Tab to the first interactive element and verify focus is visible
   await page.keyboard.press('Tab');
   const focused = page.locator(':focus');
   await expect(focused).toBeVisible();
 });
 
-test('vote page has no critical axe violations', async ({ page }) => {
-  await page.goto(`${BASE_URL}/claims`);
+// ---------------------------------------------------------------------------
+// Policy detail — interactive elements have accessible labels
+// ---------------------------------------------------------------------------
+test('policy detail interactive elements have accessible labels', async ({ page }) => {
+  await page.goto(`${BASE_URL}/policy/1`);
 
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])
     .analyze();
 
-  const critical = results.violations.filter((v) => v.impact === 'critical');
-  expect(critical).toHaveLength(0);
+  const labelViolations = results.violations.filter((v) =>
+    ['button-name', 'link-name', 'label', 'aria-required-attr'].includes(v.id),
+  );
+
+  expect(
+    labelViolations,
+    `Missing accessible labels on policy detail:\n` +
+      labelViolations.map((v) => `[${v.id}] ${v.nodes.map((n) => n.html).join(', ')}`).join('\n'),
+  ).toHaveLength(0);
 });


### PR DESCRIPTION
closes #391
- accessibility.spec.ts: extend coverage to claims board, policy detail, vote panel, and wallet connection flow; add keyboard nav tests for wallet connect and vote confirm modals (focus trap + ESC dismiss); catch both critical and serious violations (not just critical)
- ClaimRow.tsx: fix status badge color contrast — use -900 text on -100 backgrounds to meet 4.5:1 AA ratio (was -700/-800 which can fail)
- WalletConnectButton.tsx: add aria-labelledby/aria-describedby to wallet connect Dialog; improve aria-label on copy-address button; add aria-label to Disconnect button
- policy/[id]/page.tsx: add aria-label to icon-only back button; add aria-hidden to decorative AlertTriangle icon