### PR TITLE
Feat/cross contract premium calculator integration

### DIFF
--- a/contracts/niffyinsure/Cargo.toml
+++ b/contracts/niffyinsure/Cargo.toml
@@ -18,6 +18,10 @@ legacy-event-schema-tests = []
 # Reserves governance-token storage keys and optional admin entrypoints. No mint/transfer.
 # MVP / default builds must ship with this disabled.
 governance-token = []
+# Reserves the ClaimStatus::Appealed variant and appeal-window constants for future implementation.
+# Default builds compile without any appeal logic executing — the variant is documented only.
+# Enable to unlock appeal entrypoints once the full appeal flow is implemented and audited.
+appeal-stub = []
 
 [dependencies]
 soroban-sdk = { version = "=25.3.1", features = [] }

--- a/contracts/niffyinsure/docs/CALCULATOR-INTERFACE.md
+++ b/contracts/niffyinsure/docs/CALCULATOR-INTERFACE.md
@@ -1,0 +1,331 @@
+# Premium Calculator Cross-Contract Interface
+
+## Overview
+
+The `niffyinsure` policy contract integrates with an external `premium_calculator` contract via cross-contract invocation for premium computation. This document specifies the interface contract between the two systems.
+
+## Architecture
+
+```
+┌─────────────────────┐         ┌──────────────────────┐
+│  NiffyInsure        │         │  PremiumCalculator   │
+│  (Policy Contract)  │────────▶│  (Pricing Engine)    │
+│                     │ compute │                      │
+└─────────────────────┘         └──────────────────────┘
+```
+
+### Routing Logic
+
+The policy contract uses **conditional routing** for premium computation:
+
+- **Calculator configured** (`CalcAddress` set): Cross-contract call to external calculator
+- **Calculator not configured** (`CalcAddress` absent): Local fallback engine
+
+This design ensures:
+- Zero-downtime migration (existing deployments continue working)
+- Graceful degradation (local fallback if calculator unavailable)
+- Flexible pricing (admin can hot-swap calculator implementations)
+
+## Interface Specification
+
+### Version
+
+**Interface Version:** `1.0.0`  
+**Soroban SDK:** `25.3.1`  
+**Contract ABI:** Soroban `contractclient` binding
+
+### Required Entrypoint
+
+The calculator contract MUST implement:
+
+```rust
+pub fn compute(env: Env, input: CalcInput) -> Result<CalcResult, CalcError>
+```
+
+#### Input Type: `CalcInput`
+
+```rust
+#[contracttype]
+pub struct CalcInput {
+    pub region: RegionTier,      // Geographic risk tier
+    pub age_band: AgeBand,        // Underwriting age bucket
+    pub coverage: CoverageTier,   // Coverage level
+    pub safety_score: u32,        // 0..=100; percentage of max safety discount
+    pub base_amount: i128,        // Coverage amount in stroops
+}
+```
+
+**Enum Definitions:**
+
+```rust
+#[contracttype]
+pub enum RegionTier {
+    Low,
+    Medium,
+    High,
+}
+
+#[contracttype]
+pub enum AgeBand {
+    Young,
+    Adult,
+    Senior,
+}
+
+#[contracttype]
+pub enum CoverageTier {
+    Basic,
+    Standard,
+    Premium,
+}
+```
+
+#### Output Type: `CalcResult`
+
+```rust
+#[contracttype]
+pub struct CalcResult {
+    pub premium: i128,           // Computed premium in stroops
+    pub config_version: u32,     // Multiplier table version (capability flag)
+}
+```
+
+#### Error Type: `CalcError`
+
+```rust
+#[contracterror]
+pub enum CalcError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidBaseAmount = 4,
+    SafetyScoreOutOfRange = 5,
+    MissingRegionMultiplier = 6,
+    MissingAgeMultiplier = 7,
+    MissingCoverageMultiplier = 8,
+    RegionMultiplierOutOfBounds = 9,
+    AgeMultiplierOutOfBounds = 10,
+    CoverageMultiplierOutOfBounds = 11,
+    SafetyDiscountOutOfBounds = 12,
+    InvalidConfigVersion = 13,
+    Overflow = 14,
+    DivideByZero = 15,
+    NegativePremiumNotSupported = 16,
+    Paused = 17,  // ⚠️ Special: triggers CalculatorPaused in policy contract
+}
+```
+
+**Critical Error Code:**
+- `Paused = 17`: Policy contract distinguishes this error and returns `Error::CalculatorPaused` instead of generic `CalculatorCallFailed`
+
+### Optional Entrypoints
+
+```rust
+pub fn get_version(env: Env) -> u32
+```
+Returns the current multiplier table version (capability flag for version negotiation).
+
+```rust
+pub fn version(env: Env) -> String
+```
+Returns the semver version string from `Cargo.toml` (build-time metadata).
+
+## Error Handling
+
+### Policy Contract Error Mapping
+
+The policy contract (`calculator.rs`) maps calculator errors as follows:
+
+| Calculator State | Policy Contract Error | Description |
+|-----------------|----------------------|-------------|
+| `Ok(Ok(CalcResult))` | Success | Normal path |
+| `Ok(Err(_))` | `CalculatorCallFailed` | Type conversion failure |
+| `Err(Ok(CalcError::Paused))` | `CalculatorPaused` | Calculator explicitly paused |
+| `Err(Ok(CalcError::*))` | `CalculatorCallFailed` | Other typed calculator errors |
+| `Err(Err(InvokeError))` | `CalculatorCallFailed` | Host-level abort/panic/undeployed |
+
+### Fail-Closed Semantics
+
+The integration follows **fail-closed** semantics:
+- Calculator errors propagate to the caller (no silent fallback during cross-contract call)
+- Undeployed calculator → `CalculatorCallFailed` (host-level `InvokeError`)
+- Paused calculator → `CalculatorPaused` (explicit error code 17)
+
+### Fallback Behavior
+
+**Local engine fallback** only applies when:
+- `CalcAddress` is **not set** (no calculator configured)
+- NOT when calculator call fails (fail-closed)
+
+This prevents silent degradation masking operational issues.
+
+## Type Compatibility
+
+### Structural Identity Requirement
+
+The policy contract mirrors calculator types in `calculator.rs`:
+
+```rust
+// ── Mirrored types from premium_calculator ────────────────────────────────────
+// These must stay structurally identical to `premium_calculator::types`.
+
+#[contracttype]
+pub enum CalcRegionTier { Low, Medium, High }
+
+#[contracttype]
+pub enum CalcAgeBand { Young, Adult, Senior }
+
+#[contracttype]
+pub enum CalcCoverageType { Basic, Standard, Premium }
+```
+
+**Breaking Change Risk:**
+- Adding/removing enum variants breaks ABI compatibility
+- Reordering variants breaks serialization
+- Renaming fields breaks deserialization
+
+**Mitigation:**
+- Version negotiation via `get_version()` entrypoint
+- Integration tests verify type compatibility (`cross_contract.rs`)
+
+## Configuration
+
+### Admin Operations
+
+```rust
+// Set calculator address (admin-only)
+pub fn set_calculator(env: Env, calculator: Address)
+
+// Clear calculator address (revert to local engine)
+pub fn clear_calculator(env: Env)
+
+// Read current calculator address
+pub fn get_calculator(env: Env) -> Option<Address>
+```
+
+### Storage Key
+
+```rust
+DataKey::CalcAddress  // Instance storage, admin-controlled
+```
+
+## Integration Points
+
+### Policy Binding Path
+
+Cross-contract calls occur during:
+
+1. **`initiate_policy`**: New policy creation
+2. **`renew_policy`**: Policy renewal (term extension)
+
+Both call `calculator::compute_quote()` which routes to external calculator when configured.
+
+### Read-Only Quote Path
+
+**`generate_premium`** (read-only quote simulation) uses the **local engine** directly:
+- No cross-contract call
+- No persistent writes
+- Deterministic pricing from on-chain multiplier table
+
+This ensures quote availability even if calculator is paused/unavailable.
+
+## Testing
+
+### Integration Test Coverage
+
+See `contracts/niffyinsure/tests/cross_contract.rs`:
+
+| Test | Coverage |
+|------|----------|
+| `generate_premium_uses_local_engine_when_no_calculator_set` | Fallback when no calculator configured |
+| `generate_premium_routes_to_external_calculator` | Cross-contract call success path |
+| `calculator_rotation_changes_pricing` | Hot-swap calculator addresses |
+| `paused_calculator_causes_bind_fail_closed` | Paused calculator error handling |
+| `clear_calculator_reverts_to_local_engine` | Clearing calculator address |
+| `set_calculator_requires_admin_auth` | Admin authorization |
+| `undeployed_calculator_falls_back_to_local_engine` | Undeployed contract handling |
+| `initiate_policy_uses_cross_contract_calculator` | Policy binding with calculator |
+| `initiate_policy_fallback_when_calculator_not_deployed` | Policy binding fallback |
+
+## Versioning
+
+### Interface Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-04 | Initial interface specification |
+
+### Compatibility Matrix
+
+| Policy Contract | Calculator Contract | Compatible |
+|----------------|---------------------|------------|
+| 0.1.0 | 0.1.0 | ✅ |
+
+### Breaking Changes
+
+Future breaking changes require:
+1. Bump interface version
+2. Update compatibility matrix
+3. Migration guide for existing deployments
+4. Deprecation notice (minimum 1 release cycle)
+
+## Security Considerations
+
+### Trust Model
+
+- **Calculator contract is TRUSTED**: Policy contract does not validate calculator output
+- **Admin controls calculator address**: Malicious admin can point to malicious calculator
+- **No signature verification**: Calculator output is not cryptographically signed
+
+### Attack Vectors
+
+| Attack | Mitigation |
+|--------|-----------|
+| Malicious calculator returns inflated premiums | Admin key security + governance |
+| Calculator returns zero premium | Policy contract validates `premium > 0` |
+| Calculator panics/aborts | Fail-closed: transaction reverts |
+| Calculator address points to non-contract | Host-level error → `CalculatorCallFailed` |
+
+### Recommendations
+
+1. **Calculator deployment**: Use deterministic WASM builds + reproducible verification
+2. **Admin key**: Multi-sig or governance-controlled
+3. **Monitoring**: Alert on `CalculatorCallFailed` / `CalculatorPaused` errors
+4. **Auditing**: Independent security review before mainnet deployment
+
+## Operational Runbook
+
+### Calculator Upgrade Procedure
+
+1. Deploy new calculator contract
+2. Verify `compute()` returns expected values (testnet)
+3. Admin calls `set_calculator(new_address)`
+4. Monitor error rates for 24h
+5. If issues: `clear_calculator()` to revert to local engine
+
+### Emergency Response
+
+**Calculator unavailable:**
+```bash
+# Revert to local engine
+stellar contract invoke \
+  --id <policy-contract> \
+  --source-account <admin> \
+  -- clear_calculator
+```
+
+**Calculator paused:**
+```bash
+# Unpause calculator
+stellar contract invoke \
+  --id <calculator-contract> \
+  --source-account <calc-admin> \
+  -- set_paused --paused false
+```
+
+## References
+
+- Policy contract: `contracts/niffyinsure/src/calculator.rs`
+- Calculator contract: `contracts/premium_calculator/src/lib.rs`
+- Integration tests: `contracts/niffyinsure/tests/cross_contract.rs`
+- Soroban SDK: https://docs.rs/soroban-sdk/25.3.1

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -878,3 +878,27 @@ mod claim_status_history_tests {
         );
     }
 }
