### PR TITLE
feat(contract): emit asset_set event on allowlist add/remove (#589)

### DIFF
--- a/contracts/niffyinsure/src/events.rs
+++ b/contracts/niffyinsure/src/events.rs
@@ -115,7 +115,7 @@
 //! See those modules for field-level documentation.
 
 use crate::types::{ClaimStatus, VoteOption};
-use soroban_sdk::{contractevent, Address, BytesN, Env, Vec};
+use soroban_sdk::{contractevent, Address, BytesN, Env, String, Vec};
 
 /// Bump this when any event payload has a breaking change (semver-major release).
 pub const EVENT_SCHEMA_VERSION: u32 = 1;
@@ -317,7 +317,7 @@ pub fn emit_premium_table_updated(env: &Env, table_version: u32) {
     .publish(env);
 }
 
-/// Emitted by `set_allowed_asset`.
+/// Emitted by `set_allowed_asset` on every call (idempotent — emitted even if state unchanged).
 /// topics: (NS, "asset_set", asset)
 /// payload: AssetAllowlistedData
 #[contractevent(topics = ["niffyins", "asset_set"])]
@@ -328,13 +328,25 @@ pub struct AssetAllowlistedData {
     pub version: u32,
     /// 1 = added to allowlist, 0 = removed.
     pub allowed: u32,
+    /// Human-readable ticker hint (e.g. "USDC"). Empty string on removal.
+    pub symbol_hint: String,
+    /// Token decimal places (e.g. 7 for XLM). 0 on removal.
+    pub decimals: u32,
 }
 
-pub fn emit_asset_allowlisted(env: &Env, asset: &Address, allowed: bool) {
+pub fn emit_asset_allowlisted(
+    env: &Env,
+    asset: &Address,
+    allowed: bool,
+    symbol_hint: String,
+    decimals: u32,
+) {
     AssetAllowlistedData {
         asset: asset.clone(),
         version: EVENT_SCHEMA_VERSION,
         allowed: if allowed { 1 } else { 0 },
+        symbol_hint,
+        decimals,
     }
     .publish(env);
 }

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -213,11 +213,33 @@ impl NiffyInsure {
     }
 
     /// Admin-only: add or remove an asset from the allowlist.
-    pub fn set_allowed_asset(env: Env, asset: Address, allowed: bool) {
+    /// Always emits `asset_set` (idempotent — even if the state is unchanged).
+    pub fn set_allowed_asset(
+        env: Env,
+        asset: Address,
+        allowed: bool,
+        symbol_hint: soroban_sdk::String,
+        decimals: u32,
+    ) {
         let _admin = admin::require_admin(&env);
         storage::bump_instance(&env);
         claim::set_allowed_asset(&env, &asset, allowed);
-        AllowedAssetUpdated { asset, allowed }.publish(&env);
+        AllowedAssetUpdated {
+            asset: asset.clone(),
+            allowed,
+        }
+        .publish(&env);
+        events::emit_asset_allowlisted(
+            &env,
+            &asset,
+            allowed,
+            if allowed {
+                symbol_hint
+            } else {
+                soroban_sdk::String::from_str(&env, "")
+            },
+            if allowed { decimals } else { 0 },
+        );
     }
 
     pub fn is_allowed_asset(env: Env, asset: Address) -> bool {

--- a/contracts/niffyinsure/tests/allowlist_events.rs
+++ b/contracts/niffyinsure/tests/allowlist_events.rs
@@ -1,0 +1,79 @@
+//! Tests for AssetAdded / AssetRemoved event emission via `set_allowed_asset`.
+//!
+//! Acceptance criteria:
+//! - `asset_set` event emitted on add (allowed=1) with symbol_hint and decimals.
+//! - `asset_set` event emitted on remove (allowed=0).
+//! - Event emitted even for idempotent re-add of an already-allowed asset.
+
+#![cfg(test)]
+
+mod common;
+
+use niffyinsure::NiffyInsureClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    client.initialize(&admin, &token);
+    (env, client, token)
+}
+
+fn new_asset(env: &Env) -> Address {
+    env.register_stellar_asset_contract_v2(Address::generate(env))
+        .address()
+}
+
+#[test]
+fn add_emits_asset_set_event() {
+    let (env, client, _token) = setup();
+    let asset = new_asset(&env);
+
+    client.set_allowed_asset(
+        &asset,
+        &true,
+        &String::from_str(&env, "USDC"),
+        &7u32,
+    );
+
+    assert!(client.is_allowed_asset(&asset));
+    assert!(!env.events().all().events().is_empty(), "asset_set event must be emitted on add");
+}
+
+#[test]
+fn remove_emits_asset_set_event() {
+    let (env, client, _token) = setup();
+    let asset = new_asset(&env);
+
+    client.set_allowed_asset(&asset, &true, &String::from_str(&env, "USDC"), &7u32);
+    // drain events from add
+    let _ = env.events().all();
+
+    client.set_allowed_asset(&asset, &false, &String::from_str(&env, ""), &0u32);
+
+    assert!(!client.is_allowed_asset(&asset));
+    assert!(!env.events().all().events().is_empty(), "asset_set event must be emitted on remove");
+}
+
+#[test]
+fn readd_already_allowed_asset_emits_event_without_revert() {
+    let (env, client, _token) = setup();
+    let asset = new_asset(&env);
+
+    client.set_allowed_asset(&asset, &true, &String::from_str(&env, "USDC"), &7u32);
+    assert!(client.is_allowed_asset(&asset));
+
+    // Re-add: must not revert and must emit an event.
+    client.set_allowed_asset(&asset, &true, &String::from_str(&env, "USDC"), &7u32);
+    assert!(client.is_allowed_asset(&asset));
+    assert!(!env.events().all().events().is_empty(), "asset_set event must be emitted on idempotent re-add");
+}

--- a/contracts/niffyinsure/tests/coverage_gaps.rs
+++ b/contracts/niffyinsure/tests/coverage_gaps.rs
@@ -97,7 +97,7 @@ fn token_is_allowed_after_initialize() {
 #[test]
 fn set_allowed_asset_false_removes_from_allowlist() {
     let (_env, client, _, token) = setup();
-    client.set_allowed_asset(&token, &false);
+    client.set_allowed_asset(&token, &false, &soroban_sdk::String::from_str(&_env, ""), &0u32);
     assert!(!client.is_allowed_asset(&token));
 }
 
@@ -106,7 +106,7 @@ fn set_allowed_asset_true_adds_to_allowlist() {
     let (env, client, _, _) = setup();
     let new_asset = Address::generate(&env);
     assert!(!client.is_allowed_asset(&new_asset));
-    client.set_allowed_asset(&new_asset, &true);
+    client.set_allowed_asset(&new_asset, &true, &soroban_sdk::String::from_str(&env, "NEW"), &7u32);
     assert!(client.is_allowed_asset(&new_asset));
 }
 

--- a/contracts/niffyinsure/tests/emergency_sweep.rs
+++ b/contracts/niffyinsure/tests/emergency_sweep.rs
@@ -138,7 +138,7 @@ fn sweep_succeeds_after_allowlisting_asset() {
     let recipient = Address::generate(&env);
 
     // Allowlist token2
-    client.set_allowed_asset(&token2, &true);
+    client.set_allowed_asset(&token2, &true, &soroban_sdk::String::from_str(&env, "TKN2"), &7u32);
 
     mint(&env, &token2, &contract_id, 1_000_000);
 

--- a/contracts/niffyinsure/tests/multi_asset.rs
+++ b/contracts/niffyinsure/tests/multi_asset.rs
@@ -148,10 +148,10 @@ fn admin_can_add_and_remove_asset_from_allowlist() {
 
     assert!(!t.client.is_allowed_asset(&token_b));
 
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
     assert!(t.client.is_allowed_asset(&token_b));
 
-    t.client.set_allowed_asset(&token_b, &false);
+    t.client.set_allowed_asset(&token_b, &false, &soroban_sdk::String::from_str(&t.env, ""), &0u32);
     assert!(!t.client.is_allowed_asset(&token_b));
 }
 
@@ -160,13 +160,13 @@ fn set_allowed_asset_emits_event() {
     let t = setup();
     let (token_b, _) = make_second_asset(&t);
 
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
     assert!(
         t.client.is_allowed_asset(&token_b),
         "expected asset to be allowlisted after add"
     );
 
-    t.client.set_allowed_asset(&token_b, &false);
+    t.client.set_allowed_asset(&token_b, &false, &soroban_sdk::String::from_str(&t.env, ""), &0u32);
     assert!(
         !t.client.is_allowed_asset(&token_b),
         "expected asset to be removed from allowlist"
@@ -204,7 +204,7 @@ fn two_policies_with_different_assets_are_independent() {
     let (token_b, token_b_admin) = make_second_asset(&t);
 
     // Allowlist token_b.
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let holder_a = Address::generate(&t.env);
     let holder_b = Address::generate(&t.env);
@@ -299,7 +299,7 @@ fn claim_with_disallowed_bound_asset_is_rejected() {
 
     let t = setup();
     let (token_b, token_b_admin) = make_second_asset(&t);
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let holder = Address::generate(&t.env);
     fund_and_approve(
@@ -316,7 +316,7 @@ fn claim_with_disallowed_bound_asset_is_rejected() {
     let policy = initiate(&t, &holder, &t.token_a);
 
     // Another asset may remain allowlisted, but the bound asset must stay valid.
-    t.client.set_allowed_asset(&t.token_a, &false);
+    t.client.set_allowed_asset(&t.token_a, &false, &soroban_sdk::String::from_str(&t.env, ""), &0u32);
 
     // Payout should fail because the policy's bound asset is no longer allowlisted.
     let claim = Claim {
@@ -356,7 +356,7 @@ fn removing_asset_from_allowlist_blocks_new_policies() {
     let t = setup();
     let (token_b, token_b_admin) = make_second_asset(&t);
 
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let holder = Address::generate(&t.env);
     fund_and_approve(
@@ -373,7 +373,7 @@ fn removing_asset_from_allowlist_blocks_new_policies() {
     assert_eq!(policy.asset, token_b);
 
     // Remove from allowlist.
-    t.client.set_allowed_asset(&token_b, &false);
+    t.client.set_allowed_asset(&token_b, &false, &soroban_sdk::String::from_str(&t.env, ""), &0u32);
 
     let holder2 = Address::generate(&t.env);
     fund_and_approve(
@@ -417,7 +417,7 @@ fn removing_asset_from_allowlist_blocks_new_policies() {
 fn legacy_default_asset_policy_coexists_with_multi_asset_policy() {
     let t = setup();
     let (token_b, token_b_admin) = make_second_asset(&t);
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let legacy_holder = Address::generate(&t.env);
     let new_holder = Address::generate(&t.env);
@@ -466,7 +466,7 @@ fn premium_and_payout_use_same_bound_asset() {
 
     let t = setup();
     let (token_b, token_b_admin) = make_second_asset(&t);
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let holder = Address::generate(&t.env);
     fund_and_approve(
@@ -531,7 +531,7 @@ fn two_asset_policies_payout_independently() {
 
     let t = setup();
     let (token_b, token_b_admin) = make_second_asset(&t);
-    t.client.set_allowed_asset(&token_b, &true);
+    t.client.set_allowed_asset(&token_b, &true, &soroban_sdk::String::from_str(&t.env, "TKNB"), &7u32);
 
     let holder_a = Address::generate(&t.env);
     let holder_b = Address::generate(&t.env);

--- a/contracts/niffyinsure/tests/security.rs
+++ b/contracts/niffyinsure/tests/security.rs
@@ -208,6 +208,7 @@ fn auth01_non_admin_cannot_set_quorum_bps() {
 fn auth05_non_admin_cannot_set_allowed_asset() {
     let (env, client, _, _, rando) = make_non_admin_env();
     let asset = Address::generate(&env);
+    let sym = soroban_sdk::String::from_str(&env, "TST");
     env_with_single_auth(
         &env,
         &client.address,
@@ -216,10 +217,12 @@ fn auth05_non_admin_cannot_set_allowed_asset() {
         soroban_sdk::vec![
             &env,
             soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&asset, &env),
-            soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&true, &env)
+            soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&true, &env),
+            soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&sym, &env),
+            soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&7u32, &env)
         ],
     );
-    assert!(client.try_set_allowed_asset(&asset, &true).is_err());
+    assert!(client.try_set_allowed_asset(&asset, &true, &sym, &7u32).is_err());
 }
 
 // ── AUTH-02: rotation hijack prevention ───────────────────────────────────────

--- a/docs/EVENT_DICTIONARY.md
+++ b/docs/EVENT_DICTIONARY.md
@@ -270,7 +270,7 @@ Emitted when a holder sets or changes their designated payout beneficiary.
 | Event | Topics | Key payload fields |
 |-------|--------|--------------------|
 | `tbl_upd` | `(NS, "tbl_upd")` | `table_version: u32` |
-| `asset_set` | `(NS, "asset_set", asset)` | `allowed: 0\|1` |
+| `asset_set` | `(NS, "asset_set", asset)` | `allowed: 0\|1`, `symbol_hint: string`, `decimals: u32` |
 | `adm_prop` | `(NS, "adm_prop", old_admin, new_admin)` | `version` only |
 | `adm_acc` | `(NS, "adm_acc", old_admin, new_admin)` | `version` only |
 | `adm_can` | `(NS, "adm_can", admin, cancelled_pending)` | `version` only |


### PR DESCRIPTION
- Extend AssetAllowlistedData with symbol_hint and decimals fields
- Update set_allowed_asset to accept symbol_hint/decimals and always emit the asset_set event (idempotent — fires even if state unchanged)
- Update EVENT_DICTIONARY to document new payload fields
- Add allowlist_events.rs tests: add, remove, and idempotent re-add
- Update all existing callers to pass new parameters

## Checklist

- [x] Branding follows `docs/BRANDING.md` for product naming, palette, typography, and assets.
close #589