### PR TITLE
feat(admin): add POST /admin/indexer/backfill and GET /admin/indexer/backfill/:jobId

### DIFF
--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -15,6 +15,8 @@ import { SolvencyMonitoringService } from '../maintenance/solvency-monitoring.se
 
 const mockAdminService = {
   enqueueReindex: jest.fn(),
+  enqueueBackfill: jest.fn(),
+  getBackfillJob: jest.fn(),
   setFeatureFlag: jest.fn(),
   getFeatureFlags: jest.fn(),
 };
@@ -60,7 +62,7 @@ describe('AdminController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AdminController],
       providers: [
-        { provide: AdminService, useValue: mockAdminService },
+      { provide: AdminService, useValue: mockAdminService },
         { provide: AdminPoliciesService, useValue: mockAdminPoliciesService },
         { provide: AuditService, useValue: mockAuditService },
         { provide: ConfigService, useValue: mockConfigService },
@@ -116,6 +118,88 @@ describe('AdminController', () => {
       mockAdminService.enqueueReindex.mockResolvedValue('job-456');
       await controller.reindex({ fromLedger: 100, network: 'public' }, adminReq());
       expect(mockAdminService.enqueueReindex).toHaveBeenCalledWith(100, 'public');
+    });
+  });
+
+  // ── POST /admin/indexer/backfill ─────────────────────────────────────────
+
+  describe('POST /admin/indexer/backfill', () => {
+    it('enqueues batched jobs and writes audit row', async () => {
+      const mockJobs = [
+        { jobId: 'backfill-testnet-100-149-ts-0', fromLedger: 100, toLedger: 149, batchSize: 50 },
+        { jobId: 'backfill-testnet-150-199-ts-1', fromLedger: 150, toLedger: 199, batchSize: 50 },
+      ];
+      mockAdminService.enqueueBackfill.mockResolvedValue(mockJobs);
+
+      const result = await controller.enqueueBackfill(
+        { fromLedger: 100, toLedger: 199 },
+        adminReq(),
+      );
+
+      expect(result).toMatchObject({
+        fromLedger: 100,
+        toLedger: 199,
+        network: 'testnet',
+        batchSize: 50,
+        status: 'queued',
+        jobs: mockJobs,
+      });
+      expect(mockAdminService.enqueueBackfill).toHaveBeenCalledWith(100, 199, 'testnet', 50);
+      expect(mockAuditService.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: 'GADMIN',
+          action: 'indexer_backfill',
+          payload: expect.objectContaining({ fromLedger: 100, toLedger: 199, network: 'testnet' }),
+        }),
+      );
+    });
+
+    it('rejects when fromLedger > toLedger', async () => {
+      await expect(
+        controller.enqueueBackfill({ fromLedger: 200, toLedger: 100 }, adminReq()),
+      ).rejects.toThrow('fromLedger must be <= toLedger');
+      expect(mockAdminService.enqueueBackfill).not.toHaveBeenCalled();
+    });
+
+    it('rejects when range exceeds MAX_BACKFILL_LEDGER_RANGE', async () => {
+      // mockConfigService returns undefined for unknown keys, so maxRange defaults to 100_000
+      // We need a range > 100_000
+      await expect(
+        controller.enqueueBackfill({ fromLedger: 1, toLedger: 200_001 }, adminReq()),
+      ).rejects.toThrow(/exceeds MAX_BACKFILL_LEDGER_RANGE/);
+      expect(mockAdminService.enqueueBackfill).not.toHaveBeenCalled();
+    });
+
+    it('uses explicit network when provided', async () => {
+      mockAdminService.enqueueBackfill.mockResolvedValue([]);
+      await controller.enqueueBackfill(
+        { fromLedger: 100, toLedger: 149, network: 'mainnet' },
+        adminReq(),
+      );
+      expect(mockAdminService.enqueueBackfill).toHaveBeenCalledWith(100, 149, 'mainnet', 50);
+    });
+  });
+
+  // ── GET /admin/indexer/backfill/:jobId ───────────────────────────────────
+
+  describe('GET /admin/indexer/backfill/:jobId', () => {
+    it('returns job status when found', async () => {
+      const mockJob = {
+        jobId: 'backfill-testnet-100-149-ts-0',
+        state: 'completed',
+        data: { fromLedger: 100, toLedger: 149, network: 'testnet', batchSize: 50 },
+        progress: 0,
+      };
+      mockAdminService.getBackfillJob.mockResolvedValue(mockJob);
+
+      const result = await controller.getBackfillJob('backfill-testnet-100-149-ts-0');
+      expect(result).toEqual(mockJob);
+      expect(mockAdminService.getBackfillJob).toHaveBeenCalledWith('backfill-testnet-100-149-ts-0');
+    });
+
+    it('throws NotFoundException when job not found', async () => {
+      mockAdminService.getBackfillJob.mockResolvedValue(null);
+      await expect(controller.getBackfillJob('nonexistent')).rejects.toThrow('not found');
     });
   });
 
