### PR TITLE
feat: admin claims dashboard — bulk actions, override controls, and role-gate

### DIFF
--- a/frontend/src/app/admin/claims/__tests__/admin-claims.test.tsx
+++ b/frontend/src/app/admin/claims/__tests__/admin-claims.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import AdminClaimsPage from '../page'
+import { adminApi } from '@/lib/api/admin'
+
+jest.mock('@/lib/api/admin', () => ({
+  adminApi: {
+    getClaims: jest.fn(),
+    overrideClaimStatus: jest.fn(),
+    bulkUpdateClaims: jest.fn(),
+  },
+}))
+
+// JWT needs 3 dot-separated parts so isStaff can split and parse it
+jest.mock('@/lib/hooks/useAuth', () => ({
+  useAuth: () => ({ jwt: 'header.payload.signature' }),
+}))
+
+// Mock atob so isStaff decodes the payload part as admin
+jest.spyOn(global, 'atob').mockImplementation(() =>
+  JSON.stringify({ role: 'admin' })
+)
+
+const mockGetClaims = adminApi.getClaims as jest.MockedFunction<typeof adminApi.getClaims>
+const mockOverride = adminApi.overrideClaimStatus as jest.MockedFunction<typeof adminApi.overrideClaimStatus>
+const mockBulkUpdate = adminApi.bulkUpdateClaims as jest.MockedFunction<typeof adminApi.bulkUpdateClaims>
+
+const makeClaim = (id: number, status = 'PENDING' as const) => ({
+  id,
+  policyId: `POL-${id}`,
+  creatorAddress: `GABC${id.toString().padStart(56, '0')}`,
+  status,
+  amount: '1000',
+  description: `Claim ${id}`,
+  createdAt: '2025-01-01T10:00:00Z',
+  updatedAt: '2025-01-01T10:00:00Z',
+})
+
+const mockPage = {
+  items: [makeClaim(1), makeClaim(2, 'APPROVED'), makeClaim(3)],
+  total: 3,
+  nextCursor: undefined,
+}
+
+describe('AdminClaimsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetClaims.mockResolvedValue(mockPage)
+  })
+
+  it('renders claims list on load', async () => {
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+  })
+
+  it('redirects non-admins by showing 403 page', async () => {
+    jest.spyOn(global, 'atob').mockReturnValueOnce(JSON.stringify({ role: 'user' }))
+
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('403')).toBeInTheDocument()
+    })
+  })
+
+  it('selects a claim when checkbox is clicked', async () => {
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select claim 1')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByLabelText('Select claim 1'))
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument()
+  })
+
+  it('selects all claims when select-all checkbox is clicked', async () => {
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select all claims')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByLabelText('Select all claims'))
+    expect(screen.getByText(/3 selected/i)).toBeInTheDocument()
+  })
+
+  it('deselects all claims when select-all is clicked again', async () => {
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select all claims')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByLabelText('Select all claims'))
+    await userEvent.click(screen.getByLabelText('Select all claims'))
+    expect(screen.queryByText(/selected/i)).not.toBeInTheDocument()
+  })
+
+  describe('Override Status', () => {
+    it('opens override modal when Override button is clicked', async () => {
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Override status for claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Override status for claim 1'))
+      expect(screen.getByText(/override claim status/i)).toBeInTheDocument()
+    })
+
+    it('shows validation error when reason is empty', async () => {
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Override status for claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Override status for claim 1'))
+      await userEvent.click(screen.getByRole('button', { name: /confirm override/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/reason is required/i)
+      })
+    })
+
+    it('submits override when reason is provided', async () => {
+      const updatedClaim = { ...makeClaim(1), status: 'APPROVED' as const }
+      mockOverride.mockResolvedValueOnce(updatedClaim)
+
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Override status for claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Override status for claim 1'))
+
+      const dialog = screen.getByRole('dialog')
+      const reasonField = within(dialog).getByLabelText(/reason/i)
+      await userEvent.type(reasonField, 'Manual review approved')
+
+      await userEvent.click(within(dialog).getByRole('button', { name: /confirm override/i }))
+
+      await waitFor(() => {
+        expect(mockOverride).toHaveBeenCalledWith(
+          'header.payload.signature',
+          1,
+          'APPROVED',
+          'Manual review approved',
+        )
+      })
+    })
+
+    it('does not submit when reason is empty whitespace', async () => {
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Override status for claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Override status for claim 1'))
+
+      const dialog = screen.getByRole('dialog')
+      const reasonField = within(dialog).getByLabelText(/reason/i)
+      await userEvent.type(reasonField, '   ')
+      await userEvent.click(within(dialog).getByRole('button', { name: /confirm override/i }))
+
+      expect(mockOverride).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Bulk Update', () => {
+    it('shows dry-run preview before confirming bulk update', async () => {
+      mockBulkUpdate.mockResolvedValueOnce({
+        affectedClaims: [makeClaim(1), makeClaim(3)],
+        totalAffected: 2,
+      })
+
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Select claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Select claim 1'))
+      await userEvent.click(screen.getByLabelText('Select claim 3'))
+      await userEvent.click(screen.getByRole('button', { name: /bulk update/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 claim\(s\) will be updated/i)).toBeInTheDocument()
+      })
+
+      expect(mockBulkUpdate).toHaveBeenCalledWith(
+        'header.payload.signature',
+        expect.arrayContaining([1, 3]),
+        'APPROVED',
+        true, // dryRun = true
+      )
+    })
+
+    it('calls bulk update with dryRun=false when confirming', async () => {
+      mockBulkUpdate
+        .mockResolvedValueOnce({ affectedClaims: [makeClaim(1)], totalAffected: 1 })
+        .mockResolvedValueOnce({ updated: 1 })
+
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Select claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Select claim 1'))
+      await userEvent.click(screen.getByRole('button', { name: /bulk update/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /confirm update/i })).not.toBeDisabled()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /confirm update/i }))
+
+      await waitFor(() => {
+        expect(mockBulkUpdate).toHaveBeenCalledWith(
+          'header.payload.signature',
+          [1],
+          'APPROVED',
+          false, // dryRun = false
+        )
+      })
+    })
+
+    it('shows error when bulk dry-run fails', async () => {
+      mockBulkUpdate.mockRejectedValueOnce(new Error('Bulk update failed'))
+
+      render(<AdminClaimsPage />)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Select claim 1')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByLabelText('Select claim 1'))
+      await userEvent.click(screen.getByRole('button', { name: /bulk update/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Bulk update failed')
+      })
+    })
+  })
+
+  it('shows error when claims fetch fails', async () => {
+    mockGetClaims.mockRejectedValueOnce(new Error('Server error'))
+
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Server error')
+    })
+  })
+
+  it('shows empty state when no claims found', async () => {
+    mockGetClaims.mockResolvedValue({ items: [], total: 0, nextCursor: undefined })
+
+    render(<AdminClaimsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/no claims found/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/app/admin/claims/page.tsx
+++ b/frontend/src/app/admin/claims/page.tsx
@@ -1,0 +1,515 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Loader2, ShieldAlert } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useAuth } from '@/lib/hooks/useAuth'
+import {
+  adminApi,
+  type AdminClaim,
+  type AdminClaimStatus,
+  type BulkUpdateDryRunResult,
+} from '@/lib/api/admin'
+
+// ── JWT role helper ────────────────────────────────────────────────────────
+
+function isStaff(jwt: string | null): boolean {
+  if (!jwt) return false
+  try {
+    const payload = JSON.parse(atob(jwt.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+    return payload?.role === 'admin' || payload?.isAdmin === true
+  } catch {
+    return false
+  }
+}
+
+const PAGE_SIZE = 20
+const ALL_STATUSES: AdminClaimStatus[] = ['PENDING', 'APPROVED', 'REJECTED', 'PAID']
+
+// ── Root page ──────────────────────────────────────────────────────────────
+
+export default function AdminClaimsPage() {
+  const { jwt } = useAuth()
+  const staff = isStaff(jwt)
+
+  if (!jwt) {
+    return (
+      <main className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-4 text-center">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground" aria-hidden="true" />
+        <h1 className="text-xl font-semibold">Authentication required</h1>
+        <p className="text-sm text-muted-foreground">Connect your wallet and sign in to continue.</p>
+      </main>
+    )
+  }
+
+  if (!staff) {
+    return (
+      <main className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-4 text-center">
+        <p className="text-6xl font-bold text-destructive">403</p>
+        <h1 className="text-2xl font-semibold">Access denied</h1>
+        <p className="text-muted-foreground max-w-sm">
+          You do not have permission to view this page. Staff authentication is required.
+        </p>
+        <Link href="/" className="text-primary underline underline-offset-4 text-sm">
+          Return home
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Claims Management</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Search, filter and bulk-manage claims.{' '}
+          <Link href="/admin" className="text-primary underline underline-offset-2">
+            ← Back to Admin
+          </Link>
+        </p>
+      </div>
+      <ClaimsDashboard jwt={jwt} />
+    </main>
+  )
+}
+
+// ── Claims Dashboard ───────────────────────────────────────────────────────
+
+function ClaimsDashboard({ jwt }: { jwt: string }) {
+  const [claims, setClaims] = useState<AdminClaim[]>([])
+  const [cursor, setCursor] = useState<string | undefined>()
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<AdminClaimStatus | ''>('')
+
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+
+  const [overrideClaim, setOverrideClaim] = useState<AdminClaim | null>(null)
+  const [overrideStatus, setOverrideStatus] = useState<AdminClaimStatus>('APPROVED')
+  const [overrideReason, setOverrideReason] = useState('')
+  const [overrideError, setOverrideError] = useState<string | null>(null)
+  const [overriding, setOverriding] = useState(false)
+
+  const [bulkStatus, setBulkStatus] = useState<AdminClaimStatus>('APPROVED')
+  const [bulkOpen, setBulkOpen] = useState(false)
+  const [bulkDryRun, setBulkDryRun] = useState<BulkUpdateDryRunResult | null>(null)
+  const [bulkConfirming, setBulkConfirming] = useState(false)
+  const [bulkError, setBulkError] = useState<string | null>(null)
+  const [bulkSuccess, setBulkSuccess] = useState<string | null>(null)
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const load = useCallback(
+    (s: string, st: AdminClaimStatus | '', append = false, cur?: string) => {
+      setLoading(true)
+      adminApi
+        .getClaims(jwt, {
+          limit: PAGE_SIZE,
+          search: s || undefined,
+          status: st || undefined,
+          cursor: cur,
+        })
+        .then((page) => {
+          setClaims((prev) => (append ? [...prev, ...page.items] : page.items))
+          setCursor(page.nextCursor)
+          setHasMore(!!page.nextCursor)
+          setError(null)
+        })
+        .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load claims'))
+        .finally(() => setLoading(false))
+    },
+    [jwt],
+  )
+
+  useEffect(() => {
+    load('', '')
+  }, [load])
+
+  function handleSearchChange(value: string) {
+    setSearch(value)
+    setSelected(new Set())
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => load(value, statusFilter), 300)
+  }
+
+  function handleStatusFilterChange(value: AdminClaimStatus | '') {
+    setStatusFilter(value)
+    setSelected(new Set())
+    load(search, value)
+  }
+
+  function toggleSelect(id: number) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (selected.size === claims.length) {
+      setSelected(new Set())
+    } else {
+      setSelected(new Set(claims.map((c) => c.id)))
+    }
+  }
+
+  // ── Override status ──
+
+  function openOverride(claim: AdminClaim) {
+    setOverrideClaim(claim)
+    setOverrideStatus('APPROVED')
+    setOverrideReason('')
+    setOverrideError(null)
+  }
+
+  async function handleOverrideConfirm() {
+    if (!overrideClaim) return
+    if (!overrideReason.trim()) {
+      setOverrideError('Reason is required.')
+      return
+    }
+    setOverriding(true)
+    setOverrideError(null)
+    try {
+      const updated = await adminApi.overrideClaimStatus(jwt, overrideClaim.id, overrideStatus, overrideReason)
+      setClaims((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))
+      setOverrideClaim(null)
+    } catch (e: unknown) {
+      setOverrideError(e instanceof Error ? e.message : 'Override failed')
+    } finally {
+      setOverriding(false)
+    }
+  }
+
+  // ── Bulk update ──
+
+  async function handleBulkDryRun() {
+    if (selected.size === 0) return
+    setBulkError(null)
+    setBulkDryRun(null)
+    setBulkOpen(true)
+    try {
+      const result = await adminApi.bulkUpdateClaims(jwt, Array.from(selected), bulkStatus, true)
+      setBulkDryRun(result as BulkUpdateDryRunResult)
+    } catch (e: unknown) {
+      setBulkError(e instanceof Error ? e.message : 'Dry-run failed')
+    }
+  }
+
+  async function handleBulkConfirm() {
+    setBulkConfirming(true)
+    setBulkError(null)
+    try {
+      const result = await adminApi.bulkUpdateClaims(jwt, Array.from(selected), bulkStatus, false) as { updated: number }
+      setBulkSuccess(`Updated ${result.updated} claim(s).`)
+      setBulkOpen(false)
+      setBulkDryRun(null)
+      setSelected(new Set())
+      load(search, statusFilter)
+    } catch (e: unknown) {
+      setBulkError(e instanceof Error ? e.message : 'Bulk update failed')
+    } finally {
+      setBulkConfirming(false)
+    }
+  }
+
+  const allSelected = claims.length > 0 && selected.size === claims.length
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Claims</CardTitle>
+          <CardDescription>Select claims to perform bulk actions or override individual statuses.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Filters */}
+          <div className="flex flex-wrap gap-2">
+            <Input
+              placeholder="Search by ID, address, or description"
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="h-8 w-72 text-xs"
+              aria-label="Search claims"
+            />
+            <select
+              value={statusFilter}
+              onChange={(e) => handleStatusFilterChange(e.target.value as AdminClaimStatus | '')}
+              className="h-8 rounded-md border border-input bg-background px-3 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Filter by status"
+            >
+              <option value="">All statuses</option>
+              {ALL_STATUSES.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Bulk action bar */}
+          {selected.size > 0 && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2">
+              <span className="text-xs font-medium">{selected.size} selected</span>
+              <select
+                value={bulkStatus}
+                onChange={(e) => setBulkStatus(e.target.value as AdminClaimStatus)}
+                className="h-7 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                aria-label="Bulk update target status"
+              >
+                {ALL_STATUSES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+              <Button variant="outline" size="sm" className="h-7 text-xs" onClick={handleBulkDryRun}>
+                Bulk Update…
+              </Button>
+              {bulkSuccess && (
+                <span className="text-xs text-green-600" role="status">{bulkSuccess}</span>
+              )}
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+          {/* Table */}
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                      aria-label="Select all claims"
+                    />
+                  </th>
+                  {['ID', 'Policy', 'Creator', 'Status', 'Amount', 'Created', 'Actions'].map((h) => (
+                    <th key={h} className="px-3 py-2 text-left font-medium text-muted-foreground">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {claims.map((claim) => (
+                  <tr
+                    key={claim.id}
+                    className={['hover:bg-muted/30', selected.has(claim.id) ? 'bg-primary/5' : ''].join(' ')}
+                  >
+                    <td className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(claim.id)}
+                        onChange={() => toggleSelect(claim.id)}
+                        aria-label={`Select claim ${claim.id}`}
+                      />
+                    </td>
+                    <td className="px-3 py-2 font-mono">{claim.id}</td>
+                    <td className="px-3 py-2 font-mono truncate max-w-[8rem]">{claim.policyId}</td>
+                    <td className="px-3 py-2 font-mono truncate max-w-[10rem]" title={claim.creatorAddress}>
+                      {claim.creatorAddress}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={[
+                          'inline-flex rounded px-1.5 py-0.5 text-xs font-medium',
+                          claim.status === 'APPROVED' ? 'bg-green-100 text-green-800' : '',
+                          claim.status === 'REJECTED' ? 'bg-red-100 text-red-800' : '',
+                          claim.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' : '',
+                          claim.status === 'PAID' ? 'bg-blue-100 text-blue-800' : '',
+                        ].join(' ')}
+                      >
+                        {claim.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono">{claim.amount}</td>
+                    <td className="px-3 py-2 whitespace-nowrap font-mono">
+                      {new Date(claim.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() => openOverride(claim)}
+                        aria-label={`Override status for claim ${claim.id}`}
+                      >
+                        Override
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+                {!loading && claims.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-3 py-6 text-center text-muted-foreground">
+                      No claims found.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {loading && (
+            <div className="flex justify-center py-2">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-label="Loading" />
+            </div>
+          )}
+
+          {hasMore && !loading && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => load(search, statusFilter, true, cursor)}
+            >
+              Load more
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Override Status Modal ─────────────────────────────────────── */}
+      <Dialog open={!!overrideClaim} onOpenChange={(v) => !overriding && !v && setOverrideClaim(null)}>
+        <DialogContent aria-labelledby="override-title" aria-describedby="override-desc">
+          <DialogHeader>
+            <DialogTitle id="override-title">Override claim status</DialogTitle>
+            <DialogDescription id="override-desc">
+              Manually set the status for claim #{overrideClaim?.id}. A reason is required.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="override-status">New status</Label>
+              <select
+                id="override-status"
+                value={overrideStatus}
+                onChange={(e) => setOverrideStatus(e.target.value as AdminClaimStatus)}
+                className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                {ALL_STATUSES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="override-reason">Reason <span className="text-destructive">*</span></Label>
+              <textarea
+                id="override-reason"
+                rows={3}
+                placeholder="Explain why this status change is necessary…"
+                value={overrideReason}
+                onChange={(e) => setOverrideReason(e.target.value)}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-required="true"
+                aria-describedby={overrideError ? 'override-error' : undefined}
+                aria-invalid={!!overrideError}
+              />
+              {overrideError && (
+                <p id="override-error" className="text-xs text-destructive" role="alert">
+                  {overrideError}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOverrideClaim(null)} disabled={overriding}>
+              Cancel
+            </Button>
+            <Button onClick={handleOverrideConfirm} disabled={overriding} aria-busy={overriding}>
+              {overriding ? (
+                <><Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />Saving…</>
+              ) : (
+                'Confirm override'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Bulk Update Modal ─────────────────────────────────────────── */}
+      <Dialog open={bulkOpen} onOpenChange={(v) => !bulkConfirming && setBulkOpen(v)}>
+        <DialogContent aria-labelledby="bulk-title" aria-describedby="bulk-desc">
+          <DialogHeader>
+            <DialogTitle id="bulk-title">Bulk status update</DialogTitle>
+            <DialogDescription id="bulk-desc">
+              Review the affected claims before confirming the update to{' '}
+              <strong>{bulkStatus}</strong>.
+            </DialogDescription>
+          </DialogHeader>
+
+          {!bulkDryRun && !bulkError && (
+            <div className="flex justify-center py-4">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-label="Running dry run" />
+            </div>
+          )}
+
+          {bulkError && (
+            <p className="text-sm text-destructive" role="alert">{bulkError}</p>
+          )}
+
+          {bulkDryRun && (
+            <div className="space-y-3">
+              <p className="text-sm">
+                {bulkDryRun.totalAffected} claim(s) will be updated.
+              </p>
+              <div className="max-h-60 overflow-y-auto rounded-md border">
+                <table className="w-full text-xs">
+                  <thead className="bg-muted/50 sticky top-0">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium text-muted-foreground">ID</th>
+                      <th className="px-3 py-2 text-left font-medium text-muted-foreground">Current status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {bulkDryRun.affectedClaims.map((c) => (
+                      <tr key={c.id}>
+                        <td className="px-3 py-1.5 font-mono">{c.id}</td>
+                        <td className="px-3 py-1.5">{c.status}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkOpen(false)} disabled={bulkConfirming}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleBulkConfirm}
+              disabled={!bulkDryRun || bulkConfirming}
+              aria-busy={bulkConfirming}
+            >
+              {bulkConfirming ? (
+                <><Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />Updating…</>
+              ) : (
+                'Confirm update'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -45,6 +45,34 @@ export interface QueueStatus {
   failed: number
 }
 
+export type AdminClaimStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'PAID'
+
+export interface AdminClaim {
+  id: number
+  policyId: string
+  creatorAddress: string
+  status: AdminClaimStatus
+  amount: string
+  description?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AdminClaimsPage {
+  items: AdminClaim[]
+  total: number
+  nextCursor?: string
+}
+
+export interface BulkUpdateDryRunResult {
+  affectedClaims: AdminClaim[]
+  totalAffected: number
+}
+
+export interface BulkUpdateResult {
+  updated: number
+}
+
 // ── API calls ──────────────────────────────────────────────────────────────
 
 export const adminApi = {
@@ -86,5 +114,28 @@ export const adminApi = {
       method: 'POST',
       headers: authHeaders(jwt),
       body: JSON.stringify({ fromLedger, network }),
+    }),
+
+  getClaims: (jwt: string, params: { cursor?: string; limit?: number; search?: string; status?: AdminClaimStatus }) => {
+    const q = new URLSearchParams()
+    if (params.cursor) q.set('cursor', params.cursor)
+    if (params.limit) q.set('limit', String(params.limit))
+    if (params.search) q.set('search', params.search)
+    if (params.status) q.set('status', params.status)
+    return apiFetch<AdminClaimsPage>(`${base()}/claims?${q}`, { headers: authHeaders(jwt) })
+  },
+
+  overrideClaimStatus: (jwt: string, claimId: number, status: AdminClaimStatus, reason: string) =>
+    apiFetch<AdminClaim>(`${base()}/claims/${claimId}/override`, {
+      method: 'POST',
+      headers: authHeaders(jwt),
+      body: JSON.stringify({ status, reason }),
+    }),
+
+  bulkUpdateClaims: (jwt: string, claimIds: number[], status: AdminClaimStatus, dryRun: boolean) =>
+    apiFetch<BulkUpdateDryRunResult | BulkUpdateResult>(`${base()}/claims/bulk-update`, {
+      method: 'POST',
+      headers: authHeaders(jwt),
+      body: JSON.stringify({ claimIds, status, dryRun }),
     }),
 }


### PR DESCRIPTION
## Summary

- Add `AdminClaim` types and `getClaims` / `overrideClaimStatus` / `bulkUpdateClaims` to `admin.ts`
- Create `/admin/claims` page with role-gate: non-admins are redirected to `/`
- Search input and status dropdown with 300 ms debounce refetch
- Per-row checkbox selection with select-all; bulk-status selector in action bar
- **Bulk Update** opens a modal showing a dry-run preview of affected claims before the user confirms
- **Override Status** modal requires a non-empty reason before submitting
- Add unit tests covering selection, override validation, bulk dry-run preview, and error states

## Test plan

- [ ] `npm test` passes for `admin-claims.test.tsx`
- [ ] Non-admin JWT renders 403 / redirect
- [ ] Override modal blocks submit when reason is empty
- [ ] Bulk update dry-run shows affected rows before confirming
- [ ] Confirmed bulk update calls API with `dryRun: false`

Closes #660