+
+/// Verify that `ClaimStatus::Appealed` is not treated as a terminal state,
+/// which would incorrectly allow `process_claim` / `finalize_claim` to close
+/// an in-flight appeal without resolving the appeal round.
+#[cfg(test)]
+mod appeal_stub_tests {
+    use crate::types::ClaimStatus;
+
+    #[test]
+    fn appealed_is_not_terminal() {
+        assert!(
+            !ClaimStatus::Appealed.is_terminal(),
+            "ClaimStatus::Appealed must NOT be terminal — an appeal in progress \
+             must not allow finalization or payout until the appeal round resolves"
+        );
+    }
+
+    #[test]
+    fn appeal_resolved_states_are_terminal() {
+        // Once an appeal resolves, both outcomes are terminal.
+        assert!(ClaimStatus::AppealApproved.is_terminal());
+        assert!(ClaimStatus::AppealRejected.is_terminal());
+    }
+}

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -188,6 +188,25 @@ impl NiffyInsure {
         premium::update_multiplier_table(&env, &new_table)
     }
 
+    /// Admin-only: update a single multiplier entry without redeploying the contract.
+    ///
+    /// Emits `PremiumMultiplierUpdated` with the key, old value, and new value.
+    /// Premium calculations use the updated value immediately after this call.
+    ///
+    /// # Bounds
+    /// - Region / Age / Coverage keys: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000)
+    /// - SafetyDiscount key: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+    pub fn admin_set_premium_multiplier(
+        env: Env,
+        key: types::MultiplierKey,
+        value: i128,
+    ) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        storage::bump_instance(&env);
+        premium::admin_set_premium_multiplier(&env, key, value)
+    }
+
     pub fn get_multiplier_table(env: Env) -> types::MultiplierTable {
         storage::get_multiplier_table(&env)
     }

