### PR TITLE
ops: fill maintenance runbook gaps — indexer reindex, contract upgrad…

### DIFF
--- a/docs/ops/error-support-playbook.md
+++ b/docs/ops/error-support-playbook.md
@@ -6,6 +6,10 @@ Every API error response includes a `requestId` (correlation ID) that links the
 user-facing error to a specific backend log entry. Support agents should always
 ask users for this reference before escalating.
 
+Error codes are defined in `backend/src/common/errors/error-catalog.ts` and
+exported to `backend/src/common/errors/error-catalog.json` for frontend i18n.
+Run `npm run error-catalog:export` (in `backend/`) to regenerate after changes.
+
 ---
 
 ## 1. Finding a Correlation ID
@@ -19,7 +23,7 @@ Users see the reference in error toasts and inline error messages:
 {
   "statusCode": 500,
   "requestId": "req_abc123",
-  "error": "SERVER_ERROR",
+  "error": "INTERNAL_ERROR",
   "message": "Internal server error"
 }
 ```
@@ -51,18 +55,81 @@ cat /var/log/app/app.log | jq 'select(.requestId == "req_abc123")'
 
 ## 3. Error Code Reference
 
+All codes are sourced from `backend/src/common/errors/error-catalog.ts`.
+
+### Auth
+
 | Code | HTTP | Meaning | Action |
 |------|------|---------|--------|
-| `UNAUTHORIZED` | 401 | Session expired | Ask user to reconnect wallet |
-| `FORBIDDEN` | 403 | Insufficient role | Verify user permissions |
-| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests | Wait and retry; check for abuse |
-| `TRANSACTION_FAILED` | 400 | Stellar tx rejected | Check Stellar explorer with tx hash |
-| `SIGNATURE_INVALID` | 400 | Bad wallet signature | Ask user to retry signing |
-| `INSUFFICIENT_BALANCE` | 400 | Not enough XLM/token | User needs to fund wallet |
-| `LEDGER_CLOSED` | 400 | Tx missed ledger window | Resubmit transaction |
-| `SOROBAN_RPC_ERROR` | 502 | RPC node issue | Check RPC node health; retry |
-| `OPEN_CLAIM_EXISTS` | 409 | Duplicate claim attempt | Explain existing open claim |
-| `SERVER_ERROR` | 500 | Unhandled exception | Escalate with requestId |
+| `SIGNATURE_INVALID` | 401 | Wallet signature verification failed | Ask user to retry signing |
+| `NONCE_EXPIRED` | 401 | Sign-in nonce expired | Ask user to request a new nonce and retry |
+| `TOKEN_EXPIRED` | 401 | JWT access token expired | Ask user to reconnect wallet / re-authenticate |
+| `UNAUTHORIZED` | 401 | Request not authenticated | Ask user to reconnect wallet |
+| `FORBIDDEN` | 403 | Insufficient role/permission | Verify user permissions; escalate if unexpected |
+
+### Wallet / Account
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `INVALID_WALLET_ADDRESS` | 400 | Stellar address invalid or not on-chain | Ask user to verify their wallet address |
+| `ACCOUNT_NOT_FOUND` | 400 | Stellar account not found | User needs to fund account with at least 1 XLM |
+| `WRONG_NETWORK` | 400 | RPC network passphrase mismatch | Check `SOROBAN_RPC_URL` env var; verify network config |
+| `INSUFFICIENT_BALANCE` | 400 | Not enough XLM for fees | User needs to fund wallet |
+
+### Transaction / Contract
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `TRANSACTION_FAILED` | 400 | Stellar tx rejected by network | Check Stellar explorer with tx hash |
+| `TRANSACTION_REJECTED` | 400 | Tx rejected at submission | Check Stellar explorer; may be fee or sequence issue |
+| `INSUFFICIENT_FEE` | 400 | Fee below network minimum | Resubmit with higher fee |
+| `SIMULATION_FAILED` | 400 | Soroban simulation error | Check contract state; may be invalid input |
+| `SIMULATION_DECODE_FAILED` | 500 | Could not decode simulation return | Escalate with requestId; likely a contract ABI mismatch |
+| `CONTRACT_NOT_DEPLOYED` | 503 | Contract not deployed on this network | Verify `CONTRACT_ID` and network config |
+| `CONTRACT_NOT_CONFIGURED` | 400 | `CONTRACT_ID` env var not set | Check deployment environment variables |
+| `CONTRACT_NOT_INITIALIZED` | 400 | Contract not initialized | Run contract initialization; check deployment registry |
+| `SUBMISSION_FAILED` | 503 | Failed to submit tx to Soroban RPC | Check RPC node health; retry |
+| `LEDGER_CLOSED` | 400 | Target ledger already closed | Resubmit transaction |
+| `TIMEOUT_ERROR` | 504 | RPC call timed out | Check RPC node latency; retry |
+| `RPC_UNAVAILABLE` | 503 | Soroban RPC endpoint unreachable | Check RPC node health; check `SOROBAN_RPC_URL` |
+
+### Policy
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `POLICY_NOT_FOUND` | 404 | Policy does not exist | Verify policy ID; check indexer is up to date |
+| `POLICY_BATCH_TOO_LARGE` | 400 | Batch exceeds max policy count | Reduce batch size in request |
+
+### Claims
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `CLAIM_NOT_FOUND` | 404 | Claim does not exist | Verify claim ID; check indexer is up to date |
+| `CLAIM_ALREADY_FINALIZED` | 409 | Claim already finalized | Explain to user; no further action possible |
+
+### Rate Limiting
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests | Wait for window reset; check for abuse patterns |
+
+### Validation
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `VALIDATION_ERROR` | 422 | Request body failed schema validation | Check request payload against API spec |
+
+### Generic
+
+| Code | HTTP | Meaning | Action |
+|------|------|---------|--------|
+| `NOT_FOUND` | 404 | Resource not found | Verify the resource ID |
+| `INTERNAL_ERROR` | 500 | Unexpected server error | Escalate with requestId |
+
+> **Deprecated codes still in circulation:** `SERVER_ERROR` (replaced by `INTERNAL_ERROR`),
+> `SOROBAN_RPC_ERROR` (replaced by `RPC_UNAVAILABLE`), `OPEN_CLAIM_EXISTS` (replaced by
+> `CLAIM_ALREADY_FINALIZED`). These may appear in responses from older clients or cached
+> error messages. Map them to the current codes above for triage purposes.
 
 ---
 
@@ -98,3 +165,16 @@ Anonymized error events forwarded to observability tools **must not** include:
 - Private keys, seeds, or signed XDR (never, under any circumstances)
 
 See `backend/src/maintenance/privacy.service.ts` for the data-scrubbing implementation.
+
+---
+
+## 7. Keeping This Playbook Current
+
+When new error codes are added to `error-catalog.ts`:
+1. Add a row to the relevant table in section 3 above.
+2. Include the HTTP status, a plain-English description, and the recommended support action.
+3. Open a PR — required reviewers: **backend-lead** + **ops-lead**.
+
+The CI job `npm run error-catalog:check` (in `backend/`) will fail if any
+`new AppException('CODE')` call references a code not in the catalog, preventing
+undocumented codes from reaching production.

--- a/docs/ops/maintenance-runbook.md
+++ b/docs/ops/maintenance-runbook.md
@@ -181,7 +181,7 @@ Neither entrypoint can approve a claim without quorum math, change vote tallies,
 
 ### Recommended cadence
 - **Claims:** Poll or stream ledgers; for each open claim with `voting_deadline_ledger < current_ledger`, submit `process_deadline`. Typical spacing: every ledger, or every 1–5 ledgers if batching simulations (~5 s target per ledger on Mainnet).
-- **Policies:** For each tracked `(holder, policy_id)` (from indexer), call `process_expired` once `current_ledger >= end_ledger + grace`. Daily or weekly scans are enough if the indexer backfills; tighter cadence improves UI accuracy for “lapsed” state.
+- **Policies:** For each tracked `(holder, policy_id)` (from indexer), call `process_expired` once `current_ledger >= end_ledger + grace`. Daily or weekly scans are enough if the indexer backfills; tighter cadence improves UI accuracy for "lapsed" state.
 
 ### Incentives
 There is **no protocol reward** for keepers; operators run them to support product liveness (deadlines, lapsed flags) and their own UX. Use a dedicated funded account only for network fees.
@@ -189,6 +189,306 @@ There is **no protocol reward** for keepers; operators run them to support produ
 ### Failure modes
 - `process_expired`: reverts with `PolicyLapseNotReached` until grace end; `OpenClaimsMustFinalize` if a claim is still open on that policy.
 - `process_deadline`: reverts with `VotingWindowStillOpen` until after the voting deadline ledger; `ClaimAlreadyTerminal` if already finalized; `ClaimNotProcessing` if the claim left `Processing` without being terminal (e.g. appeal flows); `CalculatorPaused` while claims are paused (unlike `finalize_claim`, which panics on pause).
+
+---
+
+## 7. Indexer Reindex Procedure
+
+Use this procedure when the indexer has missed ledgers, is significantly behind, or data integrity issues require a full replay from a known-good ledger.
+
+### Prerequisites
+- Admin access to the backend deployment environment
+- `DATABASE_URL` and `SOROBAN_RPC_URL` env vars available
+- Confirm the target start ledger with the team (check `indexer_cursors` table or last known-good checkpoint)
+
+### Step-by-step
+
+**1. Identify the gap**
+```bash
+# Check current indexer cursor position
+psql $DATABASE_URL -c "SELECT contract_id, last_ledger_seq, updated_at FROM indexer_cursors ORDER BY updated_at DESC;"
+
+# Check current Stellar network ledger
+curl $SOROBAN_RPC_URL -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger","params":{}}'
+```
+
+**2. Stop the indexer**
+```bash
+# Kubernetes
+kubectl scale deployment niffyinsure-indexer --replicas=0 -n production
+
+# Docker Compose
+docker compose stop indexer
+```
+
+**3. Reset the cursor to the desired start ledger**
+```bash
+# Replace <CONTRACT_ID> and <START_LEDGER> with actual values
+psql $DATABASE_URL -c "
+  UPDATE indexer_cursors
+  SET last_ledger_seq = <START_LEDGER>, updated_at = NOW()
+  WHERE contract_id = '<CONTRACT_ID>';
+"
+```
+
+> **Warning:** Setting `START_LEDGER` too far back will cause the indexer to replay
+> already-processed events. The indexer uses upsert semantics for `raw_events`, so
+> duplicate ledger processing is safe but will increase DB load and catch-up time.
+
+**4. (Optional) Purge stale derived data for the replay range**
+```bash
+# Only needed if derived tables (e.g. claims, policies) may have corrupt rows
+# from the affected ledger range. Confirm with engineering before running.
+psql $DATABASE_URL -c "
+  DELETE FROM raw_events
+  WHERE ledger_seq >= <START_LEDGER> AND ledger_seq <= <END_LEDGER>;
+"
+```
+
+**5. Restart the indexer**
+```bash
+# Kubernetes
+kubectl scale deployment niffyinsure-indexer --replicas=1 -n production
+
+# Docker Compose
+docker compose start indexer
+```
+
+**6. Monitor catch-up progress**
+```bash
+# Watch the cursor advance
+watch -n 5 'psql $DATABASE_URL -c "SELECT last_ledger_seq, updated_at FROM indexer_cursors;"'
+
+# Check Prometheus metric
+curl http://localhost:3000/metrics | grep indexer_lag_ledgers
+```
+
+Alert threshold: `indexer_lag_ledgers > 500` → investigate RPC latency or increase `INDEXER_BATCH_SIZE` (see `backend/docs/indexer-runbook.md`).
+
+**7. Verify data integrity post-reindex**
+```bash
+# Confirm event counts are consistent
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM raw_events WHERE ledger_seq >= <START_LEDGER>;"
+
+# Spot-check a known claim or policy from the replayed range
+psql $DATABASE_URL -c "SELECT id, status, updated_at FROM claims WHERE id = '<KNOWN_CLAIM_ID>';"
+```
+
+**8. Sign off**
+- [ ] Cursor is at or near current network ledger
+- [ ] No `indexer_lag_ledgers` alert firing
+- [ ] Spot-check of replayed data passes
+- [ ] Engineer sign-off: _name, date_
+
+---
+
+## 8. Contract Upgrade Procedure
+
+Use this procedure to deploy a new WASM build to the Soroban contract and update all downstream references.
+
+### Prerequisites
+- Rust toolchain with `wasm32-unknown-unknown` target installed
+- Stellar CLI (`stellar`) configured with the admin/upgrade keypair
+- Access to the secrets manager to update `NIFFYINSURE_EXPECTED_WASM_HASH`
+- DAO approval or governance vote reference (required for Mainnet upgrades)
+
+### Step-by-step
+
+**1. Build and verify the WASM**
+```bash
+# Build optimised release WASM
+cargo build --release --target wasm32-unknown-unknown
+
+# Compute the hash
+sha256sum target/wasm32-unknown-unknown/release/niffyinsure.wasm
+# Record this value as NEW_WASM_HASH
+```
+
+**2. Verify WASM drift baseline (pre-upgrade)**
+```bash
+# Confirm current on-chain hash matches the expected hash before proceeding
+curl -X POST https://api.example.com/admin/maintenance/check-wasm-drift \
+  -H "Authorization: Bearer $ADMIN_JWT"
+# Expected: no drift alert. If drift is already present, investigate before upgrading.
+```
+
+**3. Upload the new WASM to the network**
+```bash
+stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/niffyinsure.wasm \
+  --source <UPGRADE_KEYPAIR_ALIAS> \
+  --network mainnet
+# Note the returned WASM hash — must match NEW_WASM_HASH from step 1.
+```
+
+**4. Execute the upgrade**
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <UPGRADE_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- upgrade \
+  --new_wasm_hash <NEW_WASM_HASH>
+```
+
+**5. Update the expected hash in secrets manager**
+```bash
+# AWS Secrets Manager example
+aws secretsmanager update-secret \
+  --secret-id NIFFYINSURE_EXPECTED_WASM_HASH \
+  --secret-string "<NEW_WASM_HASH>"
+```
+
+**6. Update the deployment registry**
+```json
+// contracts/deployment-registry.json
+{
+  "contractName": "niffyinsure",
+  "contractId": "<CONTRACT_ID>",
+  "expectedWasmHash": "<NEW_WASM_HASH>",
+  "deployedAt": "<ISO_TIMESTAMP>"
+}
+```
+
+**7. Verify WASM drift post-upgrade**
+```bash
+# Trigger a drift check — should return clean (no mismatch)
+curl -X POST https://api.example.com/admin/maintenance/check-wasm-drift \
+  -H "Authorization: Bearer $ADMIN_JWT"
+
+# Confirm no open drift alerts
+psql $DATABASE_URL -c "SELECT * FROM wasm_drift_alerts WHERE resolved_at IS NULL;"
+```
+
+**8. Resolve any pre-existing drift alerts**
+```sql
+UPDATE wasm_drift_alerts
+SET resolved_at = NOW()
+WHERE contract_name = 'niffyinsure' AND resolved_at IS NULL;
+```
+
+**9. Rollback procedure**
+If the upgrade introduces a regression:
+1. Re-upload the previous WASM build (keep the artifact from the prior release).
+2. Call `upgrade` with the old `WASM_HASH`.
+3. Revert `NIFFYINSURE_EXPECTED_WASM_HASH` in secrets manager to the old hash.
+4. Revert `contracts/deployment-registry.json`.
+5. Re-run drift check to confirm clean state.
+6. Document the rollback in the audit log with reason and DAO notification reference.
+
+**Sign-off checklist:**
+- [ ] New WASM hash verified against local build artifact
+- [ ] Drift check clean post-upgrade
+- [ ] `deployment-registry.json` updated and merged
+- [ ] Secrets manager updated
+- [ ] DAO / governance approval reference recorded
+- [ ] Engineer sign-off: _name, date_
+
+---
+
+## 9. Emergency Pause Procedure
+
+Use this procedure to halt claim processing or policy operations during a critical incident (e.g., smart contract exploit, oracle manipulation, regulatory hold).
+
+### Pause scope
+
+| Pause flag | Effect | Entrypoint |
+|---|---|---|
+| `claims_paused` | Blocks new claim filings and `finalize_claim`; `process_deadline` returns `CalculatorPaused` instead of panicking | `admin_set_claims_paused(true)` |
+| `policy_paused` | Blocks new policy purchases | `admin_set_policy_paused(true)` |
+
+### Prerequisites
+- Admin keypair with `ADMIN` role on the contract
+- Incident channel open (Slack `#incidents` or equivalent)
+- At least one other engineer notified before executing on Mainnet
+
+### Step-by-step
+
+**1. Assess and declare incident**
+- Open an incident in the incident tracker (PagerDuty / Linear).
+- Post in `#incidents`: contract address, observed anomaly, proposed pause scope.
+- Get verbal/async acknowledgement from one other engineer.
+
+**2. Pause claims (if claim processing is affected)**
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <ADMIN_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- admin_set_claims_paused \
+  --paused true
+```
+
+**3. Pause policy purchases (if policy issuance is affected)**
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <ADMIN_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- admin_set_policy_paused \
+  --paused true
+```
+
+**4. Verify pause is active**
+```bash
+# Attempt a test claim filing — should return CalculatorPaused / PolicyPaused
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <TEST_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- file_claim \
+  --policy_id <TEST_POLICY_ID> \
+  --description "pause verification test"
+# Expected: transaction fails with CalculatorPaused or equivalent error
+```
+
+**5. Monitor and communicate**
+- Post pause confirmation in `#incidents` with transaction hash.
+- Notify DAO / community via governance forum if pause is expected to last > 1 hour.
+- Update the incident tracker with pause timestamp and scope.
+
+**6. Investigate root cause**
+- Pull relevant logs: `grep '"level":"error"' /var/log/app/app.log | tail -200`
+- Check Stellar explorer for anomalous transactions in the affected ledger range.
+- Review `wasm_drift_alerts` for unexpected contract changes.
+
+**7. Resume operations (rollback steps)**
+
+Once the incident is resolved and root cause is confirmed safe:
+
+```bash
+# Resume claims
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <ADMIN_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- admin_set_claims_paused \
+  --paused false
+
+# Resume policy purchases
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source <ADMIN_KEYPAIR_ALIAS> \
+  --network mainnet \
+  -- admin_set_policy_paused \
+  --paused false
+```
+
+**8. Post-incident**
+- Verify normal operations: submit a test claim in staging, confirm it processes.
+- Resolve the incident in PagerDuty / Linear.
+- Write a post-mortem within 5 business days covering: timeline, root cause, impact, and mitigations.
+- Document the pause/resume in the audit log with incident reference.
+
+**Sign-off checklist:**
+- [ ] Pause confirmed active on-chain
+- [ ] Incident declared and team notified
+- [ ] Root cause identified before resuming
+- [ ] Resume confirmed active on-chain
+- [ ] Post-mortem scheduled or completed
+- [ ] Engineer sign-off: _name, date_
 
 ---
 


