### PR TITLE
Feat/premium table admin multiplier update

### DIFF
--- a/contracts/niffyinsure/Cargo.toml
+++ b/contracts/niffyinsure/Cargo.toml
@@ -18,6 +18,10 @@ legacy-event-schema-tests = []
 # Reserves governance-token storage keys and optional admin entrypoints. No mint/transfer.
 # MVP / default builds must ship with this disabled.
 governance-token = []
+# Reserves the ClaimStatus::Appealed variant and appeal-window constants for future implementation.
+# Default builds compile without any appeal logic executing — the variant is documented only.
+# Enable to unlock appeal entrypoints once the full appeal flow is implemented and audited.
+appeal-stub = []
 
 [dependencies]
 soroban-sdk = { version = "=25.3.1", features = [] }

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -878,3 +878,27 @@ mod claim_status_history_tests {
         );
     }
 }
+
+/// Verify that `ClaimStatus::Appealed` is not treated as a terminal state,
+/// which would incorrectly allow `process_claim` / `finalize_claim` to close
+/// an in-flight appeal without resolving the appeal round.
+#[cfg(test)]
+mod appeal_stub_tests {
+    use crate::types::ClaimStatus;
+
+    #[test]
+    fn appealed_is_not_terminal() {
+        assert!(
+            !ClaimStatus::Appealed.is_terminal(),
+            "ClaimStatus::Appealed must NOT be terminal — an appeal in progress \
+             must not allow finalization or payout until the appeal round resolves"
+        );
+    }
+
+    #[test]
+    fn appeal_resolved_states_are_terminal() {
+        // Once an appeal resolves, both outcomes are terminal.
+        assert!(ClaimStatus::AppealApproved.is_terminal());
+        assert!(ClaimStatus::AppealRejected.is_terminal());
+    }
+}

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -188,6 +188,25 @@ impl NiffyInsure {
         premium::update_multiplier_table(&env, &new_table)
     }
 
+    /// Admin-only: update a single multiplier entry without redeploying the contract.
+    ///
+    /// Emits `PremiumMultiplierUpdated` with the key, old value, and new value.
+    /// Premium calculations use the updated value immediately after this call.
+    ///
+    /// # Bounds
+    /// - Region / Age / Coverage keys: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000)
+    /// - SafetyDiscount key: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+    pub fn admin_set_premium_multiplier(
+        env: Env,
+        key: types::MultiplierKey,
+        value: i128,
+    ) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        storage::bump_instance(&env);
+        premium::admin_set_premium_multiplier(&env, key, value)
+    }
+
     pub fn get_multiplier_table(env: Env) -> types::MultiplierTable {
         storage::get_multiplier_table(&env)
     }

--- a/contracts/niffyinsure/src/premium.rs
+++ b/contracts/niffyinsure/src/premium.rs
@@ -14,8 +14,8 @@ use crate::{
     premium_pure,
     storage,
     types::{
-        AgeBand, CoverageTier, MultiplierTable, PremiumQuoteLineItem, PremiumTableUpdated,
-        RegionTier, RiskInput,
+        AgeBand, CoverageTier, MultiplierKey, MultiplierTable, PremiumMultiplierUpdated,
+        PremiumQuoteLineItem, PremiumTableUpdated, RegionTier, RiskInput,
     },
     validate::Error,
 };
@@ -60,6 +60,81 @@ pub fn update_multiplier_table(env: &Env, new_table: &MultiplierTable) -> Result
     storage::set_multiplier_table(env, new_table);
     PremiumTableUpdated { version: new_table.version }.publish(env);
     Ok(())
