### PR TITLE
feat(claims): add POST /claims/evidence/upload endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -124,6 +124,16 @@ IPFS_PROJECT_ID=
 # [optional] Legacy IPFS project secret kept for compatibility. Store in a secrets manager.
 IPFS_PROJECT_SECRET=
 
+# Evidence uploads
+# [optional] Maximum allowed claim evidence file size in bytes. Defaults to 10485760 (10 MB).
+EVIDENCE_MAX_BYTES=10485760
+
+# [optional] Maximum evidence uploads per wallet per rate-limit window.
+EVIDENCE_UPLOAD_RATE_LIMIT=5
+
+# [optional] Evidence upload rate-limit window in seconds.
+EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS=3600
+
 # Auth
 # [required] HMAC signing secret for user/admin JWTs. Rotate independently per environment. Store in a secrets manager.
 JWT_SECRET=replace-with-64-byte-base64url-key

--- a/backend/src/claims/__tests__/evidence-upload.spec.ts
+++ b/backend/src/claims/__tests__/evidence-upload.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * Integration tests for POST /claims/evidence/upload
+ *
+ * Covers: success (PDF, PNG, JPEG), invalid MIME, oversized, rate-limited,
+ * unauthenticated, and no-file cases.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import request from 'supertest';
+import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule } from '@nestjs/throttler';
+// Inline file shape matching multer's Express.Multer.File
+interface MulterFile {
+  fieldname: string;
+  originalname: string;
+  encoding: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+  stream: never;
+  destination: string;
+  filename: string;
+  path: string;
+}
+import { ClaimsController } from '../claims.controller';
+import { EvidenceUploadService } from '../services/evidence-upload.service';
+import { ClaimsService } from '../claims.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RateLimitGuard } from '../../rate-limit/rate-limit.guard';
+import { EVIDENCE_MAX_BYTES_DEFAULT } from '../dto/evidence-upload.dto';
+
+// ── Minimal valid file buffers ────────────────────────────────────────────
+
+const PNG_BUFFER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+  0x54, 0x08, 0xd7, 0x63, 0xf8, 0xff, 0xff, 0x3f,
+  0x00, 0x05, 0xfe, 0x02, 0xfe, 0xa3, 0x56, 0xeb,
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+const JPEG_BUFFER = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+]);
+
+const PDF_BUFFER = Buffer.from(
+  '%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\nxref\n0 2\ntrailer\n<< /Size 2 /Root 1 0 R >>\nstartxref\n9\n%%EOF',
+);
+
+// ── Mock services ─────────────────────────────────────────────────────────
+
+const MOCK_CID = 'QmTestCid1234567890abcdef1234567890abcdef12345678';
+const MOCK_GATEWAY = `https://ipfs.io/ipfs/${MOCK_CID}`;
+
+const mockEvidenceUploadService = {
+  upload: jest.fn().mockResolvedValue({ cid: MOCK_CID, gatewayUrl: MOCK_GATEWAY }),
+};
+
+const mockClaimsService = {
+  listClaims: jest.fn(),
+  getClaimById: jest.fn(),
+  buildTransaction: jest.fn(),
+  submitTransaction: jest.fn(),
+  getClaimStatuses: jest.fn(),
+  subscribeToStatusChanges: jest.fn(),
+  getClaimsNeedingVote: jest.fn(),
+};
+
+// ── Test app factory ──────────────────────────────────────────────────────
+
+type GuardOverride = { canActivate: (ctx: import('@nestjs/common').ExecutionContext) => boolean };
+
+async function buildApp(jwtGuardOverride?: GuardOverride): Promise<INestApplication> {
+  const builder = Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot({ isGlobal: true }),
+      ThrottlerModule.forRoot([{ name: 'default', ttl: 60_000, limit: 100 }]),
+    ],
+    controllers: [ClaimsController],
+    providers: [
+      { provide: EvidenceUploadService, useValue: mockEvidenceUploadService },
+      { provide: ClaimsService, useValue: mockClaimsService },
+    ],
+  });
+
+  if (jwtGuardOverride) {
+    builder.overrideGuard(JwtAuthGuard).useValue(jwtGuardOverride);
+  }
+  builder.overrideGuard(RateLimitGuard).useValue({ canActivate: () => true });
+
+  const module: TestingModule = await builder.compile();
+  const app = module.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  await app.init();
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('POST /claims/evidence/upload', () => {
+  let app: INestApplication;
+
+  const authGuard: GuardOverride = {
+    canActivate: (ctx) => {
+      ctx.switchToHttp().getRequest().user = { walletAddress: 'GTEST123WALLET' };
+      return true;
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    app = await buildApp(authGuard);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns { cid, gatewayUrl } for a valid PNG upload', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', PNG_BUFFER, { filename: 'evidence.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ cid: MOCK_CID, gatewayUrl: MOCK_GATEWAY });
+    expect(mockEvidenceUploadService.upload).toHaveBeenCalledTimes(1);
+    const [file, wallet] = mockEvidenceUploadService.upload.mock.calls[0] as [MulterFile, string];
+    expect(file.mimetype).toBe('image/png');
+    expect(wallet).toBe('GTEST123WALLET');
+  });
+
+  it('returns { cid, gatewayUrl } for a valid JPEG upload', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', JPEG_BUFFER, { filename: 'photo.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('cid', MOCK_CID);
+    expect(res.body).toHaveProperty('gatewayUrl', MOCK_GATEWAY);
+  });
+
+  it('returns { cid, gatewayUrl } for a valid PDF upload', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', PDF_BUFFER, { filename: 'claim.pdf', contentType: 'application/pdf' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('cid', MOCK_CID);
+  });
+
+  it('returns 400 when no file is provided', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .set('Content-Type', 'multipart/form-data');
+
+    expect(res.status).toBe(400);
+    expect(mockEvidenceUploadService.upload).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an unsupported MIME type and does not pin content', async () => {
+    mockEvidenceUploadService.upload.mockRejectedValueOnce(
+      new BadRequestException('Unsupported file type "image/gif"'),
+    );
+
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', Buffer.from('GIF89a'), { filename: 'anim.gif', contentType: 'image/gif' });
+
+    expect([400, 500]).toContain(res.status);
+  });
+
+  it('returns 400 for an oversized file and does not pin content', async () => {
+    mockEvidenceUploadService.upload.mockRejectedValueOnce(
+      new BadRequestException(`File exceeds maximum size of ${EVIDENCE_MAX_BYTES_DEFAULT} bytes`),
+    );
+
+    const oversized = Buffer.alloc(100, 0x00);
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', oversized, { filename: 'big.pdf', contentType: 'application/pdf' });
+
+    expect([400, 413]).toContain(res.status);
+  });
+
+  it('returns 429 when the wallet rate limit is exceeded', async () => {
+    mockEvidenceUploadService.upload.mockRejectedValueOnce(
+      new HttpException('Upload rate limit exceeded. Retry after 3600s', HttpStatus.TOO_MANY_REQUESTS),
+    );
+
+    const res = await request(app.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', PNG_BUFFER, { filename: 'evidence.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(429);
+    expect(mockEvidenceUploadService.upload).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 when the request is unauthenticated', async () => {
+    const { UnauthorizedException } = await import('@nestjs/common');
+    const unauthApp = await buildApp({
+      canActivate: () => { throw new UnauthorizedException(); },
+    });
+    const res = await request(unauthApp.getHttpServer())
+      .post('/claims/evidence/upload')
+      .attach('file', PNG_BUFFER, { filename: 'evidence.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(401);
+    await unauthApp.close();
+  });
+});
+
+// ── Unit tests for EvidenceUploadService ─────────────────────────────────
+
+describe('EvidenceUploadService (unit)', () => {
+  let service: EvidenceUploadService;
+
+  const mockIpfs = {
+    upload: jest.fn().mockResolvedValue({ cid: MOCK_CID, gatewayUrls: [MOCK_GATEWAY] }),
+  };
+  const mockAudit = { write: jest.fn().mockResolvedValue(undefined) };
+  const mockRateLimit = {
+    checkWalletEvidenceLimit: jest.fn().mockResolvedValue({ allowed: true, retryAfterSeconds: 0 }),
+  };
+  const mockConfig = { get: jest.fn((_key: string, def: unknown) => def) };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new EvidenceUploadService(
+      mockIpfs as never,
+      mockAudit as never,
+      mockRateLimit as never,
+      mockConfig as never,
+    );
+  });
+
+  function makeFile(overrides: Partial<MulterFile> = {}): MulterFile {
+    return {
+      fieldname: 'file',
+      originalname: 'evidence.png',
+      encoding: '7bit',
+      mimetype: 'image/png',
+      buffer: PNG_BUFFER,
+      size: PNG_BUFFER.length,
+      stream: null as never,
+      destination: '',
+      filename: '',
+      path: '',
+      ...overrides,
+    };
+  }
+
+  it('returns cid and gatewayUrl on success', async () => {
+    const result = await service.upload(makeFile(), 'GWALLET');
+    expect(result).toEqual({ cid: MOCK_CID, gatewayUrl: MOCK_GATEWAY });
+    expect(mockIpfs.upload).toHaveBeenCalledTimes(1);
+    expect(mockAudit.write).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'evidence_upload_success', actor: 'GWALLET' }),
+    );
+  });
+
+  it('throws 400 for unsupported MIME type without calling IPFS', async () => {
+    await expect(
+      service.upload(makeFile({ mimetype: 'image/gif' }), 'GWALLET'),
+    ).rejects.toThrow(BadRequestException);
+    expect(mockIpfs.upload).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 for oversized file without calling IPFS', async () => {
+    const bigFile = makeFile({ size: EVIDENCE_MAX_BYTES_DEFAULT + 1, buffer: Buffer.alloc(EVIDENCE_MAX_BYTES_DEFAULT + 1) });
+    await expect(service.upload(bigFile, 'GWALLET')).rejects.toThrow(BadRequestException);
+    expect(mockIpfs.upload).not.toHaveBeenCalled();
+  });
+
+  it('throws 429 when rate limit is exceeded without calling IPFS', async () => {
+    mockRateLimit.checkWalletEvidenceLimit.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 3600 });
+    await expect(service.upload(makeFile(), 'GWALLET')).rejects.toThrow(HttpException);
+    expect(mockIpfs.upload).not.toHaveBeenCalled();
+    expect(mockAudit.write).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'evidence_upload_rate_limited' }),
+    );
+  });
+
+  it('throws 400 for dangerous file extension', async () => {
+    await expect(
+      service.upload(makeFile({ originalname: 'script.exe', mimetype: 'application/pdf' }), 'GWALLET'),
+    ).rejects.toThrow(BadRequestException);
+    expect(mockIpfs.upload).not.toHaveBeenCalled();
+  });
+
+  it('does not propagate audit write failures', async () => {
+    mockAudit.write.mockRejectedValueOnce(new Error('DB down'));
+    const result = await service.upload(makeFile(), 'GWALLET');
+    expect(result.cid).toBe(MOCK_CID);
+  });
+});

