### PR TITLE
feat(claims): rebuild wizard as reliable 3-step flow with CID preview and contract validation

### DIFF
--- a/frontend/src/components/claims/ClaimWizard.tsx
+++ b/frontend/src/components/claims/ClaimWizard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Loader2, ArrowLeft, ArrowRight, CheckCircle } from 'lucide-react';
+import { Loader2, ArrowLeft, ArrowRight, CheckCircle, ExternalLink } from 'lucide-react';
 
 import {
   Stepper,
@@ -20,9 +21,8 @@ import { useDraftPersistence } from '@/hooks/use-draft-persistence';
 import { ClaimAPI } from '@/lib/api/claim';
 import { trackClaimFiled } from '@/lib/analytics';
 
-import { AmountStep } from './steps/AmountStep';
-import { EvidenceStep } from './steps/EvidenceStep';
-import { NarrativeStep } from './steps/NarrativeStep';
+import { EvidenceStep, type EvidenceAttachment } from './steps/EvidenceStep';
+import { DetailsStep } from './steps/DetailsStep';
 import { ReviewStep, type PolicyCoverageDetails } from './steps/ReviewStep';
 import { DraftResumeBanner } from './DraftResumeBanner';
 
@@ -33,13 +33,12 @@ interface ClaimWizardProps {
 }
 
 const STEPS = [
-  { id: '1', title: 'Amount', description: 'Enter claim amount' },
-  { id: '2', title: 'Narrative', description: 'Describe the incident' },
-  { id: '3', title: 'Evidence', description: 'Upload proof' },
-  { id: '4', title: 'Review', description: 'Confirm & Sign' },
+  { id: '1', title: 'Evidence', description: 'Upload proof' },
+  { id: '2', title: 'Details', description: 'Amount & narrative' },
+  { id: '3', title: 'Sign & Submit', description: 'Confirm & sign' },
 ];
 
-const CLAIM_DRAFT_SCHEMA_VERSION = 1;
+const CLAIM_DRAFT_SCHEMA_VERSION = 2;
 
 export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWizardProps) {
   const router = useRouter();
@@ -47,67 +46,77 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
   const { address, signTransaction } = useWallet();
   const [activeStep, setActiveStep] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSuccess, setIsSuccess] = useState(false);
+  const submittingRef = useRef(false); // duplicate-submission guard
+  const [claimId, setClaimId] = useState<number | null>(null);
   const [txStatus, setTxStatus] = useState<string>('');
   const [showBanner, setShowBanner] = useState(true);
   const stepHeadingRef = useRef<HTMLHeadingElement>(null);
 
+  // Contract config for min/max evidence
+  const [minEvidence, setMinEvidence] = useState(1);
+  const [maxEvidence, setMaxEvidence] = useState(5);
+
   const [formData, setFormData] = useState({
     amount: '',
     details: '',
-    evidence: [] as { url: string; contentSha256Hex: string }[],
+    evidence: [] as EvidenceAttachment[],
   });
 
   const { hasDraft, saveDraft, loadDraft, clearDraft } = useDraftPersistence(
     `claim-${policyId}`,
-    CLAIM_DRAFT_SCHEMA_VERSION
+    CLAIM_DRAFT_SCHEMA_VERSION,
   );
 
-  // Sync draft on form changes (excluding files/IPFS handled by hook sanitize)
+  // Fetch contract config on mount
   useEffect(() => {
-    if (activeStep > 0 || formData.amount || formData.details) {
+    ClaimAPI.getConfig()
+      .then((cfg) => {
+        setMinEvidence(cfg.minEvidenceCount);
+        setMaxEvidence(cfg.maxEvidenceCount);
+      })
+      .catch(() => {
+        // Non-fatal: fall back to defaults (1–5)
+      });
+  }, []);
+
+  // Persist draft on form changes
+  useEffect(() => {
+    if (activeStep > 0 || formData.amount || formData.details || formData.evidence.length > 0) {
       saveDraft({ ...formData, _step: activeStep });
     }
   }, [formData, activeStep, saveDraft]);
 
+  // Focus step heading on step change
+  useEffect(() => {
+    stepHeadingRef.current?.focus();
+  }, [activeStep]);
+
   const handleResumeDraft = () => {
     const draft = loadDraft();
     if (draft) {
-      const { _step, ...data } = draft as any;
-      setFormData(prev => ({ ...prev, ...data }));
-      if (typeof _step === 'number') {
-        setActiveStep(_step);
-      }
-      toast({
-        title: 'Draft Restored',
-        description: 'You are continuing where you left off.',
-      });
+      const { _step, ...data } = draft as Record<string, unknown> & { _step?: number };
+      setFormData(prev => ({ ...prev, ...(data as Partial<typeof formData>) }));
+      if (typeof _step === 'number') setActiveStep(_step);
+      toast({ title: 'Draft Restored', description: 'Continuing where you left off.' });
     }
     setShowBanner(false);
   };
 
   const handleDismissBanner = () => {
-    clearDraft(); // Clearing explicitly if they choose to start over?
-    // Actually, maybe not clearing immediately, but just hiding banner?
-    // Requirements say "Resume draft banner when a valid draft is detected".
-    // If they dismiss, we should probably stop showing it but maybe keep draft until new data overwrites?
-    // Let's clear it to be safe and avoid confusion.
     clearDraft();
     setShowBanner(false);
   };
 
-  // Move focus to step heading when step changes
-  useEffect(() => {
-    if (stepHeadingRef.current) {
-      stepHeadingRef.current.focus();
-    }
-  }, [activeStep]);
+  const canAdvanceFromStep = (step: number): boolean => {
+    if (step === 0) return formData.evidence.length >= minEvidence;
+    if (step === 1) return !!formData.amount && !!formData.details;
+    return true;
+  };
 
   const handleNext = () => {
     if (activeStep < STEPS.length - 1) {
       setActiveStep(prev => prev + 1);
-    } else if (activeStep === STEPS.length - 1) {
-      // Signing is only allowed from the review step (last step)
+    } else {
       handleFinalSubmit();
     }
   };
@@ -121,6 +130,7 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
   };
 
   const handleFinalSubmit = async () => {
+    if (submittingRef.current) return; // prevent duplicate submissions
     if (!address) {
       toast({
         title: 'Wallet not connected',
@@ -130,6 +140,7 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
       return;
     }
 
+    submittingRef.current = true;
     setIsSubmitting(true);
     try {
       setTxStatus('Building transaction…');
@@ -138,46 +149,36 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
         policyId: parseInt(policyId),
         amount: formData.amount,
         details: formData.details,
-        evidence: formData.evidence,
+        evidence: formData.evidence.map(({ url, contentSha256Hex }) => ({ url, contentSha256Hex })),
       });
 
       setTxStatus('Waiting for wallet signature…');
       const signedXdr = await signTransaction(unsignedXdr);
 
       setTxStatus('Submitting transaction to network…');
-      await ClaimAPI.submitTransaction(signedXdr);
+      const result = await ClaimAPI.submitTransaction(signedXdr);
 
       setTxStatus('Claim submitted successfully.');
-      setIsSuccess(true);
+      setClaimId(result.claimId);
 
       trackClaimFiled();
-
-      // EXTREMELY IMPORTANT: Clear draft on success (Issue #229)
       clearDraft();
 
       toast({
         title: 'Claim Submitted!',
-        description: 'Your claim has been successfully filed on-chain.',
+        description: `Claim #${result.claimId} has been filed on-chain.`,
       });
-
-      setTimeout(() => {
-        router.push(`/policies`);
-      }, 3000);
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'An unexpected error occurred.';
       setTxStatus(`Submission failed: ${msg}`);
-      console.error('Submission failed:', error);
-      toast({
-        title: 'Submission Failed',
-        description: msg,
-        variant: 'destructive',
-      });
+      toast({ title: 'Submission Failed', description: msg, variant: 'destructive' });
     } finally {
       setIsSubmitting(false);
+      submittingRef.current = false;
     }
   };
 
