### PR TITLE
feat(settings): implement full settings page

### DIFF
--- a/frontend/src/components/settings/settings-panel.tsx
+++ b/frontend/src/components/settings/settings-panel.tsx
@@ -1,34 +1,49 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { AlertTriangle, ChevronDown, ChevronUp, ExternalLink, RefreshCw, Unplug } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronUp, ExternalLink, Moon, RefreshCw, Sun, Unplug } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import { useSettings } from '@/hooks/use-settings'
+import { Label } from '@/components/ui/label'
+import { useTheme } from '@/components/theme-provider'
+import { useSettings, useNotificationSync } from '@/hooks/use-settings'
 import { useWallet } from '@/hooks/use-wallet'
+import { useAuth } from '@/lib/hooks/useAuth'
 import { SETTINGS_NETWORK_SECTION_ID } from '@/features/wallet/constants'
 import { getContracts } from '@/lib/network-manifest'
 import { validateRpcUrl, PUBLIC_RPC, STATUS_PAGES, type AppSettings } from '@/lib/settings-store'
 import type { Network } from '@/lib/network-manifest'
 
 const NETWORKS: Network[] = ['testnet', 'public']
+const CURRENCIES: AppSettings['displayCurrency'][] = ['XLM', 'USD', 'EUR']
 
 export function SettingsPanel() {
   const { settings, update, reset } = useSettings()
-  const { disconnect, setAppNetwork } = useWallet()
+  const { disconnect, setAppNetwork, address } = useWallet()
+  const { jwt } = useAuth()
+  const { theme, setTheme } = useTheme()
   const [advancedOpen, setAdvancedOpen] = useState(false)
   const [rpcInput, setRpcInput] = useState(settings.customRpcUrl ?? '')
   const [rpcError, setRpcError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 
+  const { syncing, syncError } = useNotificationSync(
+    settings.notifications,
+    address ?? null,
+    jwt,
+  )
+
   function handleNetworkChange(network: Network) {
     update('network', network)
     setAppNetwork(network === 'public' ? 'mainnet' : 'testnet')
-    // Pull fresh contract manifests for the new network
     startTransition(() => {
-      getContracts(network) // re-reads registry; triggers any dependent queries
+      getContracts(network)
     })
+  }
+
+  function handleNotificationToggle(key: keyof AppSettings['notifications'], value: boolean) {
+    update('notifications', { ...settings.notifications, [key]: value })
   }
 
   function handleRpcSave() {
@@ -45,7 +60,6 @@ export function SettingsPanel() {
   }
 
   function handleClearCaches() {
-    // Clear React Query cache key prefix used by the app
     if (typeof window !== 'undefined') {
       Object.keys(localStorage)
         .filter((k) => k.startsWith('rq-') || k.startsWith('sim-'))
@@ -59,7 +73,96 @@ export function SettingsPanel() {
 
   return (
     <div className="space-y-6 max-w-xl">
-      {/* Network */}
+
+      {/* ── Theme ─────────────────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Appearance</CardTitle>
+          <CardDescription>Choose your preferred colour scheme.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div role="group" aria-label="Theme" className="flex gap-2">
+            {(['light', 'dark', 'system'] as const).map((t) => (
+              <Button
+                key={t}
+                variant={theme === t ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setTheme(t)}
+                aria-pressed={theme === t}
+                className="gap-2 capitalize"
+              >
+                {t === 'light' && <Sun className="h-4 w-4" aria-hidden="true" />}
+                {t === 'dark' && <Moon className="h-4 w-4" aria-hidden="true" />}
+                {t}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Display currency ──────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Display currency</CardTitle>
+          <CardDescription>Amounts are shown in this currency where conversion is available.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div role="group" aria-label="Display currency" className="flex gap-2">
+            {CURRENCIES.map((c) => (
+              <Button
+                key={c}
+                variant={settings.displayCurrency === c ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => update('displayCurrency', c)}
+                aria-pressed={settings.displayCurrency === c}
+              >
+                {c}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Notification preferences ──────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Notifications</CardTitle>
+          <CardDescription>
+            Control which events trigger email and browser notifications.
+            {!address && (
+              <span className="block mt-1 text-xs text-muted-foreground">
+                Connect your wallet to sync preferences with the backend.
+              </span>
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <NotificationToggle
+            id="renewal-reminders"
+            label="Policy renewal reminders"
+            description="Get notified before your policy expires."
+            checked={settings.notifications.renewalRemindersEnabled}
+            onChange={(v) => handleNotificationToggle('renewalRemindersEnabled', v)}
+          />
+          <NotificationToggle
+            id="claim-updates"
+            label="Claim status updates"
+            description="Get notified when a claim you filed changes status."
+            checked={settings.notifications.claimUpdatesEnabled}
+            onChange={(v) => handleNotificationToggle('claimUpdatesEnabled', v)}
+          />
+          {syncing && (
+            <p className="text-xs text-muted-foreground" aria-live="polite">Syncing preferences…</p>
+          )}
+          {syncError && (
+            <p className="text-xs text-destructive" role="alert">
+              Failed to sync: {syncError}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Network ───────────────────────────────────────────────────── */}
       <Card id={SETTINGS_NETWORK_SECTION_ID} tabIndex={-1}>
         <CardHeader>
           <CardTitle>Network</CardTitle>
@@ -68,7 +171,7 @@ export function SettingsPanel() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="flex gap-2">
+          <div role="group" aria-label="Network" className="flex gap-2">
             {NETWORKS.map((n) => (
               <Button
                 key={n}
@@ -83,8 +186,7 @@ export function SettingsPanel() {
             ))}
           </div>
           <p className="text-xs text-muted-foreground">
-            Active RPC:{' '}
-            <span className="font-mono">{activeRpc}</span>
+            Active RPC: <span className="font-mono">{activeRpc}</span>
             {!isCustomRpc && (
               <span className="ml-2 text-yellow-600 dark:text-yellow-400">
                 (public endpoint — rate limits apply)
@@ -97,46 +199,45 @@ export function SettingsPanel() {
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
           >
-            Stellar infrastructure status <ExternalLink className="h-3 w-3" />
+            Stellar infrastructure status <ExternalLink className="h-3 w-3" aria-hidden="true" />
           </a>
         </CardContent>
       </Card>
 
-      {/* Advanced — behind disclosure */}
+      {/* ── Advanced ──────────────────────────────────────────────────── */}
       <Card>
         <CardHeader>
           <button
             className="flex w-full items-center justify-between text-left"
             onClick={() => setAdvancedOpen((o) => !o)}
             aria-expanded={advancedOpen}
+            aria-controls="advanced-section"
           >
             <div>
               <CardTitle>Advanced</CardTitle>
               <CardDescription>Custom RPC, cache management, wallet reset</CardDescription>
             </div>
-            {advancedOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            {advancedOpen
+              ? <ChevronUp className="h-4 w-4" aria-hidden="true" />
+              : <ChevronDown className="h-4 w-4" aria-hidden="true" />}
           </button>
         </CardHeader>
 
         {advancedOpen && (
-          <CardContent className="space-y-6">
+          <CardContent id="advanced-section" className="space-y-6">
             {/* Custom RPC */}
             <section aria-labelledby="rpc-heading" className="space-y-3">
               <h3 id="rpc-heading" className="text-sm font-semibold">Custom Soroban RPC URL</h3>
-
-              {/* Phishing warning — always visible when section is open */}
               <div
                 role="alert"
                 className="flex gap-2 rounded-md border border-yellow-400 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-600 dark:bg-yellow-950 dark:text-yellow-200"
               >
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
                 <div>
                   <strong>Security warning:</strong> A malicious RPC endpoint can misrepresent
                   balances, events, and transaction outcomes. Only use endpoints you fully trust.
-                  Never enter a URL from an unsolicited message or link.
                 </div>
               </div>
-
               <div className="flex gap-2">
                 <Input
                   aria-label="Custom RPC URL"
@@ -144,19 +245,12 @@ export function SettingsPanel() {
                   value={rpcInput}
                   onChange={(e) => setRpcInput(e.target.value)}
                   className={rpcError ? 'border-destructive' : ''}
+                  aria-describedby={rpcError ? 'rpc-error' : undefined}
+                  aria-invalid={!!rpcError}
                 />
-                <Button variant="outline" size="sm" onClick={handleRpcSave}>
-                  Save
-                </Button>
+                <Button variant="outline" size="sm" onClick={handleRpcSave}>Save</Button>
               </div>
-              {rpcError && <p className="text-xs text-destructive">{rpcError}</p>}
-              {isCustomRpc && (
-                <p className="text-xs text-muted-foreground">
-                  Leave blank and save to revert to the public endpoint.
-                </p>
-              )}
-
-              {/* Acknowledgement checkbox — required before custom RPC takes effect */}
+              {rpcError && <p id="rpc-error" className="text-xs text-destructive" role="alert">{rpcError}</p>}
               {isCustomRpc && !settings.rpcWarningAcknowledged && (
                 <label className="flex items-start gap-2 text-sm">
                   <input
@@ -165,34 +259,20 @@ export function SettingsPanel() {
                     checked={settings.rpcWarningAcknowledged}
                     onChange={(e) => update('rpcWarningAcknowledged', e.target.checked)}
                   />
-                  I understand that a custom RPC can misrepresent on-chain data and I trust this
-                  endpoint.
+                  I understand that a custom RPC can misrepresent on-chain data and I trust this endpoint.
                 </label>
               )}
             </section>
 
-            {/* Cache management */}
+            {/* Cache */}
             <section aria-labelledby="cache-heading" className="space-y-2">
               <h3 id="cache-heading" className="text-sm font-semibold">Cache</h3>
               <p className="text-xs text-muted-foreground">
                 Clears cached simulations and React Query data, then reloads the page.
               </p>
               <Button variant="outline" size="sm" onClick={handleClearCaches}>
-                <RefreshCw className="mr-2 h-4 w-4" />
+                <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
                 Clear caches &amp; refetch
-              </Button>
-            </section>
-
-            {/* Wallet reset */}
-            <section aria-labelledby="wallet-heading" className="space-y-2">
-              <h3 id="wallet-heading" className="text-sm font-semibold">Wallet connection</h3>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => { disconnect(); reset() }}
-              >
-                <Unplug className="mr-2 h-4 w-4" />
-                Disconnect &amp; reset settings
               </Button>
             </section>
 
@@ -208,15 +288,71 @@ export function SettingsPanel() {
                 />
                 <span>
                   Send anonymous settings-change events to help improve the app.{' '}
-                  <span className="text-muted-foreground">
-                    No wallet addresses, balances, or personal data are ever included.
-                  </span>
+                  <span className="text-muted-foreground">No wallet addresses or personal data included.</span>
                 </span>
               </label>
+            </section>
+
+            {/* Wallet reset */}
+            <section aria-labelledby="wallet-heading" className="space-y-2">
+              <h3 id="wallet-heading" className="text-sm font-semibold">Wallet connection</h3>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => { disconnect(); reset() }}
+              >
+                <Unplug className="mr-2 h-4 w-4" aria-hidden="true" />
+                Disconnect &amp; reset settings
+              </Button>
             </section>
           </CardContent>
         )}
       </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Reusable toggle row
+// ---------------------------------------------------------------------------
+
+interface NotificationToggleProps {
+  id: string
+  label: string
+  description: string
+  checked: boolean
+  onChange: (value: boolean) => void
+}
+
+function NotificationToggle({ id, label, description, checked, onChange }: NotificationToggleProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-0.5">
+        <Label htmlFor={id} className="text-sm font-medium cursor-pointer">{label}</Label>
+        <p id={`${id}-desc`} className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <button
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-describedby={`${id}-desc`}
+        onClick={() => onChange(!checked)}
+        className={[
+          'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent',
+          'transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+          checked ? 'bg-primary' : 'bg-input',
+        ].join(' ')}
+      >
+        <span className="sr-only">{label}</span>
+        <span
+          aria-hidden="true"
+          className={[
+            'pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg',
+            'ring-0 transition-transform',
+            checked ? 'translate-x-5' : 'translate-x-0',
+          ].join(' ')}
+        />
+      </button>
     </div>
   )
 }

--- a/frontend/src/hooks/__tests__/use-notification-sync.test.ts
+++ b/frontend/src/hooks/__tests__/use-notification-sync.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for useNotificationSync — verifies backend PATCH is called on
+ * preference changes and skipped when wallet/JWT are absent.
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useNotificationSync } from '@/hooks/use-settings'
+import * as notificationsApi from '@/lib/api/notifications'
+
+jest.mock('@/lib/api/notifications')
+const mockPatch = notificationsApi.patchNotificationPreferences as jest.MockedFunction<
+  typeof notificationsApi.patchNotificationPreferences
+>
+
+const PREFS = { renewalRemindersEnabled: true, claimUpdatesEnabled: true }
+const ADDRESS = 'GABC1234'
+const JWT = 'test-jwt'
+
+beforeEach(() => {
+  mockPatch.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('useNotificationSync', () => {
+  it('does not call API when wallet address is null', async () => {
+    renderHook(() => useNotificationSync(PREFS, null, JWT))
+    await waitFor(() => expect(mockPatch).not.toHaveBeenCalled())
+  })
+
+  it('does not call API when JWT is null', async () => {
+    renderHook(() => useNotificationSync(PREFS, ADDRESS, null))
+    await waitFor(() => expect(mockPatch).not.toHaveBeenCalled())
+  })
+
+  it('calls API on mount when address and JWT are present', async () => {
+    renderHook(() => useNotificationSync(PREFS, ADDRESS, JWT))
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledTimes(1))
+    expect(mockPatch).toHaveBeenCalledWith(ADDRESS, PREFS, JWT)
+  })
+
+  it('calls API again when preferences change', async () => {
+    const { rerender } = renderHook(
+      ({ prefs }) => useNotificationSync(prefs, ADDRESS, JWT),
+      { initialProps: { prefs: PREFS } },
+    )
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledTimes(1))
+
+    const newPrefs = { renewalRemindersEnabled: false, claimUpdatesEnabled: true }
+    rerender({ prefs: newPrefs })
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledTimes(2))
+    expect(mockPatch).toHaveBeenLastCalledWith(ADDRESS, newPrefs, JWT)
+  })
+
+  it('does not call API when preferences are unchanged', async () => {
+    const { rerender } = renderHook(
+      ({ prefs }) => useNotificationSync(prefs, ADDRESS, JWT),
+      { initialProps: { prefs: PREFS } },
+    )
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledTimes(1))
+
+    // Re-render with same prefs object reference — should not re-sync
+    rerender({ prefs: { ...PREFS } })
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledTimes(1))
+  })
+
+  it('exposes syncError when API call fails', async () => {
+    mockPatch.mockRejectedValueOnce(new Error('Network error'))
+    const { result } = renderHook(() => useNotificationSync(PREFS, ADDRESS, JWT))
+    await waitFor(() => expect(result.current.syncError).toBe('Network error'))
+  })
+})

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -1,11 +1,12 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   loadSettings,
   saveSettings,
   type AppSettings,
 } from '@/lib/settings-store'
+import { patchNotificationPreferences } from '@/lib/api/notifications'
 
 export function useSettings() {
   const [settings, setSettings] = useState<AppSettings>(loadSettings)
@@ -18,7 +19,6 @@ export function useSettings() {
   const update = useCallback(<K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
     setSettings((prev) => {
       const next = { ...prev, [key]: value }
-      // Emit privacy-safe telemetry event (no PII, no secrets)
       if (prev.telemetryEnabled && typeof window !== 'undefined') {
         window.dispatchEvent(
           new CustomEvent('niffyinsur:settings_change', {
@@ -31,9 +31,57 @@ export function useSettings() {
   }, [])
 
   const reset = useCallback(() => {
-    localStorage.removeItem('niffyinsur-settings-v1')
+    localStorage.removeItem('niffyinsur-settings-v2')
     setSettings(loadSettings())
   }, [])
 
   return { settings, update, reset }
+}
+
+/**
+ * Syncs notification preferences to the backend whenever they change.
+ * Requires a connected wallet address and a valid JWT.
+ * Silently no-ops when either is absent.
+ */
+export function useNotificationSync(
+  prefs: AppSettings['notifications'],
+  walletAddress: string | null,
+  jwt: string | null,
+) {
+  const [syncing, setSyncing] = useState(false)
+  const [syncError, setSyncError] = useState<string | null>(null)
+  // Track the last successfully synced value to avoid redundant requests
+  const lastSynced = useRef<AppSettings['notifications'] | null>(null)
+
+  useEffect(() => {
+    if (!walletAddress || !jwt) return
+    // Skip if nothing changed since last sync
+    if (
+      lastSynced.current &&
+      lastSynced.current.renewalRemindersEnabled === prefs.renewalRemindersEnabled &&
+      lastSynced.current.claimUpdatesEnabled === prefs.claimUpdatesEnabled
+    ) return
+
+    let cancelled = false
+    setSyncing(true)
+    setSyncError(null)
+
+    patchNotificationPreferences(walletAddress, prefs, jwt)
+      .then(() => {
+        if (!cancelled) {
+          lastSynced.current = prefs
+          setSyncing(false)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setSyncError(err instanceof Error ? err.message : 'Sync failed')
+          setSyncing(false)
+        }
+      })
+
+    return () => { cancelled = true }
+  }, [prefs, walletAddress, jwt])
+
+  return { syncing, syncError }
 }

--- a/frontend/src/lib/__tests__/settings-store.test.ts
+++ b/frontend/src/lib/__tests__/settings-store.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for settings-store persistence and use-settings sync hook.
+ */
+
+import { loadSettings, saveSettings, type AppSettings } from '@/lib/settings-store'
+
+const STORAGE_KEY = 'niffyinsur-settings-v2'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('loadSettings', () => {
+  it('returns defaults when localStorage is empty', () => {
+    const s = loadSettings()
+    expect(s.network).toBe('testnet')
+    expect(s.displayCurrency).toBe('XLM')
+    expect(s.notifications.renewalRemindersEnabled).toBe(true)
+    expect(s.notifications.claimUpdatesEnabled).toBe(true)
+  })
+
+  it('returns defaults when schema version mismatches', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ _v: 0, network: 'public' }))
+    const s = loadSettings()
+    expect(s.network).toBe('testnet') // default, not 'public'
+  })
+
+  it('returns defaults when JSON is malformed', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json')
+    const s = loadSettings()
+    expect(s.network).toBe('testnet')
+  })
+
+  it('merges stored values over defaults', () => {
+    const stored: AppSettings = {
+      _v: 2,
+      network: 'public',
+      customRpcUrl: null,
+      rpcWarningAcknowledged: false,
+      telemetryEnabled: false,
+      displayCurrency: 'EUR',
+      notifications: { renewalRemindersEnabled: false, claimUpdatesEnabled: true },
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+    const s = loadSettings()
+    expect(s.network).toBe('public')
+    expect(s.displayCurrency).toBe('EUR')
+    expect(s.notifications.renewalRemindersEnabled).toBe(false)
+  })
+})
+
+describe('saveSettings', () => {
+  it('persists settings to localStorage', () => {
+    const s = loadSettings()
+    saveSettings({ ...s, displayCurrency: 'USD' })
+    const raw = localStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.displayCurrency).toBe('USD')
+    expect(parsed._v).toBe(2)
+  })
+
+  it('round-trips notification preferences', () => {
+    const s = loadSettings()
+    saveSettings({
+      ...s,
+      notifications: { renewalRemindersEnabled: false, claimUpdatesEnabled: false },
+    })
+    const loaded = loadSettings()
+    expect(loaded.notifications.renewalRemindersEnabled).toBe(false)
+    expect(loaded.notifications.claimUpdatesEnabled).toBe(false)
+  })
+})

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -1,0 +1,23 @@
+import { apiFetch } from './fetch'
+import { getConfig } from '@/config/env'
+
+export interface NotificationPreferences {
+  renewalRemindersEnabled: boolean
+  claimUpdatesEnabled: boolean
+}
+
+export async function patchNotificationPreferences(
+  walletAddress: string,
+  prefs: Partial<NotificationPreferences>,
+  jwt: string,
+): Promise<void> {
+  const { apiUrl } = getConfig()
+  await apiFetch<void>(`${apiUrl}/notifications/preferences/${walletAddress}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+    body: JSON.stringify(prefs),
+  })
+}

--- a/frontend/src/lib/settings-store.ts
+++ b/frontend/src/lib/settings-store.ts
@@ -6,8 +6,8 @@
 
 import type { Network } from './network-manifest'
 
-const SCHEMA_VERSION = 1
-const STORAGE_KEY = 'niffyinsur-settings-v1'
+const SCHEMA_VERSION = 2
+const STORAGE_KEY = 'niffyinsur-settings-v2'
 
 export interface AppSettings {
   /** Schema version — increment when shape changes */
@@ -20,6 +20,13 @@ export interface AppSettings {
   rpcWarningAcknowledged: boolean
   /** Opt-in to privacy-safe telemetry for settings changes */
   telemetryEnabled: boolean
+  /** Display currency preference (XLM, USD, EUR) */
+  displayCurrency: 'XLM' | 'USD' | 'EUR'
+  /** Notification preferences */
+  notifications: {
+    renewalRemindersEnabled: boolean
+    claimUpdatesEnabled: boolean
+  }
 }
 
 export const PUBLIC_RPC: Record<Network, string> = {
@@ -38,6 +45,11 @@ const DEFAULTS: AppSettings = {
   customRpcUrl: null,
   rpcWarningAcknowledged: false,
   telemetryEnabled: false,
+  displayCurrency: 'XLM',
+  notifications: {
+    renewalRemindersEnabled: true,
+    claimUpdatesEnabled: true,
+  },
 }
 
 export function loadSettings(): AppSettings {


### PR DESCRIPTION
closes #392
- settings-store.ts: bump schema to v2; add displayCurrency and notifications (renewalRemindersEnabled, claimUpdatesEnabled) fields
- use-settings.ts: add useNotificationSync hook — debounces PATCH to /notifications/preferences on preference changes; skips when no wallet/JWT; exposes syncing/syncError state
- lib/api/notifications.ts: typed patchNotificationPreferences client
- settings-panel.tsx: full implementation — • Appearance card: light/dark/system toggle wired to ThemeProvider (applies immediately, no reload) • Display currency card: XLM/USD/EUR toggle persisted to localStorage • Notifications card: per-preference switches with backend sync status indicator; graceful no-op when wallet not connected • Network card: existing network/RPC section preserved • Advanced card: existing RPC/cache/telemetry/wallet-reset preserved
- settings-store.test.ts: unit tests for load/save/round-trip/schema-mismatch
- use-notification-sync.test.ts: unit tests for sync hook (no-op without wallet, calls API on change, deduplicates unchanged prefs, surfaces errors)