### PR TITLE
test(e2e): add policy initiation, claim filing, and vote submission s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,22 +172,34 @@ jobs:
     defaults:
       run:
         working-directory: frontend
+    # All E2E specs mock the backend via page.route() — no real Stellar network
+    # or backend process is required. Set NEXT_PUBLIC_API_URL to a placeholder
+    # so the app's getConfig() resolves without error; requests are intercepted
+    # by Playwright before they reach the network.
+    env:
+      NEXT_PUBLIC_API_URL: http://localhost:3001
+      NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+      NEXT_PUBLIC_EXPLORER_BASE: https://stellar.expert/explorer/testnet/tx
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright tests
+      - name: Build app
+        run: npm run build
+
+      - name: Run Playwright E2E tests
         run: npx playwright test --reporter=html
-        continue-on-error: true
 
       - name: Upload Playwright artifacts on failure
         if: failure()
@@ -195,8 +207,8 @@ jobs:
         with:
           name: playwright-failure-${{ github.run_id }}
           path: |
-            test-results/
-            playwright-report/
+            frontend/test-results/
+            frontend/playwright-report/
           retention-days: 14
 
   # ── Accessibility (axe) ───────────────────────────────────────────────────

--- a/frontend/e2e/claim-filing.spec.ts
+++ b/frontend/e2e/claim-filing.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * e2e: Claim filing wizard
+ *
+ * Covers all 4 wizard steps:
+ *   0. Amount → 1. Narrative → 2. Evidence → 3. Review → submission
+ *
+ * All backend and wallet calls are mocked — no real Stellar network access required.
+ */
+
+import { test, expect } from '@playwright/test'
+import { injectWalletMock } from './fixtures/wallet'
+import { mockClaimFilingApi } from './fixtures/api'
+
+const POLICY_ID = 'mock-policy-001'
+
+test.describe('Claim filing wizard', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectWalletMock(page)
+    await mockClaimFilingApi(page)
+  })
+
+  test('renders the claim wizard with Amount step active', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('heading', { name: /file insurance claim/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByText(/amount/i)).toBeVisible()
+  })
+
+  test('Next button is disabled until amount is entered', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeDisabled({ timeout: 10_000 })
+
+    await page.getByRole('spinbutton').fill('500')
+    await expect(page.getByRole('button', { name: /next/i })).toBeEnabled()
+  })
+
+  test('advances through Amount → Narrative steps', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('spinbutton').fill('500')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    await expect(page.getByText(/narrative|describe/i)).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('advances through all steps to Review', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    // Step 0 — Amount
+    await expect(page.getByRole('button', { name: /next/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('spinbutton').fill('500')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Step 1 — Narrative
+    await expect(page.getByRole('textbox')).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('textbox').fill('Smart contract exploit caused fund loss on the DeFi protocol.')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Step 2 — Evidence (optional, skip)
+    await expect(page.getByText(/evidence|upload/i)).toBeVisible({ timeout: 5_000 })
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Step 3 — Review
+    await expect(page.getByText(/review claim details/i)).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Review step shows entered amount and narrative', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('spinbutton').fill('500')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    await page.getByRole('textbox').fill('DeFi exploit narrative text')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Skip evidence
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Review step — verify data is shown
+    await expect(page.getByText(/review claim details/i)).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/DeFi exploit narrative text/i)).toBeVisible()
+    await expect(page.getByText(new RegExp(POLICY_ID))).toBeVisible()
+  })
+
+  test('Edit buttons on Review step navigate back to correct step', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('spinbutton').fill('500')
+    await page.getByRole('button', { name: /next/i }).click()
+    await page.getByRole('textbox').fill('Some narrative')
+    await page.getByRole('button', { name: /next/i }).click()
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // On Review step — click Edit on Narrative card
+    const editButtons = page.getByRole('button', { name: /edit/i })
+    await editButtons.nth(1).click()
+
+    // Should be back on Narrative step
+    await expect(page.getByRole('textbox')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('submits claim and shows success screen', async ({ page }) => {
+    await page.goto(`/policy/${POLICY_ID}/claim`)
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('spinbutton').fill('500')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    await page.getByRole('textbox').fill('Smart contract exploit caused fund loss.')
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Skip evidence
+    await page.getByRole('button', { name: /next/i }).click()
+
+    // Sign & Submit
+    await page.getByRole('button', { name: /sign & submit/i }).click()
+
+    await expect(page.getByText(/claim filed successfully/i)).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -96,6 +96,155 @@ export async function mockPolicyApi(page: Page): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Policy initiation API mocks (build-transaction + submit)
+// ---------------------------------------------------------------------------
+
+export async function mockPolicyInitiateApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/api/policies/initiate`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        transactionXdr: 'mock-unsigned-xdr',
+        estimatedFee: '0.01',
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      }),
+    })
+  })
+
+  await page.route(`${API_BASE}/api/policies/submit`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        policyId: 'mock-policy-001',
+        transactionHash: 'abc123def456',
+      }),
+    })
+  })
+
+  await page.route(`${API_BASE}/api/policies/mock-policy-001`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        policyId: 'mock-policy-001',
+        status: 'ACTIVE',
+        coverageAmount: 1000,
+        premium: 12.5,
+        expiresAt: new Date(Date.now() + 30 * 24 * 3_600_000).toISOString(),
+        transactionHash: 'abc123def456',
+      }),
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Claim filing API mocks (build-transaction + submit)
+// ---------------------------------------------------------------------------
+
+export async function mockClaimFilingApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/api/policies/mock-policy-001`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        policyId: 'mock-policy-001',
+        status: 'ACTIVE',
+        coverageAmount: '10000000000',
+        premium: '125000000',
+        expiresAt: new Date(Date.now() + 30 * 24 * 3_600_000).toISOString(),
+      }),
+    })
+  })
+
+  await page.route(`${API_BASE}/api/claims/build-transaction`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        unsignedXdr: 'mock-claim-unsigned-xdr',
+        minResourceFee: '100',
+        baseFee: '100',
+        totalEstimatedFee: '200',
+        totalEstimatedFeeXlm: '0.00002',
+        authRequirements: [],
+      }),
+    })
+  })
+
+  await page.route(`${API_BASE}/api/claims/submit`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        claimId: 42,
+        transactionHash: 'claim-tx-hash-abc123',
+      }),
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Vote API mocks (claim detail + eligibility + simulate + submit)
+// ---------------------------------------------------------------------------
+
+export async function mockVoteApi(page: Page, claimId = 'claim-vote-001'): Promise<void> {
+  await page.route(`${API_BASE}/api/claims/${claimId}`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        claim_id: claimId,
+        policy_id: 'policy-001',
+        claimant: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+        amount: '500000000',
+        details: 'Smart contract exploit caused fund loss.',
+        evidence: [],
+        status: 'Processing',
+        voting_deadline_ledger: 9_999_999,
+        approve_votes: 3,
+        reject_votes: 1,
+        filed_at: Date.now() - 86_400_000,
+        total_voters: 10,
+        quorum_bps: 5000,
+      }),
+    })
+  })
+
+  await page.route(
+    `${API_BASE}/api/claims/${claimId}/eligibility*`,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ eligible: true, reason: null, priorVote: null }),
+      })
+    },
+  )
+
+  await page.route(
+    `${API_BASE}/api/claims/${claimId}/vote/simulate`,
+    async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    },
+  )
+
+  await page.route(`${API_BASE}/api/claims/${claimId}/vote`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        transactionHash: 'vote-tx-hash-xyz789',
+        status: 'Processing',
+        approve_votes: 4,
+        reject_votes: 1,
+      }),
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Claims API mocks
 // ---------------------------------------------------------------------------
 