--- a/contracts/niffyinsure/src/premium.rs
+++ b/contracts/niffyinsure/src/premium.rs
@@ -14,8 +14,8 @@ use crate::{
     premium_pure,
     storage,
     types::{
-        AgeBand, CoverageTier, MultiplierTable, PremiumQuoteLineItem, PremiumTableUpdated,
-        RegionTier, RiskInput,
+        AgeBand, CoverageTier, MultiplierKey, MultiplierTable, PremiumMultiplierUpdated,
+        PremiumQuoteLineItem, PremiumTableUpdated, RegionTier, RiskInput,
     },
     validate::Error,
 };
@@ -60,6 +60,81 @@ pub fn update_multiplier_table(env: &Env, new_table: &MultiplierTable) -> Result
     storage::set_multiplier_table(env, new_table);
     PremiumTableUpdated { version: new_table.version }.publish(env);
     Ok(())
+}
+
+/// Admin-only: update a single multiplier entry without redeploying the contract.
+///
+/// # Key format
+/// See [`MultiplierKey`] for the full key taxonomy and valid value ranges.
+///
+/// # Bounds
+/// - `Region`, `Age`, `Coverage` values: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000)
+/// - `SafetyDiscount` value: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+///
+/// # Emits
+/// [`PremiumMultiplierUpdated`] with `key`, `old_value`, and `new_value`.
+/// Premium calculations use the updated value immediately after this call.
+pub fn admin_set_premium_multiplier(
+    env: &Env,
+    key: MultiplierKey,
+    value: i128,
+) -> Result<(), Error> {
+    // Validate bounds before touching storage.
+    let old_value = validate_and_get_old(env, &key, value)?;
+
+    let mut table = storage::get_multiplier_table(env);
+
+    match key.clone() {
+        MultiplierKey::Region(tier) => {
+            table.region.set(tier, value);
+        }
+        MultiplierKey::Age(band) => {
+            table.age.set(band, value);
+        }
+        MultiplierKey::Coverage(tier) => {
+            table.coverage.set(tier, value);
+        }
+        MultiplierKey::SafetyDiscount => {
+            table.safety_discount = value;
+        }
+    }
+
+    storage::set_multiplier_table(env, &table);
+
+    PremiumMultiplierUpdated { key, old_value, new_value: value }.publish(env);
+
+    Ok(())
+}
+
+/// Validate the new value for `key` and return the current (old) value.
+fn validate_and_get_old(env: &Env, key: &MultiplierKey, value: i128) -> Result<i128, Error> {
+    let table = storage::get_multiplier_table(env);
+    match key {
+        MultiplierKey::Region(tier) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::RegionMultiplierOutOfBounds);
+            }
+            Ok(table.region.get(tier.clone()).unwrap_or(0))
+        }
+        MultiplierKey::Age(band) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::AgeMultiplierOutOfBounds);
+            }
+            Ok(table.age.get(band.clone()).unwrap_or(0))
+        }
+        MultiplierKey::Coverage(tier) => {
+            if !(MIN_MULTIPLIER..=MAX_MULTIPLIER).contains(&value) {
+                return Err(Error::CoverageMultiplierOutOfBounds);
+            }
+            Ok(table.coverage.get(tier.clone()).unwrap_or(0))
+        }
+        MultiplierKey::SafetyDiscount => {
+            if value < 0 || value > MAX_SAFETY_DISCOUNT {
+                return Err(Error::SafetyDiscountOutOfBounds);
+            }
+            Ok(table.safety_discount)
+        }
+    }
 }
 
 /// Delegate to `premium_pure::compute_premium` — no Env required for the math.

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -139,6 +139,41 @@ pub enum ClaimStatus {
     AppealRejected,
     /// Claimant withdrew before voting began; record kept for audit; no payout.
     Withdrawn,
+    /// RESERVED — appeal in progress; not yet implemented.
+    ///
+    /// This variant is declared to **reserve the discriminant** in the on-chain
+    /// ABI and prevent future contract upgrades from introducing a breaking enum
+    /// change.  No existing entrypoint constructs or transitions to this status;
+    /// it is purely a forward-compatibility placeholder.
+    ///
+    /// Default builds compile without any appeal logic executing — this variant
+    /// exists in the type system but is unreachable through any live code path
+    /// until the full appeal flow is implemented and audited.
+    ///
+    /// # Intended appeal flow (future implementation)
+    ///
+    /// ```text
+    /// Rejected → Appealed        (claimant calls open_appeal within APPEAL_OPEN_WINDOW_LEDGERS)
+    ///                             appeal vote runs for APPEAL_VOTE_WINDOW_LEDGERS
+    /// Appealed → AppealApproved  (majority approve or deadline plurality)
+    /// Appealed → AppealRejected  (majority reject or deadline plurality)
+    /// ```
+    ///
+    /// # Auto-deactivation interaction
+    ///
+    /// When `on_reject` fires and the policy strike count reaches
+    /// `STRIKE_DEACTIVATION_THRESHOLD`, auto-deactivation MUST be deferred
+    /// while the claim is `Appealed`.  Implement by checking
+    /// `env.ledger().sequence() > appeal_open_deadline_ledger` before writing
+    /// `is_active = false` to the policy.
+    ///
+    /// # is_terminal() contract
+    ///
+    /// `Appealed` is intentionally **not** a terminal state — the claim is
+    /// still in flight.  `is_terminal()` returns `false` for this variant so
+    /// that voting and finalization guards correctly reject further transitions
+    /// until the appeal round resolves.
+    Appealed,
 }
 
 impl ClaimStatus {
@@ -151,6 +186,10 @@ impl ClaimStatus {
                 | ClaimStatus::AppealApproved
                 | ClaimStatus::AppealRejected
                 | ClaimStatus::Withdrawn
+            // NOTE: ClaimStatus::Appealed is intentionally absent — an appeal
+            // in progress is NOT terminal.  Adding it here would allow
+            // process_claim / finalize_claim to close an appealed claim without
+            // resolving the appeal round, which would be incorrect.
         )
     }
 }

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -374,10 +374,40 @@ pub struct MultiplierTable {
     pub version: u32,
 }
 
