### PR TITLE
feat(docs): event dictionary sync & CI guard (closes #404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,35 @@ jobs:
             exit 1
           fi
 
+  # ── Event dictionary sync guard ──────────────────────────────────────────
+  check-event-dictionary:
+    name: Event dictionary sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check every event in events.rs has a dictionary entry
+        run: |
+          # Extract event names from #[contractevent] macro topic strings in events.rs
+          EVENT_RS=contracts/niffyinsure/src/events.rs
+          DICT=EVENT_DICTIONARY.md
+
+          # Collect the second topic (event name) from each #[contractevent(...)] line
+          missing=0
+          while IFS= read -r name; do
+            if ! grep -qF "\"${name}\"" "$DICT" && ! grep -qF "\`${name}\`" "$DICT"; then
+              echo "::error file=${EVENT_RS}::Event '${name}' is defined in events.rs but has no entry in EVENT_DICTIONARY.md"
+              missing=$((missing + 1))
+            fi
+          done < <(grep -oP '(?<=#\[contractevent\(topics = \[")[^"]+(?=",\s*")[^"]*(?="\])' "$EVENT_RS" | \
+                   grep -oP '(?<=", ")[^"]+')
+
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing event(s) missing from EVENT_DICTIONARY.md. Add entries and re-push."
+            exit 1
+          fi
+          echo "✅ All events in events.rs are documented in EVENT_DICTIONARY.md"
+
   # ── Soroban ABI golden-vector drift guard ────────────────────────────────
   golden-vectors:
     name: Soroban ABI golden vectors

--- a/EVENT_DICTIONARY.md
+++ b/EVENT_DICTIONARY.md
@@ -1,8 +1,12 @@
 # niffyInsure — Event Dictionary
 
 > **Schema version: 1**  
+> `SCHEMA_VERSION` in `events.rs` and `events.schema.ts` must stay in sync.  
 > Breaking changes (field removed / type changed) → semver-major contract release + `SCHEMA_VERSION` bump.  
 > Adding new optional fields is backward-compatible; no bump required.
+>
+> **Ownership:** the contract author is responsible for updating this file on every contract release.  
+> CI enforces that every event name in `events.rs` has a corresponding entry here (see `.github/workflows/ci.yml` — `check-event-dictionary` job).
 
 ## Units
 
@@ -41,7 +45,7 @@ The indexer discriminates events by `${topic[0]}:${topic[1]}`.
   "version": 1,
   "policy_id": 3,
   "amount": "5000000",
-  "image_hash": 2864434397,
+  "evidence_hashes": ["<32-byte hex>"],
   "filed_at": 1234567
 }
 ```
@@ -50,7 +54,7 @@ The indexer discriminates events by `${topic[0]}:${topic[1]}`.
 |-------|------|-------------|
 | `policy_id` | u32 | Per-holder policy identifier |
 | `amount` | string (stroops) | Requested payout |
-| `image_hash` | u64 | FNV-1a hash of IPFS CIDs |
+| `evidence_hashes` | string[] | SHA-256 digests (32 bytes each); on-chain commitment only |
 | `filed_at` | u32 (ledger) | Ledger when claim was filed |
 
 ---
@@ -120,6 +124,30 @@ Emitted when voting reaches majority **or** the vote window expires.
 
 ---
 
+### `claim_withdrawn` — claim withdrawn by claimant
+
+Emitted when the claimant withdraws their own claim before any votes are cast.
+Indexers must surface `Withdrawn` status distinctly on the claims board.
+
+**Topics:** `("niffyinsure", "claim_withdrawn", claim_id: u64)`
+
+```json
+{
+  "version": 1,
+  "policy_id": 3,
+  "claimant": "G...",
+  "at_ledger": 1234600
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy_id` | u32 | Per-holder policy identifier |
+| `claimant` | string (G…) | Address of the withdrawing claimant |
+| `at_ledger` | u32 (ledger) | Ledger of withdrawal |
+
+---
+
 ## Policy lifecycle events  (`namespace = "niffyinsure"`)
 
 ### `PolicyInitiated` — policy bound
@@ -166,7 +194,7 @@ Emitted when voting reaches majority **or** the vote window expires.
 
 ---
 
-### `PolicyTerminated` — policy terminated
+### `policy_terminated` — policy terminated
 
 **Topics:** `("niffyinsure", "policy_terminated", holder: Address, policy_id: u32)`
 
@@ -191,6 +219,52 @@ Emitted when voting reaches majority **or** the vote window expires.
 
 ---
 
+### `policy_expired` — policy expiry detected
+
+Emitted at most once per `(holder, policy_id, expiry_ledger)` term, either by the
+`process_expired` keeper entrypoint or by `renew_policy` when called on an already-expired policy.
+May be emitted with a delay relative to the actual expiry ledger if no keeper call occurred at that ledger.
+
+**Topics:** `("niffyinsure", "policy_expired", holder: Address, policy_id: u32)`
+
+```json
+{
+  "expiry_ledger": 2285767,
+  "reported_at_ledger": 2285800
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expiry_ledger` | u32 (ledger) | Ledger at which the policy actually expired |
+| `reported_at_ledger` | u32 (ledger) | Ledger when the event was emitted (may differ from expiry_ledger) |
+
+> **Deduplication:** the backend notification service must deduplicate on `policy_id` to handle delayed keeper calls.
+
+---
+
+### `BeneficiaryUpdated` — payout beneficiary changed
+
+Emitted when a holder sets or changes their designated payout beneficiary.
+
+**Topics:** `("niffyinsure", "BeneficiaryUpdated", holder: Address, policy_id: u32)`
+
+```json
+{
+  "version": 1,
+  "old_beneficiary": "G...",
+  "new_beneficiary": "G...",
+  "at_ledger": 1234700
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_beneficiary` | string (G…) \| null | Previous beneficiary; null if unset |
+| `new_beneficiary` | string (G…) | New beneficiary address |
+
+---
+
 ## Admin / config events  (`namespace = "niffyins"`)
 
 | Event | Topics | Key payload fields |
@@ -203,6 +277,41 @@ Emitted when voting reaches majority **or** the vote window expires.
 | `adm_tok` | `(NS, "adm_tok")` | `old_token`, `new_token` |
 | `adm_paus` | `(NS, "adm_paus", admin)` | `paused: 0\|1` |
 | `adm_drn` | `(NS, "adm_drn", admin)` | `recipient`, `amount` (stroops) |
+| `quorum_updated` | `("niffyinsure", "quorum_updated")` | `old_bps: u32`, `new_bps: u32` |
+| `GracePeriodUpdated` | `("niffyinsure", "GracePeriodUpdated", admin)` | `old_ledgers: u32`, `new_ledgers: u32` |
+
+### `quorum_updated` — DAO quorum threshold changed
+
+**Topics:** `("niffyinsure", "quorum_updated")`
+
+```json
+{
+  "version": 1,
+  "old_bps": 5000,
+  "new_bps": 6000
+}
+```
+
+Does not retroactively affect claims already in `Processing`.
+
+---
+
+### `GracePeriodUpdated` — renewal grace period changed
+
+**Topics:** `("niffyinsure", "GracePeriodUpdated", admin: Address)`
+
+```json
+{
+  "version": 1,
+  "old_ledgers": 720,
+  "new_ledgers": 1440
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_ledgers` | u32 | Previous grace period in ledgers |
+| `new_ledgers` | u32 | New grace period in ledgers |
 
 ---
 

--- a/backend/src/events/events.schema.ts
+++ b/backend/src/events/events.schema.ts
@@ -78,6 +78,17 @@ export interface ClaimPaidEvent {
   at_ledger: number;
 }
 
+/** claim_withdrawn — emitted when claimant withdraws before any votes are cast.
+ *  topics: (NS_POLICY, "claim_withdrawn", claim_id: u64) */
+export interface ClaimWithdrawnEvent {
+  version: number;
+  /** Per-holder policy identifier (u32). */
+  policy_id: number;
+  /** Address of the withdrawing claimant (G…). */
+  claimant: string;
+  at_ledger: number;
+}
+
 // ── Policy lifecycle events ───────────────────────────────────────────────────
 
 /** pol_init — emitted by initiate_policy.
@@ -122,6 +133,35 @@ export interface PolicyTerminatedEvent {
   /** Number of open claims at termination time. */
   open_claims: number;
   at_ledger: number;
+}
+
+/** policy_expired — emitted when policy expiry is detected by keeper or renew_policy.
+ *  topics: (NS_POLICY, "policy_expired", holder: Address, policy_id: u32)
+ *  May be emitted with a delay; deduplicate on policy_id. */
+export interface PolicyExpiredEvent {
+  /** Ledger at which the policy actually expired. */
+  expiry_ledger: number;
+  /** Ledger when the event was emitted (may differ from expiry_ledger). */
+  reported_at_ledger: number;
+}
+
+/** BeneficiaryUpdated — emitted when a holder sets or changes their payout beneficiary.
+ *  topics: (NS_POLICY, "BeneficiaryUpdated", holder: Address, policy_id: u32) */
+export interface BeneficiaryUpdatedEvent {
+  version: number;
+  /** Previous beneficiary address (G…); null if previously unset. */
+  old_beneficiary: string | null;
+  /** New beneficiary address (G…). */
+  new_beneficiary: string;
+  at_ledger: number;
+}
+
+/** GracePeriodUpdated — emitted when admin changes the renewal grace period.
+ *  topics: (NS_POLICY, "GracePeriodUpdated", admin: Address) */
+export interface GracePeriodUpdatedEvent {
+  version: number;
+  old_ledgers: number;
+  new_ledgers: number;
 }
 
 // ── Admin / config events ─────────────────────────────────────────────────────
@@ -184,6 +224,23 @@ export interface DrainedEvent {
   amount: string;
 }
 
+/** quorum_updated — emitted by admin_set_quorum_bps.
+ *  topics: (NS_POLICY, "quorum_updated")
+ *  Does not affect claims already in Processing. */
+export interface QuorumUpdatedEvent {
+  version: number;
+  old_bps: number;
+  new_bps: number;
+}
+
+/** GracePeriodUpdated — emitted by admin when renewal grace period changes.
+ *  topics: (NS_POLICY, "GracePeriodUpdated", admin: Address) */
+export interface GracePeriodUpdatedAdminEvent {
+  version: number;
+  old_ledgers: number;
+  new_ledgers: number;
+}
+
 // ── Parser table ──────────────────────────────────────────────────────────────
 
 /**
@@ -195,9 +252,14 @@ export type EventKey =
   | 'niffyins:vote_cast'
   | 'niffyins:clm_final'
   | 'niffyins:clm_paid'
+  | 'niffyinsure:claim_withdrawn'
   | 'niffyinsure:PolicyInitiated'
   | 'niffyinsure:PolicyRenewed'
   | 'niffyinsure:policy_terminated'
+  | 'niffyinsure:policy_expired'
+  | 'niffyinsure:BeneficiaryUpdated'
+  | 'niffyinsure:quorum_updated'
+  | 'niffyinsure:GracePeriodUpdated'
   | 'niffyins:tbl_upd'
   | 'niffyins:asset_set'
   | 'niffyins:adm_prop'
@@ -239,6 +301,9 @@ export const EVENT_PARSERS: Record<
   'niffyins:clm_paid': {
     1: (r) => r as ClaimPaidEvent,
   },
+  'niffyinsure:claim_withdrawn': {
+    1: (r) => r as ClaimWithdrawnEvent,
+  },
   'niffyinsure:PolicyInitiated': {
     1: (r) => r as PolicyInitiatedEvent,
   },
@@ -247,6 +312,18 @@ export const EVENT_PARSERS: Record<
   },
   'niffyinsure:policy_terminated': {
     1: (r) => r as PolicyTerminatedEvent,
+  },
+  'niffyinsure:policy_expired': {
+    1: (r) => r as PolicyExpiredEvent,
+  },
+  'niffyinsure:BeneficiaryUpdated': {
+    1: (r) => r as BeneficiaryUpdatedEvent,
+  },
+  'niffyinsure:quorum_updated': {
+    1: (r) => r as QuorumUpdatedEvent,
+  },
+  'niffyinsure:GracePeriodUpdated': {
+    1: (r) => r as GracePeriodUpdatedAdminEvent,
   },
   'niffyins:tbl_upd': {
     1: (r) => r as PremiumTableUpdatedEvent,


### PR DESCRIPTION

Closes #404

## What changed

EVENT_DICTIONARY.md
- Added missing events: claim_withdrawn, policy_expired, BeneficiaryUpdated, 
quorum_updated, GracePeriodUpdated
- Fixed adm_paused → adm_paus to match actual topic in events.rs
- Updated clm_filed payload to reflect evidence_hashes (replaces legacy 
image_hash)
- Added ownership statement and schema version policy to header

backend/src/events/events.schema.ts
- Added interfaces: ClaimWithdrawnEvent, PolicyExpiredEvent, 
BeneficiaryUpdatedEvent, QuorumUpdatedEvent, GracePeriodUpdatedAdminEvent
- Added all 5 to EventKey union and EVENT_PARSERS

.github/workflows/ci.yml
- Added check-event-dictionary job — extracts event names from #[contractevent] 
macros in events.rs and fails CI if any lack a dictionary entry