--- a/frontend/e2e/policy-initiation.spec.ts
+++ b/frontend/e2e/policy-initiation.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * e2e: Policy initiation flow
+ *
+ * Covers the full 4-step policy creation wizard:
+ *   0. Verify Quote → 1. Connect Wallet → 2. Sign Transaction → 3. Confirmation
+ *
+ * All backend and wallet calls are mocked — no real Stellar network access required.
+ */
+
+import { test, expect } from '@playwright/test'
+import { injectWalletMock, MOCK_WALLET_ADDRESS } from './fixtures/wallet'
+import { mockQuoteApi, mockPolicyInitiateApi } from './fixtures/api'
+
+test.describe('Policy initiation flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectWalletMock(page)
+    await mockQuoteApi(page)
+    await mockPolicyInitiateApi(page)
+  })
+
+  test('renders quote verification step on load', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    await expect(
+      page.getByRole('heading', { name: /create insurance policy/i }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    await expect(page.getByText(/verify quote/i)).toBeVisible()
+  })
+
+  test('displays quote details after loading', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    // Premium and coverage from mock fixture
+    await expect(page.getByText(/12\.5|premium/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/coverage amount/i)).toBeVisible()
+  })
+
+  test('advances to wallet connection step', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    // Wait for quote to load then continue
+    await expect(page.getByRole('button', { name: /continue to wallet/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /continue to wallet/i }).click()
+
+    await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible()
+  })
+
+  test('connects wallet and advances to sign transaction step', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    await expect(page.getByRole('button', { name: /continue to wallet/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /continue to wallet/i }).click()
+    await page.getByRole('button', { name: /connect wallet/i }).click()
+
+    // Wallet connected — address should appear
+    await expect(page.getByText(MOCK_WALLET_ADDRESS.slice(0, 8))).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/sign transaction/i)).toBeVisible()
+  })
+
+  test('submits policy and shows confirmation with policy ID', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    // Step 0 → 1
+    await expect(page.getByRole('button', { name: /continue to wallet/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /continue to wallet/i }).click()
+
+    // Step 1 → 2
+    await page.getByRole('button', { name: /connect wallet/i }).click()
+    await expect(page.getByText(/sign transaction/i)).toBeVisible({ timeout: 10_000 })
+
+    // Step 2: accept terms and submit
+    await page.getByLabel(/accept the terms/i).check()
+    await page.getByRole('button', { name: /initiate policy/i }).click()
+
+    // Step 3: confirmation
+    await expect(page.getByText(/policy created successfully/i)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/mock-policy-001/i)).toBeVisible()
+  })
+
+  test('wallet address is not exposed in page source before connection', async ({ page }) => {
+    await page.goto('/policy?quoteId=mock-quote-001')
+
+    const content = await page.textContent('body')
+    expect(content).not.toContain('undefined')
+    // Full address must not appear before wallet is connected
+    expect(content).not.toContain(MOCK_WALLET_ADDRESS)
+  })
+})