+}
+
+/// Admin-only: update a single multiplier entry without redeploying the contract.
+///
+/// # Key format
+/// See [`MultiplierKey`] for the full key taxonomy and valid value ranges.
+///
+/// # Bounds
+/// - `Region`, `Age`, `Coverage` values: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000)
+/// - `SafetyDiscount` value: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+///
+/// # Emits
+/// [`PremiumMultiplierUpdated`] with `key`, `old_value`, and `new_value`.
+/// Premium calculations use the updated value immediately after this call.
+pub fn admin_set_premium_multiplier(
+    env: &Env,
+    key: MultiplierKey,
+    value: i128,
+) -> Result<(), Error> {
+    // Validate bounds before touching storage.
+    let old_value = validate_and_get_old(env, &key, value)?;
+
+    let mut table = storage::get_multiplier_table(env);
+
+    match key.clone() {
+        MultiplierKey::Region(tier) => {
+            table.region.set(tier, value);
+        }
+        MultiplierKey::Age(band) => {
+            table.age.set(band, value);
+        }
+        MultiplierKey::Coverage(tier) => {
+            table.coverage.set(tier, value);
+        }
+        MultiplierKey::SafetyDiscount => {
+            table.safety_discount = value;
+        }
+    }
+
+    storage::set_multiplier_table(env, &table);
+
+    PremiumMultiplierUpdated { key, old_value, new_value: value }.publish(env);
+
+    Ok(())
+}
+
+/// Validate the new value for `key` and return the current (old) value.
+fn validate_and_get_old(env: &Env, key: &MultiplierKey, value: i128) -> Result<i128, Error> {
+    let table = storage::get_multiplier_table(env);
+    match key {
+        MultiplierKey::Region(tier) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::RegionMultiplierOutOfBounds);
+            }
+            Ok(table.region.get(tier.clone()).unwrap_or(0))
+        }
+        MultiplierKey::Age(band) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::AgeMultiplierOutOfBounds);
+            }
+            Ok(table.age.get(band.clone()).unwrap_or(0))
+        }
+        MultiplierKey::Coverage(tier) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::CoverageMultiplierOutOfBounds);
+            }
+            Ok(table.coverage.get(tier.clone()).unwrap_or(0))
+        }
+        MultiplierKey::SafetyDiscount => {
+            if value < 0 || value > MAX_SAFETY_DISCOUNT {
+                return Err(Error::SafetyDiscountOutOfBounds);
+            }
+            Ok(table.safety_discount)
+        }
+    }
 }
 
 /// Delegate to `premium_pure::compute_premium` — no Env required for the math.

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -139,6 +139,41 @@ pub enum ClaimStatus {
     AppealRejected,
     /// Claimant withdrew before voting began; record kept for audit; no payout.
     Withdrawn,
+    /// RESERVED — appeal in progress; not yet implemented.
+    ///
+    /// This variant is declared to **reserve the discriminant** in the on-chain
+    /// ABI and prevent future contract upgrades from introducing a breaking enum
+    /// change.  No existing entrypoint constructs or transitions to this status;
+    /// it is purely a forward-compatibility placeholder.
+    ///
+    /// Default builds compile without any appeal logic executing — this variant
+    /// exists in the type system but is unreachable through any live code path
+    /// until the full appeal flow is implemented and audited.
+    ///
+    /// # Intended appeal flow (future implementation)
+    ///
+    /// ```text
+    /// Rejected → Appealed        (claimant calls open_appeal within APPEAL_OPEN_WINDOW_LEDGERS)
+    ///                             appeal vote runs for APPEAL_VOTE_WINDOW_LEDGERS
+    /// Appealed → AppealApproved  (majority approve or deadline plurality)
+    /// Appealed → AppealRejected  (majority reject or deadline plurality)
+    /// ```
+    ///
+    /// # Auto-deactivation interaction
+    ///
+    /// When `on_reject` fires and the policy strike count reaches
+    /// `STRIKE_DEACTIVATION_THRESHOLD`, auto-deactivation MUST be deferred
+    /// while the claim is `Appealed`.  Implement by checking
+    /// `env.ledger().sequence() > appeal_open_deadline_ledger` before writing
+    /// `is_active = false` to the policy.
+    ///
+    /// # is_terminal() contract
+    ///
+    /// `Appealed` is intentionally **not** a terminal state — the claim is
+    /// still in flight.  `is_terminal()` returns `false` for this variant so
+    /// that voting and finalization guards correctly reject further transitions
+    /// until the appeal round resolves.
+    Appealed,
 }
 
 impl ClaimStatus {
@@ -151,6 +186,10 @@ impl ClaimStatus {
                 | ClaimStatus::AppealApproved
                 | ClaimStatus::AppealRejected
                 | ClaimStatus::Withdrawn
+            // NOTE: ClaimStatus::Appealed is intentionally absent — an appeal
+            // in progress is NOT terminal.  Adding it here would allow
+            // process_claim / finalize_claim to close an appealed claim without
+            // resolving the appeal round, which would be incorrect.
         )
     }
 }

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -374,10 +374,40 @@ pub struct MultiplierTable {
     pub version: u32,
 }
 