--- a/backend/src/claims/claims.controller.ts
+++ b/backend/src/claims/claims.controller.ts
@@ -12,13 +12,18 @@ import {
   Body,
   Res,
   BadRequestException,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
   ApiQuery,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
@@ -26,6 +31,8 @@ import { ClaimsService } from './claims.service';
 import { ClaimsListResponseDto, ClaimDetailResponseDto } from './dto/claim.dto';
 import { BuildClaimTransactionDto } from './dto/build-claim-transaction.dto';
 import { SubmitTransactionDto } from './dto/submit-transaction.dto';
+import { EvidenceUploadService } from './services/evidence-upload.service';
+import { EVIDENCE_MAX_BYTES_DEFAULT } from './dto/evidence-upload.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { WalletAddress } from '../auth/decorators/wallet-address.decorator';
 import { RateLimitGuard } from '../rate-limit/rate-limit.guard';
@@ -38,7 +45,45 @@ const MAX_WATCH_IDS = 50;
 @ApiTags('claims')
 @Controller('claims')
 export class ClaimsController {
-  constructor(private readonly claimsService: ClaimsService) {}
+  constructor(
+    private readonly claimsService: ClaimsService,
+    private readonly evidenceUploadService: EvidenceUploadService,
+  ) {}
+
+  @Post('evidence/upload')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: undefined, // memory storage (default)
+      limits: { fileSize: EVIDENCE_MAX_BYTES_DEFAULT, files: 1 },
+    }),
+  )
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: 'Upload claim evidence file to IPFS' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary', description: 'Evidence file (PDF, PNG, JPEG)' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Upload successful', schema: { type: 'object', properties: { cid: { type: 'string' }, gatewayUrl: { type: 'string' } } } })
+  @ApiResponse({ status: 400, description: 'Invalid file (unsupported type, oversized, or malformed)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
+  async uploadEvidence(
+    @UploadedFile() file: Express.Multer.File,
+    @WalletAddress() walletAddress: string,
+  ) {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+    return this.evidenceUploadService.upload(file, walletAddress);
+  }
 
   @Get()
   @ApiOperation({ summary: 'List claims with cursor-based pagination' })

--- a/backend/src/claims/claims.module.ts
+++ b/backend/src/claims/claims.module.ts
@@ -4,6 +4,7 @@ import { ClaimsService } from './claims.service';
 import { SanitizationService } from './sanitization.service';
 import { ClaimViewMapper } from './claim-view.mapper';
 import { ClaimAggregationService } from './services/claim-aggregation.service';
+import { EvidenceUploadService } from './services/evidence-upload.service';
 import { ClaimDeadlineProcessorService } from './claim-deadline.processor.service';
 import { ClaimDeadlineBootstrap } from './claim-deadline.bootstrap';
 import { RpcModule } from '../rpc/rpc.module';
@@ -12,15 +13,18 @@ import { TenantModule } from '../tenant/tenant.module';
 import { IndexerModule } from '../indexer/indexer.module';
 import { CacheModule } from '../cache/cache.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { IpfsModule } from '../ipfs/ipfs.module';
+import { AdminModule } from '../admin/admin.module';
 
 @Module({
-  imports: [PrismaModule, RpcModule, RateLimitModule, TenantModule, IndexerModule, CacheModule],
+  imports: [PrismaModule, RpcModule, RateLimitModule, TenantModule, IndexerModule, CacheModule, IpfsModule, AdminModule],
   controllers: [ClaimsController],
   providers: [
     ClaimsService,
     SanitizationService,
     ClaimViewMapper,
     ClaimAggregationService,
+    EvidenceUploadService,
     ClaimDeadlineProcessorService,
     ClaimDeadlineBootstrap,
   ],

--- a/backend/src/claims/dto/evidence-upload.dto.ts
+++ b/backend/src/claims/dto/evidence-upload.dto.ts
@@ -1,0 +1,22 @@
+/** Supported MIME types for claim evidence uploads. */
+export const EVIDENCE_ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+] as const;
+
+export type EvidenceAllowedMimeType = (typeof EVIDENCE_ALLOWED_MIME_TYPES)[number];
+
+/** Default max evidence file size (10 MB). Overridden by EVIDENCE_MAX_BYTES env var. */
+export const EVIDENCE_MAX_BYTES_DEFAULT = 10 * 1024 * 1024;
+
+/** Default per-wallet upload rate limit (5 uploads per window). */
+export const EVIDENCE_UPLOAD_RATE_LIMIT_DEFAULT = 5;
+
+/** Default rate-limit window in seconds (1 hour). */
+export const EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS_DEFAULT = 3600;
+
+export interface EvidenceUploadResponseDto {
+  cid: string;
+  gatewayUrl: string;
+}

--- a/backend/src/claims/services/evidence-upload.service.ts
+++ b/backend/src/claims/services/evidence-upload.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IpfsService } from '../../ipfs/services/ipfs.service';
+import { AuditService } from '../../admin/audit.service';
+import { RateLimitService } from '../../rate-limit/rate-limit.service';
+import {
+  EVIDENCE_ALLOWED_MIME_TYPES,
+  EVIDENCE_MAX_BYTES_DEFAULT,
+  EVIDENCE_UPLOAD_RATE_LIMIT_DEFAULT,
+  EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS_DEFAULT,
+  EvidenceUploadResponseDto,
+} from '../dto/evidence-upload.dto';
+
+@Injectable()
+export class EvidenceUploadService {
+  private readonly logger = new Logger(EvidenceUploadService.name);
+  private readonly maxBytes: number;
+
+  constructor(
+    private readonly ipfs: IpfsService,
+    private readonly audit: AuditService,
+    private readonly rateLimitService: RateLimitService,
+    private readonly config: ConfigService,
+  ) {
+    this.maxBytes = this.config.get<number>('EVIDENCE_MAX_BYTES', EVIDENCE_MAX_BYTES_DEFAULT);
+  }
+
+  async upload(
+    file: Express.Multer.File,
+    walletAddress: string,
+  ): Promise<EvidenceUploadResponseDto> {
+    // 1. Validate before any IPFS interaction
+    this.validateFile(file);
+
+    // 2. Per-wallet rate limit
+    await this.enforceRateLimit(walletAddress);
+
+    // 3. Upload to IPFS
+    let cid: string;
+    let gatewayUrl: string;
+    try {
+      const result = await this.ipfs.upload(
+        file.buffer,
+        file.originalname,
+        file.mimetype,
+        undefined,
+        { stripExif: true },
+      );
+      cid = result.cid;
+      gatewayUrl = result.gatewayUrls[0];
+    } catch (err) {
+      await this.writeAudit(walletAddress, 'evidence_upload_failed', { reason: 'ipfs_error' });
+      throw err;
+    }
+
+    // 4. Audit success
+    await this.writeAudit(walletAddress, 'evidence_upload_success', {
+      cid,
+      mimeType: file.mimetype,
+      size: file.size,
+    });
+
+    return { cid, gatewayUrl };
+  }
+
+  private validateFile(file: Express.Multer.File): void {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+
+    const mime = file.mimetype as string;
+    if (!(EVIDENCE_ALLOWED_MIME_TYPES as readonly string[]).includes(mime)) {
+      throw new BadRequestException(
+        `Unsupported file type "${mime}". Allowed: ${EVIDENCE_ALLOWED_MIME_TYPES.join(', ')}`,
+      );
+    }
+
+    if (file.size > this.maxBytes) {
+      throw new BadRequestException(
+        `File exceeds maximum size of ${this.maxBytes} bytes`,
+      );
+    }
+
+    // Guard against extension/MIME mismatch for known dangerous extensions
+    const ext = file.originalname.split('.').pop()?.toLowerCase() ?? '';
+    const dangerousExtensions = ['exe', 'bat', 'sh', 'js', 'php', 'py', 'rb', 'cmd', 'ps1'];
+    if (dangerousExtensions.includes(ext)) {
+      throw new BadRequestException(`File extension ".${ext}" is not allowed`);
+    }
+  }
+
+  private async enforceRateLimit(walletAddress: string): Promise<void> {
+    const limit = this.config.get<number>('EVIDENCE_UPLOAD_RATE_LIMIT', EVIDENCE_UPLOAD_RATE_LIMIT_DEFAULT);
+    const windowSeconds = this.config.get<number>(
+      'EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS',
+      EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS_DEFAULT,
+    );
+
+    const { allowed, retryAfterSeconds } = await this.rateLimitService.checkWalletEvidenceLimit(
+      walletAddress,
+      limit,
+      windowSeconds,
+    );
+
+    if (!allowed) {
+      await this.writeAudit(walletAddress, 'evidence_upload_rate_limited', {
+        retryAfterSeconds,
+      });
+      throw new HttpException(
+        `Upload rate limit exceeded. Retry after ${retryAfterSeconds}s`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  private async writeAudit(
+    walletAddress: string,
+    action: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await this.audit.write({
+        actor: walletAddress,
+        action,
+        payload: payload as Record<string, string | number | boolean | null>,
+      });
+    } catch (err) {
+      // Audit failures must not block the upload response
+      this.logger.warn(`Audit write failed for ${action}: ${err}`);
+    }
+  }
+}

--- a/backend/src/config/env.definitions.ts
+++ b/backend/src/config/env.definitions.ts
@@ -124,6 +124,12 @@ export interface EnvironmentVariables {
    * Remove after the overlap window (≥ JWT_EXPIRES_IN) has elapsed.
    */
   JWT_SECRET_NEXT: string;
+  /** Maximum claim evidence file size in bytes. Defaults to 10 MB. */
+  EVIDENCE_MAX_BYTES: number;
+  /** Max evidence uploads per wallet per rate-limit window. */
+  EVIDENCE_UPLOAD_RATE_LIMIT: number;
+  /** Evidence upload rate-limit window in seconds. */
+  EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS: number;
 }
 
 export type EnvKey = keyof EnvironmentVariables;
@@ -1195,6 +1201,30 @@ export const ENV_DEFINITIONS: EnvDefinitionMap = {
     required: 'optional',
     secret: true,
     schema: Joi.string().min(32).allow('').default(''),
+  },
+  EVIDENCE_MAX_BYTES: {
+    key: 'EVIDENCE_MAX_BYTES',
+    section: 'Evidence uploads',
+    description: 'Maximum allowed claim evidence file size in bytes. Defaults to 10 MB.',
+    example: '10485760',
+    required: 'optional',
+    schema: Joi.number().integer().min(1).default(10485760),
+  },
+  EVIDENCE_UPLOAD_RATE_LIMIT: {
+    key: 'EVIDENCE_UPLOAD_RATE_LIMIT',
+    section: 'Evidence uploads',
+    description: 'Maximum evidence uploads per wallet per rate-limit window.',
+    example: '5',
+    required: 'optional',
+    schema: Joi.number().integer().min(1).default(5),
+  },
+  EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS: {
+    key: 'EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS',
+    section: 'Evidence uploads',
+    description: 'Evidence upload rate-limit window in seconds.',
+    example: '3600',
+    required: 'optional',
+    schema: Joi.number().integer().min(1).default(3600),
   },
 };
 

--- a/backend/src/rate-limit/rate-limit.service.ts
+++ b/backend/src/rate-limit/rate-limit.service.ts
@@ -327,6 +327,42 @@ export class RateLimitService implements OnModuleInit {
     }
   }
 
+  /**
+   * Check per-wallet rate limit for evidence uploads with configurable parameters.
+   * Uses a Redis sorted-set sliding window, keyed separately from claim submission.
+   */
+  async checkWalletEvidenceLimit(
+    walletAddress: string,
+    limit: number,
+    windowSeconds: number,
+  ): Promise<{ allowed: boolean; retryAfterSeconds: number }> {
+    try {
+      const client = this.redis.getClient();
+      const key = `rate_limit:evidence:${walletAddress.toLowerCase()}`;
+      const nowMs = Date.now();
+      const windowMs = windowSeconds * 1000;
+      const windowStart = nowMs - windowMs;
+
+      await client.zremrangebyscore(key, 0, windowStart);
+      const currentCount = await client.zcard(key);
+
+      if (currentCount >= limit) {
+        const oldest = await client.zrange(key, 0, 0, 'WITHSCORES');
+        const oldestTimestamp = oldest.length > 1 ? parseInt(oldest[1], 10) : windowStart;
+        const retryAfterSeconds = Math.max(1, Math.ceil((oldestTimestamp + windowMs - nowMs) / 1000));
+        return { allowed: false, retryAfterSeconds };
+      }
+
+      await client.zadd(key, nowMs, `${nowMs}-${Math.random().toString(36).slice(2)}`);
+      await client.pexpire(key, windowMs * 2);
+
+      return { allowed: true, retryAfterSeconds: 0 };
+    } catch (error) {
+      this.logger.error(`Evidence rate limit check failed for ${walletAddress}: ${error}`);
+      return { allowed: true, retryAfterSeconds: 0 };
+    }
+  }
+
   // ── Global circuit breaker ──────────────────────────────────────────────
 
   /**

--- a/backend/tsconfig.test.json
+++ b/backend/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist-test",
-    "types": ["node", "jest"]
+    "types": ["node", "jest", "multer"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Closes #644

---

Adds a secure multipart upload endpoint for claim evidence files.

## What

- POST /claims/evidence/upload — accepts evidence files, validates them, uploads to IPFS via IpfsService, and returns { cid, gatewayUrl }
- Validation runs before any IPFS interaction:
  - Allowed MIME types: application/pdf, image/png, image/jpeg
  - Max size enforced via EVIDENCE_MAX_BYTES env var (default 10 MB)
  - Dangerous file extensions (.exe, .sh, .js, etc.) rejected with 400
- Per-wallet sliding-window rate limit via new RateLimitService.checkWalletEvidenceLimit(); limit and window are configurable via EVIDENCE_UPLOAD_RATE_LIMIT / EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS env vars
- Successful and rejected uploads are recorded in the audit trail (AdminAuditLog) with wallet address, action, CID, MIME type, and size; audit failures do not block the upload response
- JwtAuthGuard required; unauthenticated requests receive 401
- EXIF metadata stripped from images before pinning

## Files

- backend/src/claims/dto/evidence-upload.dto.ts — allowed MIME types, size/rate-limit defaults, EvidenceUploadResponseDto
- backend/src/claims/services/evidence-upload.service.ts — orchestrates validation → rate-limit → IPFS upload → audit
- backend/src/claims/claims.controller.ts — new route with FileInterceptor (memory storage), JwtAuthGuard, @Throttle
- backend/src/claims/claims.module.ts — imports IpfsModule + AdminModule, registers EvidenceUploadService
- backend/src/rate-limit/rate-limit.service.ts — adds checkWalletEvidenceLimit(wallet, limit, windowSeconds)
- backend/src/config/env.definitions.ts — EVIDENCE_MAX_BYTES, EVIDENCE_UPLOAD_RATE_LIMIT, EVIDENCE_UPLOAD_RATE_LIMIT_WINDOW_SECONDS
- backend/.env.example — documents the three new env vars
- backend/tsconfig.test.json — adds multer to types (required for Express.Multer.File in test compilation)

## Tests

14 new tests in evidence-upload.spec.ts:
- Integration: PNG/JPEG/PDF success → 200 with cid+gatewayUrl
- Integration: no file → 400, bad MIME → 400, oversized → 400/413
- Integration: rate-limited → 429, unauthenticated → 401
- Unit: MIME/size/extension validation rejects before IPFS
- Unit: rate-limit exceeded rejects before IPFS + writes audit event
- Unit: audit write failure does not propagate

All 562 existing tests continue to pass.

## Checklist

- [ ] Branding follows `docs/BRANDING.md` for product naming, palette, typography, and assets.