-  if (isSuccess) {
+  if (claimId !== null) {
     return (
       <Card className="mx-auto max-w-2xl text-center py-12">
         <CardContent className="space-y-6">
@@ -190,12 +191,20 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
           <div className="space-y-2">
             <h2 className="text-2xl font-bold">Claim Filed Successfully</h2>
             <p className="text-muted-foreground">
-              Your claim has been broadcast to the network and is awaiting verification by the DAO.
+              Your claim has been broadcast to the network and is awaiting DAO verification.
             </p>
+            <p className="text-sm font-mono font-semibold">Claim ID: #{claimId}</p>
           </div>
-          <Button onClick={() => router.push(`/policies`)}>
-            Back to Policies
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Button asChild>
+              <Link href={`/claims/${claimId}`}>
+                View Claim <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button variant="outline" onClick={() => router.push('/policies')}>
+              Back to Policies
+            </Button>
+          </div>
         </CardContent>
       </Card>
     );
@@ -203,7 +212,6 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
 
   return (
     <Card className="mx-auto max-w-3xl">
-      {/* Live region announces tx progress to screen readers */}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {txStatus}
       </div>
@@ -217,20 +225,25 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
             </CardDescription>
           </div>
           <Stepper
-            steps={STEPS.map((s, i) => ({ ...s, status: i < activeStep ? 'completed' : i === activeStep ? 'active' : 'pending' as const }))}
+            steps={STEPS.map((s, i) => ({
+              ...s,
+              status: (i < activeStep ? 'completed' : i === activeStep ? 'active' : 'pending') as
+                | 'completed'
+                | 'active'
+                | 'pending',
+            }))}
             currentStep={activeStep}
             aria-label="Claim filing steps"
             className="hidden md:flex"
           />
         </div>
       </CardHeader>
+
       <CardContent className="space-y-6">
-        {/* Banner for resuming draft (Requirement: Resume draft banner detected on wizard mount) */}
         {hasDraft && showBanner && (
           <DraftResumeBanner onConfirm={handleResumeDraft} onDismiss={handleDismissBanner} />
         )}
 
-        {/* Visually hidden heading receives focus on step change */}
         <h2
           ref={stepHeadingRef}
           tabIndex={-1}
@@ -239,55 +252,45 @@ export function ClaimWizard({ policyId, maxCoverage, policyCoverage }: ClaimWiza
           Step {activeStep + 1} of {STEPS.length}: {STEPS[activeStep].title}
         </h2>
 
+        {/* Step 0: Evidence */}
         <StepContent title={STEPS[0].title} isActive={activeStep === 0} isCompleted={activeStep > 0}>
-          <AmountStep
+          <EvidenceStep
+            evidence={formData.evidence}
+            onChange={(evidence) => setFormData(prev => ({ ...prev, evidence }))}
+            minEvidence={minEvidence}
+            maxEvidence={maxEvidence}
+          />
+        </StepContent>
+
+        {/* Step 1: Details (amount + narrative) */}
+        <StepContent title={STEPS[1].title} isActive={activeStep === 1} isCompleted={activeStep > 1}>
+          <DetailsStep
             amount={formData.amount}
-            onChange={(val) => setFormData(prev => ({ ...prev, amount: val }))}
+            details={formData.details}
+            onAmountChange={(amount) => setFormData(prev => ({ ...prev, amount }))}
+            onDetailsChange={(details) => setFormData(prev => ({ ...prev, details }))}
             maxCoverage={maxCoverage}
           />
         </StepContent>
 
-        <StepContent title={STEPS[1].title} isActive={activeStep === 1} isCompleted={activeStep > 1}>
-          <NarrativeStep
-            details={formData.details}
-            onChange={(val) => setFormData(prev => ({ ...prev, details: val }))}
-          />
-        </StepContent>
-
+        {/* Step 2: Review + Sign */}
         <StepContent title={STEPS[2].title} isActive={activeStep === 2} isCompleted={activeStep > 2}>
-          <EvidenceStep
-            evidence={formData.evidence}
-            onChange={(evidence) => setFormData(prev => ({ ...prev, evidence }))}
-          />
-        </StepContent>
-
-        <StepContent title={STEPS[3].title} isActive={activeStep === 3} isCompleted={activeStep > 3}>
-          <ReviewStep 
-            data={formData} 
+          <ReviewStep
+            data={formData}
             policyId={policyId}
             policyCoverage={policyCoverage}
-            onEdit={(step) => setActiveStep(step)} 
+            onEdit={(step) => setActiveStep(step)}
           />
         </StepContent>
 
-
         <div className="flex justify-between pt-4 border-t">
-          <Button
-            variant="ghost"
-            onClick={handleBack}
-            disabled={isSubmitting}
-          >
+          <Button variant="ghost" onClick={handleBack} disabled={isSubmitting}>
             <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
             {activeStep === 0 ? 'Cancel' : 'Back'}
           </Button>
           <Button
             onClick={handleNext}
-            disabled={
-              isSubmitting ||
-              (activeStep === 0 && !formData.amount) ||
-              (activeStep === 1 && !formData.details) ||
-              (activeStep === 3 && isSubmitting)
-            }
+            disabled={isSubmitting || !canAdvanceFromStep(activeStep)}
             aria-busy={isSubmitting}
           >
             {isSubmitting ? (

--- a/frontend/src/components/claims/__tests__/ClaimWizard.test.tsx
+++ b/frontend/src/components/claims/__tests__/ClaimWizard.test.tsx
@@ -1,15 +1,13 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ClaimWizard } from '../ClaimWizard';
 import { useWallet } from '@/hooks/use-wallet';
 import { useRouter } from 'next/navigation';
+import { ClaimAPI } from '@/lib/api/claim';
 
-// Mock dependencies
 jest.mock('@/hooks/use-wallet');
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
-}));
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
 jest.mock('@/hooks/use-draft-persistence', () => ({
   useDraftPersistence: jest.fn(() => ({
     hasDraft: false,
@@ -20,209 +18,393 @@ jest.mock('@/hooks/use-draft-persistence', () => ({
 }));
 jest.mock('@/lib/api/claim', () => ({
   ClaimAPI: {
+    getConfig: jest.fn(),
     buildTransaction: jest.fn(),
     submitTransaction: jest.fn(),
   },
 }));
+jest.mock('@/lib/analytics', () => ({ trackClaimFiled: jest.fn() }));
 
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+const mockClaimAPI = ClaimAPI as jest.Mocked<typeof ClaimAPI>;
 
-describe('ClaimWizard - Review Step Integration', () => {
-  const mockRouter = {
-    push: jest.fn(),
-    back: jest.fn(),
-  };
+const mockRouter = { push: jest.fn(), back: jest.fn() };
+const mockWallet = {
+  address: 'GTEST123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  signTransaction: jest.fn(),
+  connectionStatus: 'connected' as const,
+};
+const mockPolicyCoverage = {
+  coverageAmount: 50000000,
+  currency: 'XLM',
+  status: 'ACTIVE',
+  expiresAt: '2027-01-01T00:00:00.000Z',
+};
 
-  const mockWallet = {
-    address: 'GTEST123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-    signTransaction: jest.fn(),
-    connectionStatus: 'connected' as const,
-  };
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseRouter.mockReturnValue(mockRouter as any);
+  mockUseWallet.mockReturnValue(mockWallet as any);
+  mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 1, maxEvidenceCount: 5 });
+});
 
-  const mockPolicyCoverage = {
-    coverageAmount: 50000000,
-    currency: 'XLM',
-    status: 'ACTIVE',
-    expiresAt: '2027-01-01T00:00:00.000Z',
-  };
+// ─── helpers ────────────────────────────────────────────────────────────────
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseRouter.mockReturnValue(mockRouter as any);
-    mockUseWallet.mockReturnValue(mockWallet as any);
+function renderWizard(props?: Partial<React.ComponentProps<typeof ClaimWizard>>) {
+  return render(
+    <ClaimWizard
+      policyId="123"
+      maxCoverage="100000000"
+      policyCoverage={mockPolicyCoverage}
+      {...props}
+    />,
+  );
+}
+
+/** Navigate to the review step (step 2) with minEvidence=0 */
+async function navigateToReview() {
+  mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+  renderWizard();
+  // Wait for config to load
+  await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+
+  // Step 0 → 1 (evidence step, minEvidence=0 so Next is enabled)
+  await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+  // Fill details
+  await waitFor(() => expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument());
+  fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+    target: { value: '5000000' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+    target: { value: 'Test narrative' },
   });
 
-  it('prevents signing until review step is reached', () => {
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
+  // Step 1 → 2
+  await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+  // Wait for review step
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument(),
+  );
+}
+
+// ─── Step navigation ─────────────────────────────────────────────────────────
+
+describe('ClaimWizard – step navigation', () => {
+  it('starts on Evidence step (step 0)', async () => {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    expect(screen.getByText('Evidence Collection')).toBeInTheDocument();
+  });
+
+  it('Next button is disabled on step 0 when no evidence uploaded', async () => {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    const nextBtn = screen.getByRole('button', { name: /next/i });
+    expect(nextBtn).toBeDisabled();
+  });
+
+  it('Back on step 0 calls router.back()', async () => {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockRouter.back).toHaveBeenCalled();
+  });
+
+  it('shows Confirm & Sign on last step', async () => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+
+    // Step 0 → 1 (minEvidence=0 so Next is enabled)
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    // Fill details
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument(),
     );
-
-    // Step 0: Amount - should show "Next" button, not "Confirm & Sign"
-    expect(screen.getByText('Next')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /confirm & sign/i })).not.toBeInTheDocument();
-  });
-
-  it('shows review step as penultimate step before signing', () => {
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
-    );
-
-    // Fill amount
-    const amountInput = screen.getByPlaceholderText(/Enter claim amount/i);
-    fireEvent.change(amountInput, { target: { value: '1000000' } });
-
-    // Navigate to step 2 (Narrative)
-    fireEvent.click(screen.getByText('Next'));
-
-    // Fill narrative
-    const narrativeInput = screen.getByPlaceholderText(/Describe what happened/i);
-    fireEvent.change(narrativeInput, { target: { value: 'Test incident description' } });
-
-    // Navigate to step 3 (Evidence)
-    fireEvent.click(screen.getByText('Next'));
-
-    // Navigate to step 4 (Review)
-    fireEvent.click(screen.getByText('Next'));
-
-    // Now we should see the review step content
-    expect(screen.getByText('Review Claim Details')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument();
-  });
-
-  it('displays all claim inputs on review step', () => {
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
-    );
-
-    // Fill and navigate through all steps
-    const amountInput = screen.getByPlaceholderText(/Enter claim amount/i);
-    fireEvent.change(amountInput, { target: { value: '5000000' } });
-    fireEvent.click(screen.getByText('Next'));
-
-    const narrativeInput = screen.getByPlaceholderText(/Describe what happened/i);
-    fireEvent.change(narrativeInput, { target: { value: 'Detailed incident report' } });
-    fireEvent.click(screen.getByText('Next'));
-
-    // Skip evidence for this test
-    fireEvent.click(screen.getByText('Next'));
-
-    // Verify review step shows all data
-    expect(screen.getByText('Review Claim Details')).toBeInTheDocument();
-    expect(screen.getByText(/0\.50/)).toBeInTheDocument(); // Amount (5000000 stroops = 0.50 XLM)
-    expect(screen.getAllByText('Detailed incident report').length).toBeGreaterThan(0); // Narrative
-    expect(screen.getByText('Policy ID: #123')).toBeInTheDocument();
-  });
-
-  it('allows editing from review step and preserves other field values', () => {
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
-    );
-
-    // Fill all fields
-    const amountInput = screen.getByPlaceholderText(/Enter claim amount/i);
-    fireEvent.change(amountInput, { target: { value: '5000000' } });
-    fireEvent.click(screen.getByText('Next'));
-
-    const narrativeInput = screen.getByPlaceholderText(/Describe what happened/i);
-    fireEvent.change(narrativeInput, { target: { value: 'Original narrative' } });
-    fireEvent.click(screen.getByText('Next'));
-
-    fireEvent.click(screen.getByText('Next')); // Skip evidence
-
-    // Now on review step - click Edit for amount
-    const editAmountButton = screen.getByRole('button', { name: /edit claim amount/i });
-    fireEvent.click(editAmountButton);
-
-    // Should be back on step 0
-    expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument();
-
-    // Navigate back to review
-    fireEvent.click(screen.getByText('Next')); // Amount
-    fireEvent.click(screen.getByText('Next')); // Narrative
-    fireEvent.click(screen.getByText('Next')); // Evidence
-
-    // Verify narrative is still preserved
-    expect(screen.getAllByText('Original narrative').length).toBeGreaterThan(0);
-  });
-
-  it('only triggers signing from review step', async () => {
-    const { ClaimAPI } = require('@/lib/api/claim');
-    ClaimAPI.buildTransaction.mockResolvedValue({
-      unsignedXdr: 'mock-xdr',
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '1000000' },
     });
-    mockWallet.signTransaction.mockResolvedValue('signed-xdr');
-    ClaimAPI.submitTransaction.mockResolvedValue({});
+    fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+      target: { value: 'Test incident' },
+    });
 
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
+    // Step 1 → 2
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument(),
     );
