### PR TITLE
feat: implement ClaimVotePanel with wallet-resolved eligibility and v…

### DIFF
--- a/frontend/src/app/claims/[claimId]/page.tsx
+++ b/frontend/src/app/claims/[claimId]/page.tsx
@@ -71,11 +71,6 @@ export default async function ClaimPage({ params }: ClaimPageProps) {
     notFound()
   }
 
-  // Wallet address and currentLedger are resolved client-side to avoid
-  // exposing wallet-specific data in server-rendered HTML (issue #228 req).
-  const walletAddress: string | null = null
-  const currentLedger = 0
-
   return (
     <main
       className="mx-auto max-w-2xl px-4 py-10 pb-[calc(2.5rem+env(safe-area-inset-bottom,0px))]"
@@ -87,11 +82,7 @@ export default async function ClaimPage({ params }: ClaimPageProps) {
       <h1 className="mb-6 text-xl font-bold">
         Claim vote — <span className="font-mono text-base">{claimId}</span>
       </h1>
-      <ClaimVotePanel
-        claimId={claimId}
-        walletAddress={walletAddress}
-        currentLedger={currentLedger}
-      />
+      <ClaimVotePanel claimId={claimId} />
     </main>
   )
 }

--- a/frontend/src/components/claims/claim-vote-panel.tsx
+++ b/frontend/src/components/claims/claim-vote-panel.tsx
@@ -7,6 +7,8 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/components/ui/use-toast'
+import { useWallet } from '@/features/wallet'
+import { useLatestLedger } from '@/hooks/use-latest-ledger'
 import {
   fetchClaim,
   fetchEligibility,
@@ -31,24 +33,16 @@ import { VoteTally } from './vote-tally'
 
 interface ClaimVotePanelProps {
   claimId: string
-  /** Connected wallet address — null when no wallet connected */
-  walletAddress: string | null
-  /** Current Stellar ledger sequence for deadline calculation */
-  currentLedger: number
-  /** Called to request wallet signature for the given XDR */
-  requestSignature?: (xdr: string) => Promise<string>
 }
 
 type SubmitState = 'idle' | 'simulating' | 'confirming' | 'signing' | 'submitting' | 'done'
 
 const POLL_INTERVAL_MS = 8_000
 
-export function ClaimVotePanel({
-  claimId,
-  walletAddress,
-  currentLedger,
-  requestSignature,
-}: ClaimVotePanelProps) {
+export function ClaimVotePanel({ claimId }: ClaimVotePanelProps) {
+  const { address: walletAddress, signTransaction } = useWallet()
+  const latestLedger = useLatestLedger()
+  const currentLedger = latestLedger ?? 0
   const { toast } = useToast()
 
   const [claim, setClaim] = useState<Claim | null>(null)
@@ -128,9 +122,7 @@ export function ClaimVotePanel({
     try {
       // In production, requestSignature opens the wallet popup with the XDR.
       // Here we pass a placeholder XDR; the backend builds the real transaction.
-      const signedXdr = requestSignature
-        ? await requestSignature(`vote:${claimId}:${pendingVote}`)
-        : `mock-signed-xdr-${Date.now()}`
+      const signedXdr = await signTransaction(`vote:${claimId}:${pendingVote}`)
 
       setSubmitState('submitting')
       const result = await submitVote(claimId, walletAddress, pendingVote, signedXdr)


### PR DESCRIPTION
…ote flow

- Resolve walletAddress client-side via useWallet hook (not server props)
- Resolve currentLedger client-side via useLatestLedger hook
- Use wallet signTransaction for XDR signing
- Tally, eligibility check, VoteConfirmModal, voted state all wired up
- Ineligible/disconnected wallets see read-only tally without vote buttons
- Voted state persists via eligibility.priorVote after page reload
closes #387 