### PR DESCRIPTION
…e, emergency pause

Closes ops maintenance runbook gaps identified in the CommentOps issue.

Changes:
- docs/ops/maintenance-runbook.md
  - Added §7 Indexer Reindex Procedure: step-by-step guide covering gap identification, cursor reset, optional raw_events purge, restart, catch-up monitoring, and post-reindex integrity verification with sign-off checklist.
  - Added §8 Contract Upgrade Procedure: full WASM build → upload → invoke upgrade → secrets manager update → deployment registry update → post-upgrade drift verification → rollback steps with sign-off checklist. Includes WASM drift verification both pre- and post-upgrade.
  - Added §9 Emergency Pause Procedure: incident declaration, on-chain pause of claims and/or policy purchases via admin entrypoints, pause verification, monitoring/comms guidance, resume (rollback) steps, and post-incident requirements with sign-off checklist.

- docs/ops/error-support-playbook.md
  - Replaced the partial error code table with a complete reference sourced directly from backend/src/common/errors/error-catalog.ts, covering all current codes across Auth, Wallet/Account, Transaction/Contract, Policy, Claims, Rate Limiting, Validation, and Generic categories.
  - Added deprecation notice for legacy codes (SERVER_ERROR, SOROBAN_RPC_ERROR, OPEN_CLAIM_EXISTS) still in circulation from older clients.
  - Added §7 with instructions for keeping the playbook in sync with the error catalog going forward. closes #400 