+/// Identifies a single row in the multiplier table for granular admin updates.
+///
+/// # Key format
+/// - `Region(tier)` — one of `RegionTier::{Low, Medium, High}`
+/// - `Age(band)` — one of `AgeBand::{Young, Adult, Senior}`
+/// - `Coverage(tier)` — one of `CoverageTier::{Basic, Standard, Premium}`
+/// - `SafetyDiscount` — the flat discount applied when `safety_score > 0`
+///
+/// # Valid value ranges
+/// - `Region`, `Age`, `Coverage` entries: `MIN_MULTIPLIER..=MAX_MULTIPLIER` (5_000–20_000, scale 10_000 = 1×)
+/// - `SafetyDiscount`: `0..=MAX_SAFETY_DISCOUNT` (0–5_000)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MultiplierKey {
+    Region(RegionTier),
+    Age(AgeBand),
+    Coverage(CoverageTier),
+    SafetyDiscount,
+}
+
 #[contractevent(topics = ["niffyinsure", "premium_table_updated"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PremiumTableUpdated {
     pub version: u32,
+}
+
+/// Emitted by `admin_set_premium_multiplier` for each granular update.
+/// topics: ("niffyinsure", "premium_multiplier_updated")
+#[contractevent(topics = ["niffyinsure", "premium_multiplier_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PremiumMultiplierUpdated {
+    pub key: MultiplierKey,
+    pub old_value: i128,
+    pub new_value: i128,
 }
 
 #[contractevent(topics = ["niffyinsure", "claim_paid"])]