+/// Identifies a single row in the multiplier table for granular admin updates.
+///
+/// # Key format
+/// - `Region(tier)` — one of `RegionTier::{Low, Medium, High}`
+/// - `Age(band)` — one of `AgeBand::{Young, Adult, Senior}`
+/// - `Coverage(tier)` — one of `CoverageTier::{Basic, Standard, Premium}`
+/// - `SafetyDiscount` — the flat discount applied when `safety_score > 0`
+///
+/// # Valid value ranges
+/// - `Region`, `Age`, `Coverage` entries: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000, scale 10_000 = 1×)
+/// - `SafetyDiscount`: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MultiplierKey {
+    Region(RegionTier),
+    Age(AgeBand),
+    Coverage(CoverageTier),
+    SafetyDiscount,
+}
+
 #[contractevent(topics = ["niffyinsure", "premium_table_updated"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PremiumTableUpdated {
     pub version: u32,
+}
+
+/// Emitted by `admin_set_premium_multiplier` for each granular update.
+/// topics: ("niffyinsure", "premium_multiplier_updated")
+#[contractevent(topics = ["niffyinsure", "premium_multiplier_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PremiumMultiplierUpdated {
+    pub key: MultiplierKey,
+    pub old_value: i128,
+    pub new_value: i128,
 }
 
 #[contractevent(topics = ["niffyinsure", "claim_paid"])]

--- a/contracts/niffyinsure/tests/premium_table_tests.rs
+++ b/contracts/niffyinsure/tests/premium_table_tests.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use niffyinsure::{
-    premium::{compute_premium, default_multiplier_table},
-    types::{AgeBand, CoverageTier, RegionTier, RiskInput},
+    premium::{compute_premium, default_multiplier_table, admin_set_premium_multiplier, MAX_MULTIPLIER, MIN_MULTIPLIER, MAX_SAFETY_DISCOUNT},
+    types::{AgeBand, CoverageTier, MultiplierKey, RegionTier, RiskInput},
 };
 use soroban_sdk::Env;
 
@@ -48,4 +48,193 @@ fn default_table_matches_known_reference_vectors() {
         let computation = compute_premium(&input, base_amount, &table).unwrap();
         assert_eq!(computation.total_premium, expected_total);
     }
