### PR TITLE
feat: notification preferences page at /settings/notifications

### DIFF
--- a/frontend/src/app/settings/notifications/__tests__/notifications-page.test.tsx
+++ b/frontend/src/app/settings/notifications/__tests__/notifications-page.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import NotificationsPage from '../page'
+import {
+  getNotificationPreferences,
+  patchNotificationPreferences,
+} from '@/lib/api/notifications'
+
+jest.mock('@/lib/api/notifications', () => ({
+  getNotificationPreferences: jest.fn(),
+  patchNotificationPreferences: jest.fn(),
+}))
+
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({ jwt: 'mock-jwt-token' }),
+}))
+
+jest.mock('@/hooks/use-wallet', () => ({
+  useWallet: () => ({ address: 'GABC123' }),
+}))
+
+const mockGet = getNotificationPreferences as jest.MockedFunction<typeof getNotificationPreferences>
+const mockPatch = patchNotificationPreferences as jest.MockedFunction<typeof patchNotificationPreferences>
+
+const defaultPrefs = {
+  renewalRemindersEnabled: true,
+  claimUpdatesEnabled: true,
+  voteRemindersEnabled: false,
+}
+
+describe('NotificationsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGet.mockResolvedValue(defaultPrefs)
+    mockPatch.mockResolvedValue(undefined)
+  })
+
+  it('fetches and shows current preferences on load', async () => {
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /policy renewal reminders/i })).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('switch', { name: /policy renewal reminders/i })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('switch', { name: /claim status updates/i })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('switch', { name: /vote reminders/i })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('renders all three notification toggles', async () => {
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /policy renewal reminders/i })).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('switch', { name: /claim status updates/i })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: /vote reminders/i })).toBeInTheDocument()
+  })
+
+  it('toggles a preference when clicking the switch', async () => {
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /vote reminders/i })).toBeInTheDocument()
+    })
+
+    const toggle = screen.getByRole('switch', { name: /vote reminders/i })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    await userEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('saves updated preferences and shows success confirmation', async () => {
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /vote reminders/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('switch', { name: /vote reminders/i }))
+    await userEvent.click(screen.getByRole('button', { name: /save preferences/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/preferences saved/i)).toBeInTheDocument()
+    })
+
+    expect(mockPatch).toHaveBeenCalledWith(
+      'GABC123',
+      { ...defaultPrefs, voteRemindersEnabled: true },
+      'mock-jwt-token',
+    )
+  })
+
+  it('shows inline error without resetting unsaved changes on API failure', async () => {
+    mockPatch.mockRejectedValueOnce(new Error('Network error'))
+
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /vote reminders/i })).toBeInTheDocument()
+    })
+
+    // Toggle vote reminders on
+    await userEvent.click(screen.getByRole('switch', { name: /vote reminders/i }))
+    expect(screen.getByRole('switch', { name: /vote reminders/i })).toHaveAttribute('aria-checked', 'true')
+
+    await userEvent.click(screen.getByRole('button', { name: /save preferences/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network error')
+    })
+
+    // Toggle state is preserved (unsaved changes not lost)
+    expect(screen.getByRole('switch', { name: /vote reminders/i })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows loading state while fetching', () => {
+    mockGet.mockImplementation(() => new Promise(() => {}))
+
+    render(<NotificationsPage />)
+    expect(screen.getByText(/loading preferences/i)).toBeInTheDocument()
+  })
+
+  it('shows fetch error when loading fails', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Failed to fetch'))
+
+    render(<NotificationsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to fetch')
+    })
+  })
+})