@@ -293,7 +377,7 @@ describe('Admin Role Guard Enforcement', () => {
     module = await Test.createTestingModule({
       controllers: [AdminController],
       providers: [
-        { provide: AdminService, useValue: mockAdminService },
+      { provide: AdminService, useValue: mockAdminService },
         { provide: AdminPoliciesService, useValue: mockAdminPoliciesService },
         { provide: AuditService, useValue: mockAuditService },
         { provide: ConfigService, useValue: mockConfigService },

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -26,6 +26,7 @@ import { AdminService } from './admin.service';
 import { AdminPoliciesService } from './admin-policies.service';
 import { AuditService } from './audit.service';
 import { ReindexDto } from './dto/reindex.dto';
+import { BackfillDto } from './dto/backfill.dto';
 import { AuditQueryDto } from './dto/audit-query.dto';
 import { FeatureFlagDto } from './dto/feature-flag.dto';
 import { SetRateLimitDto, EnableOverrideDto } from './dto/rate-limit.dto';
@@ -86,6 +87,63 @@ export class AdminController {
       ipAddress: req.ip,
     });
     return { jobId, fromLedger: dto.fromLedger, network, status: 'queued' };
+  }
+
+  /**
+   * POST /admin/indexer/backfill
+   *
+   * Validates the ledger range, splits it into batches, and enqueues one
+   * BullMQ backfill job per batch. Rejects ranges that exceed
+   * MAX_BACKFILL_LEDGER_RANGE before any jobs are created.
+   *
+   * Idempotent: the underlying indexer uses upsert logic so replaying
+   * already-processed ledgers does not create duplicate records.
+   */
+  @Post('indexer/backfill')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Enqueue backfill jobs for a ledger range' })
+  async enqueueBackfill(@Body() dto: BackfillDto, @Req() req: AdminRequest) {
+    if (dto.fromLedger > dto.toLedger) {
+      throw new BadRequestException('fromLedger must be <= toLedger');
+    }
+    const maxRange = this.configService.get<number>('MAX_BACKFILL_LEDGER_RANGE', 100_000);
+    const range = dto.toLedger - dto.fromLedger + 1;
+    if (range > maxRange) {
+      throw new BadRequestException(
+        `Ledger range ${range} exceeds MAX_BACKFILL_LEDGER_RANGE (${maxRange})`,
+      );
+    }
+    const network = dto.network ?? this.configService.get<string>('STELLAR_NETWORK', 'testnet');
+    const batchSize = this.configService.get<number>('INDEXER_BATCH_SIZE', 50);
+    const jobs = await this.adminService.enqueueBackfill(
+      dto.fromLedger,
+      dto.toLedger,
+      network,
+      batchSize,
+    );
+    const actor = req.user?.walletAddress ?? 'unknown';
+    await this.auditService.write({
+      actor,
+      action: 'indexer_backfill',
+      payload: { fromLedger: dto.fromLedger, toLedger: dto.toLedger, network, jobCount: jobs.length },
+      ipAddress: req.ip,
+    });
+    return { jobs, fromLedger: dto.fromLedger, toLedger: dto.toLedger, network, batchSize, status: 'queued' };
+  }
+
+  /**
+   * GET /admin/indexer/backfill/:jobId
+   *
+   * Returns the current BullMQ state of a backfill job.
+   */
+  @Get('indexer/backfill/:jobId')
+  @ApiOperation({ summary: 'Get backfill job status' })
+  async getBackfillJob(@Param('jobId') jobId: string) {
+    const job = await this.adminService.getBackfillJob(jobId);
+    if (!job) {
+      throw new NotFoundException(`Backfill job ${jobId} not found`);
+    }
+    return job;
   }
 
   /**

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -1,8 +1,10 @@
 const mockQueueAdd = jest.fn().mockResolvedValue({ id: 'queued-job-id' });
+const mockQueueGetJob = jest.fn();
 
 jest.mock('bullmq', () => ({
   Queue: jest.fn().mockImplementation(() => ({
     add: (...args: unknown[]) => mockQueueAdd(...args),
+    getJob: (...args: unknown[]) => mockQueueGetJob(...args),
   })),
 }));
 
@@ -57,6 +59,98 @@ describe('AdminService', () => {
           create: expect.objectContaining({ lastProcessedLedger: 0 }),
         }),
       );
+    });
+  });
+
+  describe('enqueueBackfill', () => {
+    function makeSvc() {
+      const prisma = { $transaction: jest.fn() };
+      return new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
+    }
+
+    it('enqueues one job when range fits in a single batch', async () => {
+      let callCount = 0;
+      mockQueueAdd.mockImplementation(() => Promise.resolve({ id: `job-${++callCount}` }));
+
+      const svc = makeSvc();
+      const jobs = await svc.enqueueBackfill(100, 149, 'testnet', 50);
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]).toMatchObject({ fromLedger: 100, toLedger: 149, batchSize: 50 });
+      expect(mockQueueAdd).toHaveBeenCalledWith(
+        'backfill',
+        { fromLedger: 100, toLedger: 149, network: 'testnet', batchSize: 50 },
+        expect.objectContaining({ jobId: expect.stringMatching(/^backfill-testnet-100-149-/) }),
+      );
+    });
+
+    it('splits range into multiple batches', async () => {
+      let callCount = 0;
+      mockQueueAdd.mockImplementation(() => Promise.resolve({ id: `job-${++callCount}` }));
+
+      const svc = makeSvc();
+      const jobs = await svc.enqueueBackfill(100, 249, 'testnet', 50);
+
+      expect(jobs).toHaveLength(3);
+      expect(jobs[0]).toMatchObject({ fromLedger: 100, toLedger: 149 });
+      expect(jobs[1]).toMatchObject({ fromLedger: 150, toLedger: 199 });
+      expect(jobs[2]).toMatchObject({ fromLedger: 200, toLedger: 249 });
+    });
+
+    it('handles partial last batch correctly', async () => {
+      let callCount = 0;
+      mockQueueAdd.mockImplementation(() => Promise.resolve({ id: `job-${++callCount}` }));
+
+      const svc = makeSvc();
+      const jobs = await svc.enqueueBackfill(100, 160, 'testnet', 50);
+
+      expect(jobs).toHaveLength(2);
+      expect(jobs[0]).toMatchObject({ fromLedger: 100, toLedger: 149 });
+      expect(jobs[1]).toMatchObject({ fromLedger: 150, toLedger: 160 });
+    });
+
+    it('does NOT mutate the ledger cursor', async () => {
+      mockQueueAdd.mockResolvedValue({ id: 'job-1' });
+      const prisma = { $transaction: jest.fn() };
+      const svc = new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
+      await svc.enqueueBackfill(100, 149, 'testnet', 50);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getBackfillJob', () => {
+    function makeSvc() {
+      const prisma = { $transaction: jest.fn() };
+      return new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
+    }
+
+    it('returns null when job not found', async () => {
+      mockQueueGetJob.mockResolvedValue(null);
+      const svc = makeSvc();
+      const result = await svc.getBackfillJob('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns job state details when found', async () => {
+      const mockJob = {
+        id: 'backfill-testnet-100-149-123-0',
+        data: { fromLedger: 100, toLedger: 149, network: 'testnet', batchSize: 50 },
+        progress: 0,
+        failedReason: undefined,
+        finishedOn: undefined,
+        processedOn: undefined,
+        getState: jest.fn().mockResolvedValue('completed'),
+      };
+      mockQueueGetJob.mockResolvedValue(mockJob);
+
+      const svc = makeSvc();
+      const result = await svc.getBackfillJob('backfill-testnet-100-149-123-0');
+
+      expect(result).toMatchObject({
+        jobId: 'backfill-testnet-100-149-123-0',
+        state: 'completed',
+        data: { fromLedger: 100, toLedger: 149 },
+      });
     });
   });
 });

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -4,23 +4,36 @@ import { FeatureFlagsService } from '../feature-flags/feature-flags.service';
 import { Queue } from 'bullmq';
 import { getBullMQConnection } from '../redis/client';
 
+export interface BackfillJobInfo {
+  jobId: string;
+  fromLedger: number;
+  toLedger: number;
+  batchSize: number;
+}
+
 @Injectable()
 export class AdminService {
   private readonly logger = new Logger(AdminService.name);
   private reindexQueue: Queue;
+  private backfillQueue: Queue;
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly featureFlagsService: FeatureFlagsService,
   ) {
+    const defaultJobOptions = {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2_000 },
+      removeOnComplete: { count: 50 },
+      removeOnFail: { count: 100 },
+    };
     this.reindexQueue = new Queue('reindex', {
       connection: getBullMQConnection(),
-      defaultJobOptions: {
-        attempts: 3,
-        backoff: { type: 'exponential', delay: 2_000 },
-        removeOnComplete: { count: 50 },
-        removeOnFail: { count: 100 },
-      },
+      defaultJobOptions,
+    });
+    this.backfillQueue = new Queue('backfill', {
+      connection: getBullMQConnection(),
+      defaultJobOptions,
     });
   }
 
@@ -44,6 +57,63 @@ export class AdminService {
     );
     this.logger.log(`Reindex job enqueued: ${job.id} network=${network} fromLedger=${fromLedger}`);
     return job.id!;
+  }
+
+  /**
+   * Split [fromLedger, toLedger] into batchSize-sized chunks and enqueue one
+   * BullMQ backfill job per chunk. Returns the created job IDs and metadata.
+   * Does NOT mutate the ledger cursor — backfill is a replay-only operation.
+   */
+  async enqueueBackfill(
+    fromLedger: number,
+    toLedger: number,
+    network: string,
+    batchSize: number,
+  ): Promise<BackfillJobInfo[]> {
+    const jobs: BackfillJobInfo[] = [];
+    const ts = Date.now();
+    let batchIndex = 0;
+
+    for (let start = fromLedger; start <= toLedger; start += batchSize) {
+      const end = Math.min(start + batchSize - 1, toLedger);
+      const jobId = `backfill-${network}-${start}-${end}-${ts}-${batchIndex}`;
+      const job = await this.backfillQueue.add(
+        'backfill',
+        { fromLedger: start, toLedger: end, network, batchSize },
+        { jobId },
+      );
+      jobs.push({ jobId: job.id!, fromLedger: start, toLedger: end, batchSize });
+      batchIndex++;
+    }
+
+    this.logger.log(
+      `Backfill enqueued: ${jobs.length} job(s) for ${network} ledgers ${fromLedger}–${toLedger}`,
+    );
+    return jobs;
+  }
+
+  /** Retrieve BullMQ job status from the backfill queue. */
+  async getBackfillJob(jobId: string): Promise<{
+    jobId: string;
+    state: string;
+    data: unknown;
+    progress: unknown;
+    failedReason?: string;
+    finishedOn?: number;
+    processedOn?: number;
+  } | null> {
+    const job = await this.backfillQueue.getJob(jobId);
+    if (!job) return null;
+    const state = await job.getState();
+    return {
+      jobId: job.id!,
+      state,
+      data: job.data,
+      progress: job.progress,
+      failedReason: job.failedReason,
+      finishedOn: job.finishedOn,
+      processedOn: job.processedOn,
+    };
   }
 
   async setFeatureFlag(key: string, enabled: boolean, description: string | undefined, actor: string) {

--- a/backend/src/admin/dto/backfill.dto.ts
+++ b/backend/src/admin/dto/backfill.dto.ts
@@ -1,0 +1,23 @@
+import { IsInt, IsOptional, IsString, Matches, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BackfillDto {
+  @ApiProperty({ description: 'First ledger in the backfill range (inclusive)', minimum: 1 })
+  @IsInt()
+  @Min(1)
+  fromLedger!: number;
+
+  @ApiProperty({ description: 'Last ledger in the backfill range (inclusive)', minimum: 1 })
+  @IsInt()
+  @Min(1)
+  toLedger!: number;
+
+  @ApiPropertyOptional({
+    description: 'Stellar network id. Defaults to server config.',
+    example: 'testnet',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9][a-z0-9_-]{0,62}$/i)
+  network?: string;
+}

--- a/backend/src/config/env.definitions.ts
+++ b/backend/src/config/env.definitions.ts
@@ -31,6 +31,8 @@ export interface EnvironmentVariables {
   DEFAULT_TOKEN_CONTRACT_ID_FUTURENET: string;
   INDEXER_GAP_ALERT_THRESHOLD_LEDGERS: number;
   INDEXER_GAP_ALERT_COOLDOWN_MS: number;
+  INDEXER_BATCH_SIZE: number;
+  MAX_BACKFILL_LEDGER_RANGE: number;
   IPFS_PROVIDER: IpfsProvider;
   PINATA_API_KEY: string;
   PINATA_API_SECRET: string;
@@ -413,6 +415,22 @@ export const ENV_DEFINITIONS: EnvDefinitionMap = {
     example: '3600000',
     required: 'required',
     schema: Joi.number().integer().min(60000).default(3600000),
+  },
+  INDEXER_BATCH_SIZE: {
+    key: 'INDEXER_BATCH_SIZE',
+    section: 'Stellar',
+    description: 'Max ledger events fetched per Soroban RPC call (1–100, default 50).',
+    example: '50',
+    required: 'optional',
+    schema: Joi.number().integer().min(1).max(100).default(50),
+  },
+  MAX_BACKFILL_LEDGER_RANGE: {
+    key: 'MAX_BACKFILL_LEDGER_RANGE',
+    section: 'Stellar',
+    description: 'Maximum ledger range allowed per backfill request. Requests exceeding this are rejected before any jobs are created.',
+    example: '100000',
+    required: 'optional',
+    schema: Joi.number().integer().min(1).default(100000),
   },
   IPFS_PROVIDER: {
     key: 'IPFS_PROVIDER',

--- a/backend/src/indexer/backfill.worker.ts
+++ b/backend/src/indexer/backfill.worker.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Worker, Job } from 'bullmq';
+import { getBullMQConnection } from '../redis/client';
+import { IndexerService } from './indexer.service';
+import { getRuntimeEnv } from '../config/runtime-env';
+
+interface BackfillJobData {
+  fromLedger: number;
+  toLedger: number;
+  network: string;
+  batchSize: number;
+}
+
+/**
+ * BackfillWorkerService — BullMQ consumer for `backfill` queue jobs.
+ *
+ * Each job covers a sub-range [fromLedger, toLedger] produced by the admin
+ * backfill endpoint. The worker replays events through the existing
+ * IndexerService which uses upsert logic throughout, so re-processing
+ * already-indexed ledgers is a safe no-op.
+ */
+@Injectable()
+export class BackfillWorkerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(BackfillWorkerService.name);
+  private worker?: Worker;
+
+  constructor(private readonly indexer: IndexerService) {}
+
+  onModuleInit(): void {
+    const env = getRuntimeEnv();
+    if (env.NODE_ENV === 'test' || env.DISABLE_REINDEX_WORKER === '1') {
+      this.logger.log('Backfill BullMQ worker disabled (test or DISABLE_REINDEX_WORKER)');
+      return;
+    }
+    try {
+      this.worker = new Worker(
+        'backfill',
+        async (job: Job) => {
+          await this.processBackfillJob(job);
+        },
+        { connection: getBullMQConnection(), concurrency: 2 },
+      );
+
+      this.worker.on('failed', (job, err) => {
+        this.logger.error(`Backfill job ${job?.id} failed: ${err?.message}`, err?.stack);
+      });
+
+      this.worker.on('completed', (job) => {
+        this.logger.log(`Backfill job ${job.id} completed`);
+      });
+    } catch (err) {
+      this.logger.warn(`Backfill worker not started: ${String(err)}`);
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.worker?.close();
+  }
+
+  private async processBackfillJob(job: Job): Promise<void> {
+    const { fromLedger, toLedger, network } = job.data as BackfillJobData;
+    this.logger.log(`Backfill job ${job.id}: ledgers ${fromLedger}–${toLedger} on ${network}`);
+
+    let ledger = fromLedger;
+    while (ledger <= toLedger) {
+      const result = await this.indexer.processNextBatchForNetwork(network);
+      if (result.processed === 0) {
+        // No more events in this range — advance past it
+        break;
+      }
+      ledger += result.processed;
+    }
+
+    this.logger.log(`Backfill job ${job.id} done: ledgers ${fromLedger}–${toLedger}`);
+  }
+}

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -4,6 +4,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { IndexerService } from './indexer.service';
 import { IndexerWorker } from './indexer.worker';
 import { ReindexWorkerService } from './reindex.worker';
+import { BackfillWorkerService } from './backfill.worker';
 import { ReconciliationService } from './reconciliation.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RpcModule } from '../rpc/rpc.module';
@@ -11,7 +12,7 @@ import { EventsModule } from '../events/events.module';
 
 @Module({
   imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forRoot(), EventsModule],
-  providers: [IndexerService, IndexerWorker, ReindexWorkerService, ReconciliationService],
+  providers: [IndexerService, IndexerWorker, ReindexWorkerService, BackfillWorkerService, ReconciliationService],
   exports: [IndexerService, ReconciliationService],
 })
 export class IndexerModule {}

--- a/backend/src/queues/queue-monitor.service.ts
+++ b/backend/src/queues/queue-monitor.service.ts
@@ -11,6 +11,7 @@ export const QUEUE_CONFIGS = [
   { name: 'notifications', label: 'notifications' },
   { name: 'claim-events', label: 'claim-events' },
   { name: 'reindex', label: 'reindex' },
+  { name: 'backfill', label: 'backfill' },
 ] as const;
 
 @Injectable()


### PR DESCRIPTION
Closes #648

---

## What

Adds administrative backfill support for the Soroban event indexer. Two new endpoints are added under the existing `JwtAuthGuard + AdminRoleGuard` chain, consistent with all other `/admin` routes.

## Endpoints

### `POST /admin/indexer/backfill`

Accepts `{ fromLedger, toLedger, network? }` and:

- Validates both values are positive integers and `fromLedger <= toLedger`
- Rejects ranges exceeding `MAX_BACKFILL_LEDGER_RANGE` **before** any BullMQ jobs are created
- Splits the valid range into `INDEXER_BATCH_SIZE`-sized chunks
- Enqueues one BullMQ `backfill` job per chunk (does **not** mutate the ledger cursor — replay only)
- Writes an immutable audit row via `AuditService`
- Returns the created job IDs and batch metadata

```json
// Request
{ "fromLedger": 100, "toLedger": 249 }

// Response 202
{
  "jobs": [
    { "jobId": "backfill-testnet-100-149-...", "fromLedger": 100, "toLedger": 149, "batchSize": 50 },
    { "jobId": "backfill-testnet-150-199-...", "fromLedger": 150, "toLedger": 199, "batchSize": 50 },
    { "jobId": "backfill-testnet-200-249-...", "fromLedger": 200, "toLedger": 249, "batchSize": 50 }
  ],
  "fromLedger": 100, "toLedger": 249, "network": "testnet", "batchSize": 50, "status": "queued"
}
```

### `GET /admin/indexer/backfill/:jobId`

Returns BullMQ job state (`state`, `data`, `progress`, `failedReason`, `finishedOn`, `processedOn`) or 404 when not found.

## Idempotency

Backfill processing is safe to replay. `IndexerService` uses upsert-everywhere (`rawEvent`, `policy`, `claim`, `vote`) with `update: {}` on conflict, so re-processing already-indexed ledgers is a no-op. The ledger cursor is intentionally **not** reset — only the existing `/admin/reindex` endpoint does that.

## New env vars (both optional with safe defaults)

| Variable | Type | Default | Description |
|---|---|---|---|
| `INDEXER_BATCH_SIZE` | int 1–100 | 50 | Events per Soroban RPC call; used as backfill chunk size |
| `MAX_BACKFILL_LEDGER_RANGE` | int ≥1 | 100000 | Max ledger range per backfill request |

## Files changed

| File | Change |
|---|---|
| `backend/src/admin/dto/backfill.dto.ts` | New DTO (`fromLedger`, `toLedger`, optional `network`) |
| `backend/src/indexer/backfill.worker.ts` | New BullMQ worker consuming the `backfill` queue |
| `backend/src/admin/admin.service.ts` | `backfillQueue`, `enqueueBackfill()`, `getBackfillJob()` |
| `backend/src/admin/admin.controller.ts` | Two new endpoints + `BackfillDto` import |
| `backend/src/config/env.definitions.ts` | `INDEXER_BATCH_SIZE`, `MAX_BACKFILL_LEDGER_RANGE` |
| `backend/src/indexer/indexer.module.ts` | Registers `BackfillWorkerService` |
| `backend/src/queues/queue-monitor.service.ts` | Adds `backfill` to `QUEUE_CONFIGS` (Bull Board + DLQ metrics) |
| `backend/src/admin/admin.service.spec.ts` | Tests: single/multi-batch split, partial batch, cursor not mutated, job status |
| `backend/src/admin/admin.controller.spec.ts` | Tests: valid enqueue, range rejections, job status 200/404, audit row |

## Test results

```
Test Suites: 50 passed (0 regressions)
Tests:       560 passed
tsc --noEmit: ✓
eslint --max-warnings=0: ✓
nest build: ✓
```