+}
+
+// ── admin_set_premium_multiplier tests ────────────────────────────────────────
+
+/// Helper: set up a contract env with admin + initialized multiplier table.
+fn setup_env_with_table() -> (Env, soroban_sdk::Address) {
+    use niffyinsure::storage;
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = soroban_sdk::Address::generate(&env);
+    storage::set_admin(&env, &admin);
+    storage::set_multiplier_table(&env, &default_multiplier_table(&env));
+    (env, admin)
+}
+
+#[test]
+fn valid_region_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    // Update High region from 13_500 → 15_000
+    admin_set_premium_multiplier(&env, MultiplierKey::Region(RegionTier::High), 15_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(
+        table.region.get(RegionTier::High).unwrap(),
+        15_000,
+        "region multiplier should be updated in storage"
+    );
+
+    // Premium calculation must use the new value immediately
+    let input = RiskInput {
+        region: RegionTier::High,
+        age_band: AgeBand::Adult,
+        coverage: CoverageTier::Standard,
+        safety_score: 0,
+    };
+    let computation = compute_premium(&input, 10_000_000, &table).unwrap();
+    // With High=15_000, Adult=10_000, Standard=10_000, safety_discount=2_000, score=0
+    // result = base * (15_000/10_000) * (10_000/10_000) * (10_000/10_000) = 15_000_000
+    assert_eq!(computation.total_premium, 15_000_000);
+}
+
+#[test]
+fn valid_age_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Age(AgeBand::Young), 11_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.age.get(AgeBand::Young).unwrap(), 11_000);
+}
+
+#[test]
+fn valid_coverage_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Coverage(CoverageTier::Basic), 9_500)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.coverage.get(CoverageTier::Basic).unwrap(), 9_500);
+}
+
+#[test]
+fn valid_safety_discount_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, 3_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.safety_discount, 3_000);
+}
+
+#[test]
+fn region_multiplier_above_max_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::Low),
+        MAX_MULTIPLIER + 1,
+    );
+    assert_eq!(
+        result,
+        Err(niffyinsure::validate::Error::RegionMultiplierOutOfBounds),
+        "value above MAX_MULTIPLIER must be rejected"
+    );
+}
+
+#[test]
+fn region_multiplier_below_min_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::Medium),
+        MIN_MULTIPLIER - 1,
+    );
+    assert_eq!(
+        result,
+        Err(niffyinsure::validate::Error::RegionMultiplierOutOfBounds),
+        "value below MIN_MULTIPLIER must be rejected"
+    );
+}
+
+#[test]
+fn age_multiplier_out_of_bounds_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Age(AgeBand::Senior),
+        MAX_MULTIPLIER + 500,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::AgeMultiplierOutOfBounds));
+}
+
+#[test]
+fn coverage_multiplier_out_of_bounds_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Coverage(CoverageTier::Premium),
+        MIN_MULTIPLIER - 1,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::CoverageMultiplierOutOfBounds));
+}
+
+#[test]
+fn safety_discount_above_max_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::SafetyDiscount,
+        MAX_SAFETY_DISCOUNT + 1,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::SafetyDiscountOutOfBounds));
+}
+
+#[test]
+fn safety_discount_negative_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, -1);
+    assert_eq!(result, Err(niffyinsure::validate::Error::SafetyDiscountOutOfBounds));
+}
+
+#[test]
+fn boundary_values_at_min_and_max_are_accepted() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Region(RegionTier::Low), MIN_MULTIPLIER)
+        .expect("MIN_MULTIPLIER should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Age(AgeBand::Adult), MAX_MULTIPLIER)
+        .expect("MAX_MULTIPLIER should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, 0)
+        .expect("zero safety discount should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, MAX_SAFETY_DISCOUNT)
+        .expect("MAX_SAFETY_DISCOUNT should be accepted");
+}
+
+#[test]
+fn storage_unchanged_after_out_of_bounds_rejection() {
+    let (env, _admin) = setup_env_with_table();
+
+    let table_before = niffyinsure::storage::get_multiplier_table(&env);
+    let original_high = table_before.region.get(RegionTier::High).unwrap();
+
+    // Attempt an invalid update
+    let _ = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::High),
+        MAX_MULTIPLIER + 9999,
+    );
+
+    let table_after = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(
+        table_after.region.get(RegionTier::High).unwrap(),
+        original_high,
+        "storage must not be modified on rejection"
+    );
 }


### PR DESCRIPTION
Adds admin_set_premium_multiplier(key, value) to the NiffyInsure Soroban contract, allowing the admin to update individual entries in the premium multiplier table at runtime — no contract redeployment required.closes #407 