### PR TITLE
feat(docs): sync MDX content and add docs link check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Check docs internal links
+        run: node scripts/check-docs-links.js
+
       - name: Check generated OpenAPI types are up to date
         run: |
           npm run generate-client

--- a/frontend/src/content/claims.mdx
+++ b/frontend/src/content/claims.mdx
@@ -35,6 +35,31 @@ T+72h  Payout transaction submitted (Approve) OR claim marked Rejected
 
 The claimant may call `withdraw_claim` while the claim is `Processing` and **no approve or reject votes have been cast**. After the first ballot, withdrawal is blocked so governance rounds cannot be manipulated. Withdrawn claims stay readable on-chain and in the indexer; surface them distinctly from `Rejected` on the claims board.
 
+## Evidence Hash Commitment
+
+Every evidence item submitted with a claim must include a **SHA-256 content hash** alongside the URL. This is enforced on-chain by the `niffyinsure` contract.
+
+```
+ClaimEvidenceEntry {
+  url:  String          // IPFS gateway URL or other content-addressed URI
+  hash: BytesN<32>      // SHA-256 digest of the file content (32 bytes)
+}
+```
+
+**Rules enforced at `file_claim`:**
+
+- The all-zero digest (`0x000…000`) is **rejected** — it indicates a missing or uncalculated hash.
+- Each `hash` must be the SHA-256 of the bytes at the corresponding `url`.
+- The contract stores `evidence_hashes` (a `Vec<BytesN<32>>`) in the on-chain `Claim` record in the same order as submitted.
+
+**Why this matters:**
+
+The hash is a cryptographic commitment. Off-chain services (the NestJS IPFS proxy and verification workers) download the content and compare its digest against the stored hash. A mismatch means the file was altered after filing — the claim can be flagged for review.
+
+**Frontend responsibility:**
+
+The frontend computes the SHA-256 of each file before upload and passes `contentSha256Hex` to the backend. The backend converts the hex string to `BytesN<32>` before building the Soroban transaction. Never submit a zero hash or skip the hash field.
+
 ## Rate Limiting
 
 The backend enforces per-wallet claim submission rate limits to prevent spam. On-chain, the contract spaces **successful** `file_claim` calls per holder using `LastClaimLedger` and `RATE_LIMIT_WINDOW_LEDGERS`. **Withdrawal does not count against that limit going forward:** the contract restores the holder’s previous rate-limit anchor (or clears it if this was their first filing), so a withdrawn mistaken claim does not force an extra full waiting period before refiling. The per-policy **one open claim** rule still applies while a claim is open; withdrawal clears the open slot like any other terminal resolution.

--- a/frontend/src/content/voting.mdx
+++ b/frontend/src/content/voting.mdx
@@ -63,6 +63,12 @@ The contract keeps **`voting_duration_ledgers`** in instance storage (admin-set,
 | Admin bypass | Admin may bypass the open-claim guard only when `force_admin_bypass = true` |
 | Quorum | `quorum_bps` in instance storage; per-claim snapshot at filing; `admin_set_quorum_bps` + `QuorumUpdated` event |
 
+## Voter snapshot TTL
+
+At `file_claim`, the contract takes a snapshot of all eligible voters and stores it as `ClaimVoters(claim_id)` in **persistent** storage. This snapshot is used for all eligibility checks during the voting window.
+
+The snapshot has a TTL. If a claim remains open for an unusually long time (e.g. due to a pause), the snapshot may expire. Anyone can call `extend_claim_voters_snapshot_ttl(claim_id)` (permissionless) to refresh the TTL and keep the snapshot alive. The UI surfaces a warning when the snapshot is close to expiry.
+
 ## Verifying a Vote On-Chain
 
 1. Find the `claim_id` from the Claims board.


### PR DESCRIPTION
closes #394
- claims.mdx: add Evidence Hash Commitment section documenting the on-chain ClaimEvidenceEntry struct, SHA-256 requirement, zero-hash rejection, and frontend/backend responsibilities — sourced directly from contracts/niffyinsure/src/types.rs and claim.rs
- voting.mdx: add Voter Snapshot TTL section documenting the ClaimVoters persistent storage snapshot, TTL expiry risk, and the permissionless extend_claim_voters_snapshot_ttl() escape hatch
- ci.yml: add 'Check docs internal links' step to the frontend job running node scripts/check-docs-links.js — exits 1 on any broken /docs/* internal link, verified passing against current content