+  });
 
-    // Fill and navigate to review
-    const amountInput = screen.getByPlaceholderText(/Enter claim amount/i);
-    fireEvent.change(amountInput, { target: { value: '5000000' } });
-    fireEvent.click(screen.getByText('Next'));
+  it('Back from step 1 returns to step 0', async () => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
 
-    const narrativeInput = screen.getByPlaceholderText(/Describe what happened/i);
-    fireEvent.change(narrativeInput, { target: { value: 'Test narrative' } });
-    fireEvent.click(screen.getByText('Next'));
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
-    fireEvent.click(screen.getByText('Next')); // Evidence
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByText('Evidence Collection')).toBeInTheDocument();
+  });
+});
 
-    // Now on review step - click Confirm & Sign
-    const confirmButton = screen.getByRole('button', { name: /confirm & sign/i });
-    fireEvent.click(confirmButton);
+// ─── Contract config & evidence validation ───────────────────────────────────
 
-    // Verify signing was triggered
+describe('ClaimWizard – contract config & evidence validation', () => {
+  it('fetches contract config on mount', async () => {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows min-evidence error when no files uploaded', async () => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 2, maxEvidenceCount: 5 });
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    // The EvidenceStep renders inside the wizard; wait for it to reflect updated minEvidence
+    await waitFor(() =>
+      expect(
+        screen.getByText(/at least 2 files required before proceeding/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('blocks Next when evidence count is below minimum', async () => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 1, maxEvidenceCount: 5 });
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('falls back to defaults when getConfig fails', async () => {
+    mockClaimAPI.getConfig.mockRejectedValue(new Error('Network error'));
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    expect(screen.getByText('Evidence Collection')).toBeInTheDocument();
+    // Default minEvidence=1, so Next is disabled
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+});
+
+// ─── Details step validation ──────────────────────────────────────────────────
+
+describe('ClaimWizard – details step', () => {
+  beforeEach(() => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+  });
+
+  async function goToDetailsStep() {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument(),
+    );
+  }
+
+  it('Next is disabled on step 1 when amount is empty', async () => {
+    await goToDetailsStep();
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('Next is disabled on step 1 when narrative is empty', async () => {
+    await goToDetailsStep();
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '1000000' },
+    });
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('Next is enabled when both amount and narrative are filled', async () => {
+    await goToDetailsStep();
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '1000000' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+      target: { value: 'Incident description' },
+    });
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
+
+  it('preserves field values when navigating back and forward', async () => {
+    await goToDetailsStep();
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '5000000' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+      target: { value: 'Preserved narrative' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByDisplayValue('5000000')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Preserved narrative')).toBeInTheDocument();
+  });
+});
+
+// ─── Submission ───────────────────────────────────────────────────────────────
+
+describe('ClaimWizard – submission', () => {
+  it('calls buildTransaction and submitTransaction on Confirm & Sign', async () => {
+    mockClaimAPI.buildTransaction.mockResolvedValue({ unsignedXdr: 'mock-xdr' } as any);
+    mockWallet.signTransaction.mockResolvedValue('signed-xdr');
+    mockClaimAPI.submitTransaction.mockResolvedValue({ claimId: 42, transactionHash: 'hash' });
+
+    await navigateToReview();
+    fireEvent.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
     await waitFor(() => {
-      expect(ClaimAPI.buildTransaction).toHaveBeenCalledWith({
+      expect(mockClaimAPI.buildTransaction).toHaveBeenCalledWith({
         holder: mockWallet.address,
         policyId: 123,
         amount: '5000000',
         details: 'Test narrative',
         evidence: [],
       });
+      expect(mockClaimAPI.submitTransaction).toHaveBeenCalledWith('signed-xdr');
     });
   });
 
-  it('prevents URL manipulation by using state-based navigation', () => {
-    render(
-      <ClaimWizard
-        policyId="123"
-        maxCoverage="100000000"
-        policyCoverage={mockPolicyCoverage}
-      />
+  it('displays claim ID and link to claim detail page on success', async () => {
+    mockClaimAPI.buildTransaction.mockResolvedValue({ unsignedXdr: 'mock-xdr' } as any);
+    mockWallet.signTransaction.mockResolvedValue('signed-xdr');
+    mockClaimAPI.submitTransaction.mockResolvedValue({ claimId: 99, transactionHash: 'hash' });
+
+    await navigateToReview();
+    fireEvent.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Claim ID: #99/i)).toBeInTheDocument();
+    });
+
+    const viewLink = screen.getByRole('link', { name: /view claim/i });
+    expect(viewLink).toHaveAttribute('href', '/claims/99');
+  });
+
+  it('prevents duplicate submissions via submittingRef guard', async () => {
+    let resolveSubmit!: (v: { claimId: number; transactionHash: string }) => void;
+    mockClaimAPI.buildTransaction.mockResolvedValue({ unsignedXdr: 'mock-xdr' } as any);
+    mockWallet.signTransaction.mockResolvedValue('signed-xdr');
+    mockClaimAPI.submitTransaction.mockImplementation(
+      () => new Promise<{ claimId: number; transactionHash: string }>(resolve => { resolveSubmit = resolve; }),
     );
 
-    // The wizard uses internal state (activeStep) not URL params
-    // Users cannot skip to review step via URL
-    // Verify we start at step 0
-    expect(screen.getByText('Enter claim amount')).toBeInTheDocument();
-    // The wizard uses internal state (activeStep) not URL params for navigation
-    // Verify we start at step 0 by checking the amount input is present
-    expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument();
+    await navigateToReview();
+    const confirmBtn = screen.getByRole('button', { name: /confirm & sign/i });
+    fireEvent.click(confirmBtn);
 
-    // The only way to reach review is through sequential navigation
-    // which is controlled by the Next button and activeStep state
+    // Wait for submission to start (button becomes disabled/loading)
+    await waitFor(() => expect(confirmBtn).toBeDisabled());
+
+    // Second click while in-flight (button is disabled, but also test the ref guard)
+    fireEvent.click(confirmBtn);
+
+    await act(async () => {
+      resolveSubmit({ claimId: 1, transactionHash: 'hash' });
+    });
+
+    // submitTransaction should only be called once
+    expect(mockClaimAPI.submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error toast and re-enables button on submission failure', async () => {
+    mockClaimAPI.buildTransaction.mockRejectedValue(new Error('Build failed'));
+
+    await navigateToReview();
+    fireEvent.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeEnabled();
+    });
+  });
+
+  it('does not call buildTransaction when wallet is not connected', async () => {
+    // Override wallet mock to have no address
+    mockUseWallet.mockReturnValue({ ...mockWallet, address: undefined } as any);
+
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+
+    // Navigate to review
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '5000000' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+      target: { value: 'Test narrative' },
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /confirm & sign/i }));
+
+    await waitFor(() => {
+      expect(mockClaimAPI.buildTransaction).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ─── Review step edit navigation ─────────────────────────────────────────────
+
+describe('ClaimWizard – review step edit links', () => {
+  beforeEach(() => {
+    mockClaimAPI.getConfig.mockResolvedValue({ minEvidenceCount: 0, maxEvidenceCount: 5 });
+  });
+
+  async function goToReview() {
+    renderWizard();
+    await waitFor(() => expect(mockClaimAPI.getConfig).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByPlaceholderText(/Enter claim amount/i), {
+      target: { value: '1000000' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Describe what happened/i), {
+      target: { value: 'Narrative' },
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument(),
+    );
+  }
+
+  it('Edit evidence navigates back to step 0', async () => {
+    await goToReview();
+    fireEvent.click(screen.getByRole('button', { name: /edit evidence/i }));
+    expect(screen.getByText('Evidence Collection')).toBeInTheDocument();
+  });
+
+  it('Edit amount navigates back to step 1', async () => {
+    await goToReview();
+    fireEvent.click(screen.getByRole('button', { name: /edit claim amount/i }));
+    expect(screen.getByPlaceholderText(/Enter claim amount/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/claims/__tests__/EvidenceStep.test.tsx
+++ b/frontend/src/components/claims/__tests__/EvidenceStep.test.tsx
@@ -1,34 +1,158 @@
-import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { EvidenceStep } from '../steps/EvidenceStep'
+import { EvidenceStep } from '../steps/EvidenceStep';
 
+// NOTE: jest.mock is hoisted before variable declarations, so we use literals here.
 jest.mock('@/lib/ipfs-upload', () => ({
   computeFileSha256Hex: jest.fn().mockResolvedValue(
     '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
   ),
   uploadFileWithProgress: jest.fn(),
-}))
+}));
+
+const MOCK_CID = 'QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7hh5XBnZASHxxx';
+const MOCK_HASH = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+const MOCK_URL = `https://ipfs.io/ipfs/${MOCK_CID}`;
+
+function makeFile(name = 'test.png') {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' });
+}
+
+function selectFile(container: HTMLElement, file: File) {
+  const input = container.querySelector('#file-upload') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+}
 
 describe('EvidenceStep', () => {
-  it('shows retry action on upload failure without mutating evidence list', async () => {
-    const onChange = jest.fn()
-    const { container } = render(<EvidenceStep evidence={[]} onChange={onChange} />)
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    const fileInput = container.querySelector('#file-upload') as HTMLInputElement
-    const file = new File([new Uint8Array([1, 2, 3])], 'test.png', { type: 'image/png' })
-    fireEvent.change(fileInput, { target: { files: [file] } })
+  it('shows retry action on upload failure without mutating evidence list', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<EvidenceStep evidence={[]} onChange={onChange} />);
 
     const { uploadFileWithProgress } = jest.requireMock('@/lib/ipfs-upload') as {
-      uploadFileWithProgress: jest.Mock
-    }
-    uploadFileWithProgress.mockRejectedValueOnce(new Error('Network error during upload'))
+      uploadFileWithProgress: jest.Mock;
+    };
+    uploadFileWithProgress.mockRejectedValueOnce(new Error('Network error during upload'));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+    selectFile(container, makeFile());
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
-    })
-    expect(onChange).not.toHaveBeenCalled()
-  })
-})
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('displays CID preview after successful upload', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<EvidenceStep evidence={[]} onChange={onChange} />);
+
+    const { uploadFileWithProgress } = jest.requireMock('@/lib/ipfs-upload') as {
+      uploadFileWithProgress: jest.Mock;
+    };
+    uploadFileWithProgress.mockResolvedValueOnce({
+      cid: MOCK_CID,
+      gatewayUrls: [MOCK_URL],
+      contentSha256Hex: MOCK_HASH,
+    });
+
+    selectFile(container, makeFile());
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cid-preview')).toHaveTextContent(MOCK_CID);
+    });
+  });
+
+  it('calls onChange with cid, url, and contentSha256Hex on success', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<EvidenceStep evidence={[]} onChange={onChange} />);
+
+    const { uploadFileWithProgress } = jest.requireMock('@/lib/ipfs-upload') as {
+      uploadFileWithProgress: jest.Mock;
+    };
+    uploadFileWithProgress.mockResolvedValueOnce({
+      cid: MOCK_CID,
+      gatewayUrls: [MOCK_URL],
+      contentSha256Hex: MOCK_HASH,
+    });
+
+    selectFile(container, makeFile());
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        { cid: MOCK_CID, url: MOCK_URL, contentSha256Hex: MOCK_HASH },
+      ]);
+    });
+  });
+
+  it('shows min-evidence error when evidence count is below minimum', () => {
+    render(<EvidenceStep evidence={[]} onChange={jest.fn()} minEvidence={2} maxEvidence={5} />);
+    expect(
+      screen.getByText(/at least 2 files required before proceeding/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows max-evidence message when at limit', () => {
+    const evidence = [
+      { cid: 'Qm1', url: 'https://ipfs.io/ipfs/Qm1', contentSha256Hex: 'a'.repeat(64) },
+      { cid: 'Qm2', url: 'https://ipfs.io/ipfs/Qm2', contentSha256Hex: 'b'.repeat(64) },
+    ];
+    render(<EvidenceStep evidence={evidence} onChange={jest.fn()} minEvidence={1} maxEvidence={2} />);
+    expect(screen.getByText(/maximum of 2 files reached/i)).toBeInTheDocument();
+  });
+
+  it('retries upload successfully after initial failure', async () => {
+    const onChange = jest.fn();
+    const { container } = render(<EvidenceStep evidence={[]} onChange={onChange} />);
+
+    const { uploadFileWithProgress } = jest.requireMock('@/lib/ipfs-upload') as {
+      uploadFileWithProgress: jest.Mock;
+    };
+    uploadFileWithProgress
+      .mockRejectedValueOnce(new Error('Network error during upload'))
+      .mockResolvedValueOnce({
+        cid: MOCK_CID,
+        gatewayUrls: [MOCK_URL],
+        contentSha256Hex: MOCK_HASH,
+      });
+
+    selectFile(container, makeFile());
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cid-preview')).toHaveTextContent(MOCK_CID);
+    });
+    expect(onChange).toHaveBeenCalledWith([
+      { cid: MOCK_CID, url: MOCK_URL, contentSha256Hex: MOCK_HASH },
+    ]);
+  });
+
+  it('does not corrupt evidence list when upload is cancelled before starting', () => {
+    const onChange = jest.fn();
+    const existingEvidence = [
+      { cid: 'QmExisting', url: 'https://ipfs.io/ipfs/QmExisting', contentSha256Hex: 'c'.repeat(64) },
+    ];
+    const { container } = render(
+      <EvidenceStep evidence={existingEvidence} onChange={onChange} />,
+    );
+
+    selectFile(container, makeFile('new.png'));
+
+    // Cancel before uploading (no cid yet, so onChange should not be called)
+    fireEvent.click(screen.getByRole('button', { name: /remove new\.png/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/claims/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/components/claims/__tests__/ReviewStep.test.tsx
@@ -11,12 +11,14 @@ describe('ReviewStep', () => {
     details: 'This is a test claim narrative documenting the incident.',
     evidence: [
       {
-        url: 'ipfs://QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7h...',
+        cid: 'QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7hh5XBnZASHxxx',
+        url: 'https://ipfs.io/ipfs/QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7hh5XBnZASHxxx',
         contentSha256Hex:
           'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
       },
       {
-        url: 'https://example.com/long-file-name-that-should-be-truncated-in-ui.jpg',
+        cid: 'QmABC123def456',
+        url: 'https://ipfs.io/ipfs/QmABC123def456',
         contentSha256Hex:
           '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b',
       },
@@ -39,92 +41,68 @@ describe('ReviewStep', () => {
   it('renders all claim data correctly', () => {
     render(<ReviewStep data={mockData} policyId={policyId} />);
 
-    // Check amount (1000 minor units with 7 decimals = 0.0001 XLM)
+    // Amount (1000 minor units with 7 decimals = 0.0001 XLM)
     expect(screen.getByText(/0\.0001/)).toBeInTheDocument();
 
-    // Check policy ID
+    // Policy ID
     expect(screen.getByText('Policy ID: #12345')).toBeInTheDocument();
 
-    // Check narrative
+    // Narrative
     expect(
-      screen.getByText('This is a test claim narrative documenting the incident.')
+      screen.getByText('This is a test claim narrative documenting the incident.'),
     ).toBeInTheDocument();
 
-    // Check evidence count
+    // Evidence count
     expect(screen.getByText('Evidence (2 files)')).toBeInTheDocument();
 
-    // Check evidence items
-    expect(screen.getByText('QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7h...')).toBeInTheDocument();
+    // CIDs shown
     expect(
-      screen.getByText('long-file-name-that-should-be-truncated-in-ui.jpg')
+      screen.getByText('QmYwAPJzv5CZsnA625s3Xf2SmxWeN4A7hh5XBnZASHxxx'),
     ).toBeInTheDocument();
+    expect(screen.getByText('QmABC123def456')).toBeInTheDocument();
 
-    // Check hashes (first and last parts)
+    // Hashes (truncated)
     expect(screen.getByText('e3b0c44298fc1c14...7852b855')).toBeInTheDocument();
     expect(screen.getByText('01ba4719c80b6fe9...daca546b')).toBeInTheDocument();
   });
 
   it('renders policy coverage details when provided', () => {
     render(
-      <ReviewStep data={mockData} policyId={policyId} policyCoverage={mockPolicyCoverage} />
+      <ReviewStep data={mockData} policyId={policyId} policyCoverage={mockPolicyCoverage} />,
     );
 
-    // Coverage section heading
     expect(screen.getByText('Policy Coverage')).toBeInTheDocument();
-
-    // Coverage amount (50000000 stroops = 5 XLM)
-    expect(screen.getByText(/5\.00/)).toBeInTheDocument();
-
-    // Status (lowercased)
+    expect(screen.getByText(/5\.00/)).toBeInTheDocument(); // 50000000 stroops = 5 XLM
     expect(screen.getByText('active')).toBeInTheDocument();
-
-    // Expiry date rendered
     expect(screen.getByText(/2027/)).toBeInTheDocument();
   });
 
-  it('does not render policy coverage section when policyCoverage is omitted', () => {
+  it('does not render policy coverage section when omitted', () => {
     render(<ReviewStep data={mockData} policyId={policyId} />);
     expect(screen.queryByText('Policy Coverage')).not.toBeInTheDocument();
   });
 
   it('handles empty evidence correctly', () => {
     render(<ReviewStep data={{ ...mockData, evidence: [] }} policyId={policyId} />);
-
     expect(screen.getByText('Evidence (0 files)')).toBeInTheDocument();
     expect(screen.getByText('No evidence uploaded.')).toBeInTheDocument();
   });
 
-  it('triggers onEdit with correct step index when Edit is clicked', () => {
+  it('triggers onEdit(0) for evidence, onEdit(1) for amount and narrative', () => {
     render(<ReviewStep data={mockData} policyId={policyId} onEdit={mockOnEdit} />);
 
-    // Edit Amount
     fireEvent.click(screen.getByRole('button', { name: /edit claim amount/i }));
-    expect(mockOnEdit).toHaveBeenCalledWith(0);
+    expect(mockOnEdit).toHaveBeenCalledWith(1);
 
-    // Edit Narrative
     fireEvent.click(screen.getByRole('button', { name: /edit narrative/i }));
     expect(mockOnEdit).toHaveBeenCalledWith(1);
 
-    // Edit Evidence
     fireEvent.click(screen.getByRole('button', { name: /edit evidence/i }));
-    expect(mockOnEdit).toHaveBeenCalledWith(2);
+    expect(mockOnEdit).toHaveBeenCalledWith(0);
   });
 
   it('does not render Edit buttons when onEdit is not provided', () => {
     render(<ReviewStep data={mockData} policyId={policyId} />);
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
-  });
-
-  it('renders all evidence file names and hashes', () => {
-    const evidence = [
-      {
-        url: 'ipfs://QmABC123/photo.jpg',
-        contentSha256Hex: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
-      },
-    ];
-    render(<ReviewStep data={{ ...mockData, evidence }} policyId={policyId} />);
-
-    expect(screen.getByText('photo.jpg')).toBeInTheDocument();
-    expect(screen.getByText('abcdef1234567890...34567890')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/claims/steps/DetailsStep.tsx
+++ b/frontend/src/components/claims/steps/DetailsStep.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Label } from '@/components/ui';
+import { NumericInput } from '@/components/ui';
+import { formatTokenAmount } from '@/lib/formatTokenAmount';
+
+interface DetailsStepProps {
+  amount: string;
+  details: string;
+  onAmountChange: (amount: string) => void;
+  onDetailsChange: (details: string) => void;
+  maxCoverage: string;
+  decimals?: number;
+  currency?: string;
+  locale?: string;
+}
+
+export function DetailsStep({
+  amount,
+  details,
+  onAmountChange,
+  onDetailsChange,
+  maxCoverage,
+  decimals = 7,
+  currency = 'XLM',
+  locale = 'en-US',
+}: DetailsStepProps) {
+  return (
+    <div className="space-y-6 py-4">
+      <div className="space-y-2">
+        <Label htmlFor="amount">Claim Amount ({currency})</Label>
+        <NumericInput
+          id="amount"
+          value={amount}
+          onChange={(e) => onAmountChange(e.target.value)}
+          placeholder={`Enter claim amount (e.g. 10000000 for 1 ${currency})`}
+          min="1"
+          max={maxCoverage}
+        />
+        <p className="text-sm text-muted-foreground">
+          Maximum coverage: {formatTokenAmount(maxCoverage || '0', decimals, locale)} {currency}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="details">Claim Narrative</Label>
+        <textarea
+          id="details"
+          value={details}
+          onChange={(e) => onDetailsChange(e.target.value)}
+          placeholder="Describe what happened and why you are filing this claim..."
+          className="min-h-[160px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          maxLength={1000}
+        />
+        <p className="text-right text-xs text-muted-foreground">{details.length}/1000</p>
+      </div>
+
+      <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-900/30 dark:bg-yellow-900/20">
+        <p className="text-sm text-yellow-800 dark:text-yellow-200">
+          <strong>Privacy Warning:</strong> Do not include sensitive personal information (SSN,
+          medical records, etc.) in the narrative. Focus on the event details.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/claims/steps/EvidenceStep.tsx
+++ b/frontend/src/components/claims/steps/EvidenceStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { X, Upload, FileText, AlertTriangle, CheckCircle2 } from 'lucide-react';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 
 import { Button, Progress, Label } from '@/components/ui';
 import {
@@ -14,119 +14,109 @@ interface FileUploadState {
   file: File;
   progress: number;
   status: 'pending' | 'hashing' | 'uploading' | 'completed' | 'error';
+  cid?: string;
   url?: string;
   hash?: string;
   error?: string;
   controller?: AbortController;
 }
 
-export type EvidenceAttachment = { url: string; contentSha256Hex: string };
+export type EvidenceAttachment = { cid: string; url: string; contentSha256Hex: string };
 
 interface EvidenceStepProps {
   evidence: EvidenceAttachment[];
   onChange: (items: EvidenceAttachment[]) => void;
+  minEvidence?: number;
+  maxEvidence?: number;
 }
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
-export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
+export function EvidenceStep({ evidence, onChange, minEvidence = 1, maxEvidence = 5 }: EvidenceStepProps) {
   const [uploads, setUploads] = useState<Record<string, FileUploadState>>({});
+  const uploadsRef = useRef<Record<string, FileUploadState>>({});
+  const evidenceRef = useRef(evidence);
+  evidenceRef.current = evidence;
+
   const [consent, setConsent] = useState(false);
+
+  const completedCount = evidence.length;
+  const belowMin = completedCount < minEvidence;
+  const atMax = completedCount >= maxEvidence;
+
+  const updateUpload = useCallback((id: string, patch: Partial<FileUploadState>) => {
+    setUploads(prev => {
+      const next = { ...prev, [id]: { ...prev[id], ...patch } };
+      uploadsRef.current = next;
+      return next;
+    });
+  }, []);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
-    const newUploads = { ...uploads };
+    e.target.value = '';
 
-    files.forEach((file) => {
-      // Validation
-      if (file.size > MAX_FILE_SIZE) {
-        alert(`File ${file.name} is too large. Max size is 5MB.`);
-        return;
-      }
-      if (!ALLOWED_TYPES.includes(file.type)) {
-        alert(`File ${file.name} has unsupported type. Use JPEG, PNG or WebP.`);
-        return;
-      }
-
-      const id = `${file.name}-${Date.now()}`;
-      newUploads[id] = {
-        file,
-        progress: 0,
-        status: 'pending',
-      };
+    setUploads(prev => {
+      const next = { ...prev };
+      files.forEach((file) => {
+        if (file.size > MAX_FILE_SIZE || !ALLOWED_TYPES.includes(file.type)) return;
+        const id = `${file.name}-${Date.now()}-${Math.random()}`;
+        next[id] = { file, progress: 0, status: 'pending' };
+      });
+      uploadsRef.current = next;
+      return next;
     });
+  }, []);
 
-    setUploads(newUploads);
-  }, [uploads]);
-
-  const startUpload = async (id: string) => {
-    const upload = uploads[id];
-    if (!upload || upload.status === 'uploading') return;
+  const startUpload = useCallback(async (id: string) => {
+    const upload = uploadsRef.current[id];
+    if (!upload || upload.status === 'uploading' || upload.status === 'hashing') return;
 
     const controller = new AbortController();
-    setUploads(prev => ({
-      ...prev,
-      [id]: { ...prev[id], status: 'hashing', progress: 0, controller, error: undefined }
-    }));
+    updateUpload(id, { status: 'hashing', progress: 0, controller, error: undefined });
 
     try {
       const contentSha256Hex = await computeFileSha256Hex(upload.file);
-      setUploads(prev => ({
-        ...prev,
-        [id]: { ...prev[id], hash: contentSha256Hex, status: 'uploading' },
-      }));
+      updateUpload(id, { hash: contentSha256Hex, status: 'uploading' });
 
       const response = await uploadFileWithProgress(
         upload.file,
-        (p: UploadProgress) => {
-          setUploads(prev => ({
-            ...prev,
-            [id]: { ...prev[id], progress: p.percentage }
-          }));
-        },
+        (p: UploadProgress) => updateUpload(id, { progress: p.percentage }),
         controller.signal,
         3,
-        contentSha256Hex
+        contentSha256Hex,
       );
 
+      const cid = response.cid;
       const url = response.gatewayUrls[0] || '';
-      setUploads(prev => ({
-        ...prev,
-        [id]: {
-          ...prev[id],
-          status: 'completed',
-          progress: 100,
-          url,
-          hash: contentSha256Hex,
-        }
-      }));
+      updateUpload(id, { status: 'completed', progress: 100, cid, url });
 
-      const nextEvidence = evidence.filter((entry) => entry.url !== url);
-      onChange([...nextEvidence, { url, contentSha256Hex }]);
+      const current = evidenceRef.current;
+      onChange([...current.filter(e => e.cid !== cid), { cid, url, contentSha256Hex }]);
     } catch (err) {
       if (err instanceof Error && err.message === 'Upload aborted') return;
-      
-      setUploads(prev => ({
-        ...prev,
-        [id]: { ...prev[id], status: 'error', error: err instanceof Error ? err.message : 'Upload failed' }
-      }));
+      updateUpload(id, {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Upload failed',
+      });
     }
-  };
+  }, [updateUpload, onChange]);
 
-  const cancelUpload = (id: string) => {
-    const upload = uploads[id];
-    if (upload.controller) {
-      upload.controller.abort();
+  const cancelUpload = useCallback((id: string) => {
+    const upload = uploadsRef.current[id];
+    if (!upload) return;
+    upload.controller?.abort();
+    if (upload.cid) {
+      onChange(evidenceRef.current.filter(e => e.cid !== upload.cid));
     }
-    const newUploads = { ...uploads };
-    delete newUploads[id];
-    setUploads(newUploads);
-
-    if (upload.url) {
-      onChange(evidence.filter((e) => e.url !== upload.url));
-    }
-  };
+    setUploads(prev => {
+      const next = { ...prev };
+      delete next[id];
+      uploadsRef.current = next;
+      return next;
+    });
+  }, [onChange]);
 
   return (
     <div className="space-y-6 py-4">
@@ -135,7 +125,12 @@ export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
           <Upload className="mx-auto h-10 w-10 text-muted-foreground/50" />
           <h3 className="mt-4 text-lg font-semibold">Evidence Collection</h3>
           <p className="mt-2 text-sm text-muted-foreground">
-            Upload photos or documents as evidence for your claim. Max 5MB per file.
+            Upload photos or documents as evidence. Max 5MB per file.
+            {minEvidence > 0 && (
+              <span className="block mt-1">
+                Required: {minEvidence}–{maxEvidence} files.
+              </span>
+            )}
           </p>
           <div className="mt-6">
             <input
@@ -145,14 +140,35 @@ export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
               accept="image/*"
               className="hidden"
               onChange={handleFileSelect}
+              disabled={atMax}
             />
-            <Button asChild variant="outline">
-              <label htmlFor="file-upload" className="cursor-pointer">
+            <Button asChild variant="outline" disabled={atMax}>
+              <label
+                htmlFor="file-upload"
+                className={atMax ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}
+              >
                 Select Files
               </label>
             </Button>
           </div>
         </div>
+
+        {/* Validation messages */}
+        {belowMin && completedCount === 0 && (
+          <p role="alert" className="text-sm text-destructive">
+            At least {minEvidence} file{minEvidence !== 1 ? 's' : ''} required before proceeding.
+          </p>
+        )}
+        {belowMin && completedCount > 0 && (
+          <p role="alert" className="text-sm text-destructive">
+            At least {minEvidence} file{minEvidence !== 1 ? 's' : ''} required. {completedCount} uploaded so far.
+          </p>
+        )}
+        {atMax && (
+          <p className="text-sm text-muted-foreground">
+            Maximum of {maxEvidence} files reached.
+          </p>
+        )}
 
         {/* Upload List */}
         <div className="space-y-3">
@@ -168,21 +184,28 @@ export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
                     <Button size="sm" onClick={() => startUpload(id)}>Upload</Button>
                   )}
                   {upload.status === 'error' && (
-                    <Button size="sm" variant="outline" onClick={() => startUpload(id)}>
-                      Retry
-                    </Button>
+                    <>
+                      <span className="text-xs text-destructive">{upload.error}</span>
+                      <Button size="sm" variant="outline" onClick={() => startUpload(id)}>
+                        Retry
+                      </Button>
+                    </>
                   )}
                   {upload.status === 'completed' && (
                     <CheckCircle2 className="h-5 w-5 text-green-500" />
                   )}
-                  {upload.status === 'error' && (
-                    <span className="text-xs text-destructive">{upload.error}</span>
-                  )}
-                  <Button size="icon" variant="ghost" className="h-8 w-8" onClick={() => cancelUpload(id)}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={() => cancelUpload(id)}
+                    aria-label={`Remove ${upload.file.name}`}
+                  >
                     <X className="h-4 w-4" />
                   </Button>
                 </div>
               </div>
+
               {upload.status === 'uploading' && (
                 <div className="space-y-1">
                   <Progress value={upload.progress} className="h-1.5" />
@@ -195,6 +218,32 @@ export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
               {upload.status === 'hashing' && (
                 <p className="text-[10px] text-muted-foreground">Computing SHA-256 hash...</p>
               )}
+
+              {/* CID preview — shown immediately after upload completes */}
+              {upload.status === 'completed' && upload.cid && (
+                <div className="rounded-md bg-muted/50 p-2 space-y-1">
+                  <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide">
+                    IPFS CID
+                  </p>
+                  <p
+                    className="text-[11px] font-mono break-all text-foreground"
+                    data-testid="cid-preview"
+                  >
+                    {upload.cid}
+                  </p>
+                  {upload.url && (
+                    <a
+                      href={upload.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-primary hover:underline"
+                    >
+                      View on gateway ↗
+                    </a>
+                  )}
+                </div>
+              )}
+
               {upload.hash && (
                 <div className="text-[10px] text-muted-foreground font-mono break-all">
                   SHA-256: {upload.hash}
@@ -209,10 +258,12 @@ export function EvidenceStep({ evidence, onChange }: EvidenceStepProps) {
         <div className="flex gap-3">
           <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-500" />
           <div className="space-y-2">
-            <h4 className="text-sm font-bold text-yellow-900 dark:text-yellow-200">Legal & Privacy Reminder</h4>
+            <h4 className="text-sm font-bold text-yellow-900 dark:text-yellow-200">
+              Legal &amp; Privacy Reminder
+            </h4>
             <ul className="list-disc pl-4 text-xs text-yellow-800 space-y-1 dark:text-yellow-300">
-              <li>Evidence uploaded via IPFS is **permanently immutable**. It cannot be deleted.</li>
-              <li>Please **redact** any PII (Personally Identifiable Information) that is not relevant to the claim.</li>
+              <li>Evidence uploaded via IPFS is permanently immutable. It cannot be deleted.</li>
+              <li>Please redact any PII not relevant to the claim.</li>
               <li>Ensure you have the right to share these images.</li>
             </ul>
             <div className="flex items-center space-x-2 pt-2">

--- a/frontend/src/components/claims/steps/ReviewStep.tsx
+++ b/frontend/src/components/claims/steps/ReviewStep.tsx
@@ -2,6 +2,7 @@ import { FileText, Image as ImageIcon, Wallet, ShieldCheck } from 'lucide-react'
 
 import { Card, CardContent } from '@/components/ui';
 import { formatTokenAmount } from '@/lib/formatTokenAmount';
+import type { EvidenceAttachment } from './EvidenceStep';
 
 export interface PolicyCoverageDetails {
   coverageAmount: number;
@@ -14,7 +15,7 @@ interface ReviewStepProps {
   data: {
     amount: string;
     details: string;
-    evidence: { url: string; contentSha256Hex: string }[];
+    evidence: EvidenceAttachment[];
   };
   policyId: string;
   policyCoverage?: PolicyCoverageDetails;
@@ -86,7 +87,7 @@ export function ReviewStep({
                   <p className="text-xs font-medium text-muted-foreground">Claim Amount</p>
                   {onEdit && (
                     <button
-                      onClick={() => onEdit(0)}
+                      onClick={() => onEdit(1)}
                       className="text-xs font-medium text-primary hover:underline"
                       aria-label="Edit claim amount"
                     >
@@ -143,7 +144,7 @@ export function ReviewStep({
                   </p>
                   {onEdit && (
                     <button
-                      onClick={() => onEdit(2)}
+                      onClick={() => onEdit(0)}
                       className="text-xs font-medium text-primary hover:underline"
                       aria-label="Edit evidence"
                     >
@@ -159,17 +160,14 @@ export function ReviewStep({
                         className="flex flex-col gap-1 rounded-md border bg-muted/30 p-2 text-xs"
                       >
                         <div className="flex items-center justify-between">
-                          <span
-                            className="font-medium truncate max-w-[200px]"
-                            title={item.url}
-                          >
-                            {item.url.split('/').pop() || 'file'}
+                          <span className="font-mono font-medium truncate max-w-[200px]" title={item.cid}>
+                            {item.cid}
                           </span>
                           <a
                             href={item.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-primary hover:underline"
+                            className="text-primary hover:underline shrink-0 ml-2"
                           >
                             View
                           </a>

--- a/frontend/src/lib/api/claim.ts
+++ b/frontend/src/lib/api/claim.ts
@@ -2,6 +2,11 @@ import { getConfig } from '@/config/env';
 
 const { apiUrl: API_BASE_URL } = getConfig();
 
+export interface ClaimsConfig {
+  minEvidenceCount: number;
+  maxEvidenceCount: number;
+}
+
 export interface Claim {
   id: number;
   policyId: string;
@@ -32,6 +37,11 @@ export class ClaimAPI {
       throw new Error(errorData.message || 'API Error');
     }
     return response.json();
+  }
+
+  static async getConfig(): Promise<ClaimsConfig> {
+    const response = await fetch(`${API_BASE_URL}/api/claims/config`);
+    return this.handleResponse<ClaimsConfig>(response);
   }
 
   static async buildTransaction(data: {


### PR DESCRIPTION
Closes #655

---

## What

Rebuilds the claim filing wizard from a 4-step flow into a focused, reliable **3-step flow**:

| Step | Name | Content |
|------|------|---------|
| 1 | Evidence | IPFS upload with CID preview |
| 2 | Details | Amount + narrative combined |
| 3 | Sign & Submit | Review + wallet signing |

## Why

The previous wizard had several reliability gaps: no CID preview after upload, no contract-driven evidence count validation, no duplicate submission guard, and the success screen discarded the returned claim ID instead of linking to the detail page.

## Changes

### `ClaimWizard.tsx`
- Restructured to 3 steps: Evidence → Details → Sign & Submit
- Fetches `/api/claims/config` on mount for `minEvidenceCount` / `maxEvidenceCount`; falls back to defaults (1–5) on network failure (non-fatal, no crash)
- `canAdvanceFromStep()` blocks **Next** until evidence count ≥ min and both amount + narrative are filled — inline validation, no progression until resolved
- `submittingRef` guard prevents duplicate submissions independent of React state
- Success screen displays **Claim ID: #N** and a working `<Link href="/claims/[claimId]">` to the detail page
- Draft persistence bumped to schema version 2

### `EvidenceStep.tsx`
- `EvidenceAttachment` type now includes `cid` alongside `url` + `contentSha256Hex`
- **CID preview** rendered immediately after upload completes (`data-testid="cid-preview"`)
- Inline `role="alert"` validation messages for below-min and at-max evidence counts
- `useRef` tracks current uploads/evidence to avoid stale closure bugs in async upload handlers
- Graceful retry: failed uploads show **Retry** button without corrupting wizard state
- Cancel before upload does not call `onChange` (no state corruption)

### `DetailsStep.tsx` *(new)*
- Combined amount + narrative step replacing the separate `AmountStep` + `NarrativeStep`

### `ReviewStep.tsx`
- Updated to consume `EvidenceAttachment` with `cid`; displays CID in evidence list
- Edit buttons correctly map to step 0 (evidence) and step 1 (details)

### `lib/api/claim.ts`
- Added `ClaimsConfig` interface `{ minEvidenceCount, maxEvidenceCount }`
- Added `ClaimAPI.getConfig()` static method calling `GET /api/claims/config`

## Tests

**33 tests passing, 0 regressions introduced.**

| File | Coverage |
|------|----------|
| `ClaimWizard.test.tsx` | Step navigation, contract config fetch + fallback, min-evidence blocking, field validation + persistence, successful submission, claim ID + link display, duplicate submission prevention, error recovery, wallet-not-connected guard |
| `EvidenceStep.test.tsx` | Successful upload → CID preview, `onChange` payload shape, failure → Retry (no state corruption), retry success, min/max inline messages, cancel before upload |
| `ReviewStep.test.tsx` | Updated for new `EvidenceAttachment` shape with `cid` |

Pre-existing failures in `copy-button`, `use-copy-to-clipboard`, and `translations` test suites are unaffected and were present before this PR.

## Testing

```bash
cd frontend
NEXT_PUBLIC_API_URL=http://localhost:3001 npx jest src/components/claims/__tests__
```