--- a/contracts/niffyinsure/tests/cross_contract.rs
+++ b/contracts/niffyinsure/tests/cross_contract.rs
@@ -248,3 +248,133 @@ fn calculator_rejects_zero_base_amount() {
     let result = calc_client.try_compute(&bad_input);
     assert!(result.is_err());
 }
+
+/// When calculator address points to an undeployed contract, generate_premium
+/// falls back to the local engine gracefully.
+#[test]
+fn undeployed_calculator_falls_back_to_local_engine() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (policy_client, _, _, _) = setup_policy_contract(&env);
+
+    // Point to a non-existent contract address (not deployed)
+    let fake_calc_addr = Address::generate(&env);
+    policy_client.set_calculator(&fake_calc_addr);
+    assert_eq!(policy_client.get_calculator(), Some(fake_calc_addr));
+
+    // generate_premium should still succeed using local fallback
+    let quote = policy_client.generate_premium(&standard_risk_input(), &10_000_000i128, &false);
+    assert_eq!(quote.total_premium, 10_000_000);
+}
+
+/// initiate_policy uses the cross-contract calculator when configured.
+#[test]
+fn initiate_policy_uses_cross_contract_calculator() {
+    use niffyinsure::types::{AgeBand, CoverageTier, InitiatePolicyOptions, PolicyType, RegionTier};
+    use soroban_sdk::token;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (policy_client, _, admin, token_addr) = setup_policy_contract(&env);
+    let (calc_client, calc_id, _) = setup_calculator(&env);
+
+    // Set up token balance and approval for premium payment
+    let holder = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let stellar_token = env.register_stellar_asset_contract_v2(issuer.clone()).address();
+    
+    // Re-initialize with stellar token for proper token operations
+    let new_contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let new_client = NiffyInsureClient::new(&env, &new_contract_id);
+    new_client.initialize(&admin, &stellar_token);
+    
+    // Mint tokens and approve
+    token::StellarAssetClient::new(&env, &stellar_token).mint(&holder, &100_000_000);
+    token::Client::new(&env, &stellar_token).approve(
+        &holder,
+        &new_client.address,
+        &100_000_000,
+        &(env.ledger().sequence() + 10_000),
+    );
+
+    // Configure calculator
+    new_client.set_calculator(&calc_id);
+
+    // Verify calculator returns expected premium
+    let direct_result = calc_client.compute(&standard_calc_input(10_000_000));
+    assert_eq!(direct_result.premium, 10_000_000);
+
+    // initiate_policy should use the calculator
+    let policy = new_client.initiate_policy(
+        &holder,
+        &PolicyType::Auto,
+        &RegionTier::Medium,
+        &AgeBand::Adult,
+        &CoverageTier::Standard,
+        &0u32, // safety_score
+        &10_000_000i128,
+        &stellar_token,
+        &InitiatePolicyOptions {
+            beneficiary: None,
+            deductible: None,
+            expected_nonce: None,
+        },
+    );
+
+    // Premium should match calculator output
+    assert_eq!(policy.premium, direct_result.premium);
+    assert_eq!(policy.coverage, 10_000_000);
+}
+
+/// When calculator is unavailable (not deployed), initiate_policy falls back
+/// to local engine gracefully.
+#[test]
+fn initiate_policy_fallback_when_calculator_not_deployed() {
+    use niffyinsure::types::{AgeBand, CoverageTier, InitiatePolicyOptions, PolicyType, RegionTier};
+    use soroban_sdk::token;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let stellar_token = env.register_stellar_asset_contract_v2(issuer.clone()).address();
+    
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    client.initialize(&admin, &stellar_token);
+    
+    let holder = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &stellar_token).mint(&holder, &100_000_000);
+    token::Client::new(&env, &stellar_token).approve(
+        &holder,
+        &client.address,
+        &100_000_000,
+        &(env.ledger().sequence() + 10_000),
+    );
+
+    // Point to undeployed calculator
+    let fake_calc_addr = Address::generate(&env);
+    client.set_calculator(&fake_calc_addr);
+
+    // initiate_policy should fall back to local engine
+    let policy = client.initiate_policy(
+        &holder,
+        &PolicyType::Auto,
+        &RegionTier::Medium,
+        &AgeBand::Adult,
+        &CoverageTier::Standard,
+        &0u32,
+        &10_000_000i128,
+        &stellar_token,
+        &InitiatePolicyOptions {
+            beneficiary: None,
+            deductible: None,
+            expected_nonce: None,
+        },
+    );
+
+    // Should succeed with local engine premium (Medium/Adult/Standard/0 = 10_000_000)
+    assert_eq!(policy.premium, 10_000_000);
+    assert_eq!(policy.coverage, 10_000_000);
+    assert!(policy.is_active);
+}