--- a/frontend/e2e/vote-submission.spec.ts
+++ b/frontend/e2e/vote-submission.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * e2e: Vote submission flow
+ *
+ * Covers the ClaimVotePanel on /claims/[claimId]:
+ *   - Read-only tally visible to all visitors
+ *   - Vote buttons shown only to eligible connected wallets
+ *   - VoteConfirmModal appears before wallet signing
+ *   - Voted state shown after successful submission
+ *   - Ineligible wallet sees tally without vote buttons
+ *
+ * All backend and wallet calls are mocked — no real Stellar network access required.
+ */
+
+import { test, expect } from '@playwright/test'
+import { injectWalletMock, injectNoWalletMock, MOCK_WALLET_ADDRESS } from './fixtures/wallet'
+import { mockVoteApi } from './fixtures/api'
+
+const CLAIM_ID = 'claim-vote-001'
+const CLAIM_URL = `/claims/${CLAIM_ID}`
+
+test.describe('Vote submission — eligible wallet', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectWalletMock(page)
+    await mockVoteApi(page, CLAIM_ID)
+  })
+
+  test('renders vote tally for all visitors', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByText(/current tally/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/approve/i)).toBeVisible()
+    await expect(page.getByText(/reject/i)).toBeVisible()
+  })
+
+  test('shows Approve and Reject buttons for eligible connected wallet', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByRole('button', { name: /vote to reject/i })).toBeVisible()
+  })
+
+  test('clicking Approve opens confirmation modal', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /vote to approve/i }).click()
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/confirm approval vote/i)).toBeVisible()
+  })
+
+  test('confirmation modal shows current tally snapshot', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /vote to approve/i }).click()
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    // Tally snapshot from mock: approve=3, reject=1
+    await expect(page.getByText(/current tally/i)).toBeVisible()
+    await expect(page.getByText(/approve.*3|3.*approve/i)).toBeVisible()
+  })
+
+  test('cancelling modal dismisses it without submitting', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /vote to approve/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByRole('button', { name: /cancel/i }).click()
+
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3_000 })
+    // Vote buttons still present — no vote was cast
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible()
+  })
+
+  test('confirming vote submits and shows voted state', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /vote to approve/i }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByRole('button', { name: /sign & approve/i }).click()
+
+    // Voted state: "You voted Approve on this claim"
+    await expect(page.getByText(/you voted/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText(/approve/i)).toBeVisible()
+  })
+
+  test('vote confirmed on-chain banner appears after submission', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /vote to approve/i }).click()
+    await page.getByRole('button', { name: /sign & approve/i }).click()
+
+    await expect(page.getByText(/vote confirmed on-chain/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('link', { name: /view on explorer/i })).toBeVisible()
+  })
+})
+
+test.describe('Vote submission — no wallet connected', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectNoWalletMock(page)
+    await mockVoteApi(page, CLAIM_ID)
+  })
+
+  test('tally is visible without wallet', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByText(/current tally/i)).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('vote buttons are disabled without wallet', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeDisabled()
+    await expect(page.getByRole('button', { name: /vote to reject/i })).toBeDisabled()
+  })
+
+  test('ineligibility message is shown', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByText(/connect your wallet to vote/i)).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+test.describe('Vote submission — already voted', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectWalletMock(page)
+
+    // Override eligibility to return priorVote
+    const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+    await mockVoteApi(page, CLAIM_ID)
+    await page.route(
+      `${API_BASE}/api/claims/${CLAIM_ID}/eligibility*`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ eligible: true, reason: null, priorVote: 'Approve' }),
+        })
+      },
+    )
+  })
+
+  test('shows prior vote badge and disables vote buttons', async ({ page }) => {
+    await page.goto(CLAIM_URL)
+
+    await expect(page.getByText(/you voted/i)).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('button', { name: /vote to approve/i })).toBeDisabled()
+    await expect(page.getByRole('button', { name: /vote to reject/i })).toBeDisabled()
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: './e2e',
   timeout: 30_000,
   use: {
     baseURL: process.env.BASE_URL ?? 'http://localhost:3000',


### PR DESCRIPTION
…pecs

- Add mockPolicyInitiateApi, mockClaimFilingApi, mockVoteApi to fixtures/api.ts
- policy-initiation.spec.ts: full 4-step wizard (quote → wallet → sign → confirm)
- claim-filing.spec.ts: all 4 wizard steps including review, edit navigation, submission
- vote-submission.spec.ts: tally display, confirm modal, voted state, ineligible wallet
- Fix playwright.config.ts testDir: './tests' → './e2e'
- Harden CI e2e-tests job: remove continue-on-error, add env vars, build before test
closes #395 