--- a/frontend/src/app/settings/notifications/page.tsx
+++ b/frontend/src/app/settings/notifications/page.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { Metadata } from 'next'
+import { CheckCircle, AlertCircle, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { useAuth } from '@/lib/hooks/useAuth'
+import { useWallet } from '@/hooks/use-wallet'
+import {
+  getNotificationPreferences,
+  patchNotificationPreferences,
+  type NotificationPreferences,
+} from '@/lib/api/notifications'
+
+// Metadata must be exported from a server component, but this page is 'use client'.
+// The title is set on the parent settings layout / page instead.
+
+interface ToggleRowProps {
+  id: string
+  label: string
+  description: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}
+
+function ToggleRow({ id, label, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-0.5">
+        <Label htmlFor={id} className="text-sm font-medium cursor-pointer">
+          {label}
+        </Label>
+        <p id={`${id}-desc`} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      <button
+        id={id}
+        role="switch"
+        aria-checked={checked}
+        aria-describedby={`${id}-desc`}
+        onClick={() => onChange(!checked)}
+        className={[
+          'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent',
+          'transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+          checked ? 'bg-primary' : 'bg-input',
+        ].join(' ')}
+      >
+        <span className="sr-only">{label}</span>
+        <span
+          aria-hidden="true"
+          className={[
+            'pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform',
+            checked ? 'translate-x-5' : 'translate-x-0',
+          ].join(' ')}
+        />
+      </button>
+    </div>
+  )
+}
+
+export default function NotificationsPage() {
+  const { jwt } = useAuth()
+  const { address } = useWallet()
+
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null)
+  const [draft, setDraft] = useState<NotificationPreferences | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!address || !jwt) {
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setFetchError(null)
+    getNotificationPreferences(address, jwt)
+      .then((p) => {
+        setPrefs(p)
+        setDraft(p)
+      })
+      .catch((err: unknown) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load preferences')
+      })
+      .finally(() => setLoading(false))
+  }, [address, jwt])
+
+  function handleToggle(key: keyof NotificationPreferences, value: boolean) {
+    setDraft((prev) => prev ? { ...prev, [key]: value } : prev)
+    // Reset save status when user makes changes
+    if (saveStatus === 'saved') setSaveStatus('idle')
+  }
+
+  async function handleSave() {
+    if (!address || !jwt || !draft) return
+    setSaveStatus('saving')
+    setSaveError(null)
+    try {
+      await patchNotificationPreferences(address, draft, jwt)
+      setPrefs(draft)
+      setSaveStatus('saved')
+    } catch (err: unknown) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save preferences')
+      setSaveStatus('error')
+    }
+  }
+
+  if (!address || !jwt) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <h1 className="mb-6 text-2xl font-semibold">Notification Preferences</h1>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground text-sm">
+            Connect your wallet to manage notification preferences.
+          </CardContent>
+        </Card>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-10">
+      <h1 className="mb-6 text-2xl font-semibold">Notification Preferences</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Alerts</CardTitle>
+          <CardDescription>
+            Choose which events trigger email and browser notifications.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {loading && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Loading preferences…
+            </div>
+          )}
+
+          {fetchError && (
+            <p className="flex items-center gap-1 text-sm text-destructive" role="alert">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
+              {fetchError}
+            </p>
+          )}
+
+          {!loading && !fetchError && draft && (
+            <>
+              <ToggleRow
+                id="renewal-reminders"
+                label="Policy renewal reminders"
+                description="Get notified before your policy expires."
+                checked={draft.renewalRemindersEnabled}
+                onChange={(v) => handleToggle('renewalRemindersEnabled', v)}
+              />
+              <ToggleRow
+                id="claim-updates"
+                label="Claim status updates"
+                description="Get notified when a claim you filed changes status."
+                checked={draft.claimUpdatesEnabled}
+                onChange={(v) => handleToggle('claimUpdatesEnabled', v)}
+              />
+              <ToggleRow
+                id="vote-reminders"
+                label="Vote reminders"
+                description="Get notified about active governance votes you haven't cast yet."
+                checked={draft.voteRemindersEnabled}
+                onChange={(v) => handleToggle('voteRemindersEnabled', v)}
+              />
+
+              <div className="flex items-center gap-3 pt-2">
+                <Button
+                  onClick={handleSave}
+                  disabled={saveStatus === 'saving'}
+                  aria-busy={saveStatus === 'saving'}
+                >
+                  {saveStatus === 'saving' ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      Saving…
+                    </>
+                  ) : (
+                    'Save preferences'
+                  )}
+                </Button>
+
+                {saveStatus === 'saved' && (
+                  <p className="flex items-center gap-1 text-sm text-green-600" role="status" aria-live="polite">
+                    <CheckCircle className="h-4 w-4" aria-hidden="true" />
+                    Preferences saved.
+                  </p>
+                )}
+
+                {saveStatus === 'error' && saveError && (
+                  <p className="flex items-center gap-1 text-sm text-destructive" role="alert">
+                    <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                    {saveError}
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/frontend/src/components/settings/settings-panel.tsx
+++ b/frontend/src/components/settings/settings-panel.tsx
@@ -154,6 +154,13 @@ export function SettingsPanel() {
             checked={settings.notifications.claimUpdatesEnabled}
             onChange={(v) => handleNotificationToggle('claimUpdatesEnabled', v)}
           />
+          <NotificationToggle
+            id="vote-reminders"
+            label="Vote reminders"
+            description="Get notified about active governance votes you haven't cast yet."
+            checked={settings.notifications.voteRemindersEnabled}
+            onChange={(v) => handleNotificationToggle('voteRemindersEnabled', v)}
+          />
           {syncing && (
             <p className="text-xs text-muted-foreground" aria-live="polite">Syncing preferences…</p>
           )}

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -4,6 +4,19 @@ import { getConfig } from '@/config/env'
 export interface NotificationPreferences {
   renewalRemindersEnabled: boolean
   claimUpdatesEnabled: boolean
+  voteRemindersEnabled: boolean
+}
+
+export async function getNotificationPreferences(
+  walletAddress: string,
+  jwt: string,
+): Promise<NotificationPreferences> {
+  const { apiUrl } = getConfig()
+  return apiFetch<NotificationPreferences>(`${apiUrl}/notifications/preferences/${walletAddress}`, {
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+    },
+  })
 }
 
 export async function patchNotificationPreferences(

--- a/frontend/src/lib/settings-store.ts
+++ b/frontend/src/lib/settings-store.ts
@@ -26,6 +26,7 @@ export interface AppSettings {
   notifications: {
     renewalRemindersEnabled: boolean
     claimUpdatesEnabled: boolean
+    voteRemindersEnabled: boolean
   }
 }
 
@@ -51,6 +52,7 @@ const DEFAULTS: AppSettings = {
   notifications: {
     renewalRemindersEnabled: true,
     claimUpdatesEnabled: true,
+    voteRemindersEnabled: true,
   },
 }
 


### PR DESCRIPTION
## Summary

- Create `/settings/notifications` dedicated page that fetches current preferences via `GET /notifications/preferences` on load
- Add `voteRemindersEnabled` to `NotificationPreferences` interface and `AppSettings`
- Render toggle controls for renewal reminders, claim updates, and vote reminders
- Explicit Save button shows confirmation on success and inline error (without losing unsaved toggle state) on failure
- Add unit tests covering initial load, toggle state, save flow, and API error handling

## Test plan

- [ ] `npm test` passes for `notifications-page.test.tsx`
- [ ] Toggles reflect API-fetched state on mount
- [ ] Save button updates preferences and shows "Preferences saved."
- [ ] API error shows inline message and preserves unsaved toggle changes

Closes #662