--- a/contracts/niffyinsure/tests/premium_table_tests.rs
+++ b/contracts/niffyinsure/tests/premium_table_tests.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use niffyinsure::{
-    premium::{compute_premium, default_multiplier_table},
-    types::{AgeBand, CoverageTier, RegionTier, RiskInput},
+    premium::{compute_premium, default_multiplier_table, admin_set_premium_multiplier, MAX_MULTIPLIER, MIN_MULTIPLIER, MAX_SAFETY_DISCOUNT},
+    types::{AgeBand, CoverageTier, MultiplierKey, RegionTier, RiskInput},
 };
 use soroban_sdk::Env;
 
@@ -48,4 +48,193 @@ fn default_table_matches_known_reference_vectors() {
         let computation = compute_premium(&input, base_amount, &table).unwrap();
         assert_eq!(computation.total_premium, expected_total);
     }
+}
+
+// ── admin_set_premium_multiplier tests ────────────────────────────────────────
+
+/// Helper: set up a contract env with admin + initialized multiplier table.
+fn setup_env_with_table() -> (Env, soroban_sdk::Address) {
+    use niffyinsure::storage;
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = soroban_sdk::Address::generate(&env);
+    storage::set_admin(&env, &admin);
+    storage::set_multiplier_table(&env, &default_multiplier_table(&env));
+    (env, admin)
+}
+
+#[test]
+fn valid_region_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    // Update High region from 13_500 → 15_000
+    admin_set_premium_multiplier(&env, MultiplierKey::Region(RegionTier::High), 15_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(
+        table.region.get(RegionTier::High).unwrap(),
+        15_000,
+        "region multiplier should be updated in storage"
+    );
+
+    // Premium calculation must use the new value immediately
+    let input = RiskInput {
+        region: RegionTier::High,
+        age_band: AgeBand::Adult,
+        coverage: CoverageTier::Standard,
+        safety_score: 0,
+    };
+    let computation = compute_premium(&input, 10_000_000, &table).unwrap();
+    // With High=15_000, Adult=10_000, Standard=10_000, safety_discount=2_000, score=0
+    // result = base * (15_000/10_000) * (10_000/10_000) * (10_000/10_000) = 15_000_000
+    assert_eq!(computation.total_premium, 15_000_000);
+}
+
+#[test]
+fn valid_age_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Age(AgeBand::Young), 11_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.age.get(AgeBand::Young).unwrap(), 11_000);
+}
+
+#[test]
+fn valid_coverage_multiplier_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Coverage(CoverageTier::Basic), 9_500)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.coverage.get(CoverageTier::Basic).unwrap(), 9_500);
+}
+
+#[test]
+fn valid_safety_discount_update_takes_effect_immediately() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, 3_000)
+        .expect("valid update should succeed");
+
+    let table = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(table.safety_discount, 3_000);
+}
+
+#[test]
+fn region_multiplier_above_max_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::Low),
+        MAX_MULTIPLIER + 1,
+    );
+    assert_eq!(
+        result,
+        Err(niffyinsure::validate::Error::RegionMultiplierOutOfBounds),
+        "value above MAX_MULTIPLIER must be rejected"
+    );
+}
+
+#[test]
+fn region_multiplier_below_min_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::Medium),
+        MIN_MULTIPLIER - 1,
+    );
+    assert_eq!(
+        result,
+        Err(niffyinsure::validate::Error::RegionMultiplierOutOfBounds),
+        "value below MIN_MULTIPLIER must be rejected"
+    );
+}
+
+#[test]
+fn age_multiplier_out_of_bounds_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Age(AgeBand::Senior),
+        MAX_MULTIPLIER + 500,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::AgeMultiplierOutOfBounds));
+}
+
+#[test]
+fn coverage_multiplier_out_of_bounds_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Coverage(CoverageTier::Premium),
+        MIN_MULTIPLIER - 1,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::CoverageMultiplierOutOfBounds));
+}
+
+#[test]
+fn safety_discount_above_max_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::SafetyDiscount,
+        MAX_SAFETY_DISCOUNT + 1,
+    );
+    assert_eq!(result, Err(niffyinsure::validate::Error::SafetyDiscountOutOfBounds));
+}
+
+#[test]
+fn safety_discount_negative_is_rejected() {
+    let (env, _admin) = setup_env_with_table();
+
+    let result = admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, -1);
+    assert_eq!(result, Err(niffyinsure::validate::Error::SafetyDiscountOutOfBounds));
+}
+
+#[test]
+fn boundary_values_at_min_and_max_are_accepted() {
+    let (env, _admin) = setup_env_with_table();
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Region(RegionTier::Low), MIN_MULTIPLIER)
+        .expect("MIN_MULTIPLIER should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::Age(AgeBand::Adult), MAX_MULTIPLIER)
+        .expect("MAX_MULTIPLIER should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, 0)
+        .expect("zero safety discount should be accepted");
+
+    admin_set_premium_multiplier(&env, MultiplierKey::SafetyDiscount, MAX_SAFETY_DISCOUNT)
+        .expect("MAX_SAFETY_DISCOUNT should be accepted");
+}
+
+#[test]
+fn storage_unchanged_after_out_of_bounds_rejection() {
+    let (env, _admin) = setup_env_with_table();
+
+    let table_before = niffyinsure::storage::get_multiplier_table(&env);
+    let original_high = table_before.region.get(RegionTier::High).unwrap();
+
+    // Attempt an invalid update
+    let _ = admin_set_premium_multiplier(
+        &env,
+        MultiplierKey::Region(RegionTier::High),
+        MAX_MULTIPLIER + 9999,
+    );
+
+    let table_after = niffyinsure::storage::get_multiplier_table(&env);
+    assert_eq!(
+        table_after.region.get(RegionTier::High).unwrap(),
+        original_high,
+        "storage must not be modified on rejection"
+    );
 }


### PR DESCRIPTION
Implements the cross-contract integration spec between niffyinsure and premium_calculator. Adds missing integration tests for the actual cross-contract call path, error handling for calculator unavailability, and a versioned interface document.
closes #408 