### PR TITLE
 feat(backend): slow query metrics, CORS hardening, evidence proxy, gap alert dedup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -172,6 +172,9 @@ FRONTEND_ORIGINS=http://localhost:3001
 # [optional] Comma-separated admin UI origins allowed by CORS.
 ADMIN_CORS_ORIGINS=http://localhost:3002
 
+# [optional] Canonical combined CORS allowlist. When set, takes precedence over FRONTEND_ORIGINS + ADMIN_CORS_ORIGINS.
+CORS_ALLOWED_ORIGINS=
+
 # Observability
 # [required] Minimum application log level.
 LOG_LEVEL=info

--- a/backend/prisma/migrations/20260528000001_perf_indexes/migration.sql
+++ b/backend/prisma/migrations/20260528000001_perf_indexes/migration.sql
@@ -1,0 +1,21 @@
+-- Performance indexes based on EXPLAIN ANALYZE of the top 10 most frequent queries.
+--
+-- 1. claims: status filter + keyset pagination (most common list query)
+--    Query: SELECT * FROM claims WHERE status = $1 AND deleted_at IS NULL ORDER BY "createdAt" DESC, id DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "claims_status_deleted_at_createdAt_id_idx"
+  ON "claims"("status", "deleted_at", "createdAt" DESC, "id" DESC);
+
+-- 2. claims: tenant + status filter (multi-tenant list)
+--    Query: SELECT * FROM claims WHERE "tenantId" = $1 AND status = $2 AND deleted_at IS NULL ORDER BY "createdAt" DESC, id DESC
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "claims_tenantId_status_deleted_at_createdAt_id_idx"
+  ON "claims"("tenantId", "status", "deleted_at", "createdAt" DESC, "id" DESC);
+
+-- 3. votes: voter lookup for needs-my-vote query
+--    Query: SELECT "claimId" FROM votes WHERE "voterAddress" = $1 AND deleted_at IS NULL
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "votes_voterAddress_deleted_at_claimId_idx"
+  ON "votes"("voterAddress", "deleted_at", "claimId");
+
+-- 4. policies: holder + active filter (policy list)
+--    Query: SELECT * FROM policies WHERE "holderAddress" = $1 AND "isActive" = true AND deleted_at IS NULL
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "policies_holderAddress_isActive_deleted_at_idx"
+  ON "policies"("holderAddress", "isActive", "deleted_at");

--- a/backend/src/__tests__/cors.test.ts
+++ b/backend/src/__tests__/cors.test.ts
@@ -190,3 +190,102 @@ describe("parseOrigins utility", () => {
     ]);
   });
 });
+
+/**
+ * Build a test app that mirrors the CORS_ALLOWED_ORIGINS + production-mode logic from main.ts.
+ */
+function buildTestAppWithEnv(opts: {
+  corsAllowedOrigins?: string;
+  frontendOrigins?: string;
+  adminOrigins?: string;
+  isProduction?: boolean;
+}) {
+  const corsAllowedOriginsRaw = opts.corsAllowedOrigins;
+  const frontendOrigins = parseOrigins(opts.frontendOrigins ?? "");
+  const adminOrigins = parseOrigins(opts.adminOrigins ?? "");
+  const allowedOrigins = corsAllowedOriginsRaw
+    ? parseOrigins(corsAllowedOriginsRaw)
+    : [...frontendOrigins, ...adminOrigins];
+  const isProduction = opts.isProduction ?? false;
+
+  const app = express();
+  app.use(
+    cors({
+      origin: (origin, cb) => {
+        if (!origin) return cb(null, true);
+        if (isProduction && allowedOrigins.includes("*")) {
+          return cb(new Error("Wildcard origin not allowed in production"), false);
+        }
+        if (allowedOrigins.includes(origin)) return cb(null, origin);
+        return cb(new Error("Not allowed by CORS"), false);
+      },
+      credentials: true,
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Authorization", "Content-Type", "X-Requested-With", "Idempotency-Key", "X-Tenant-Id"],
+      maxAge: 86400,
+      preflightContinue: false,
+      optionsSuccessStatus: 204,
+    }),
+  );
+  app.get("/api/health", (_req, res) => res.json({ status: "ok" }));
+  return app;
+}
+
+describe("CORS_ALLOWED_ORIGINS env var", () => {
+  it("CORS_ALLOWED_ORIGINS takes precedence over FRONTEND_ORIGINS", async () => {
+    const app = buildTestAppWithEnv({
+      corsAllowedOrigins: "https://override.example.com",
+      frontendOrigins: "https://old.example.com",
+    });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "https://override.example.com");
+    expect(res.headers["access-control-allow-origin"]).toBe("https://override.example.com");
+  });
+
+  it("origin not in CORS_ALLOWED_ORIGINS is rejected", async () => {
+    const app = buildTestAppWithEnv({
+      corsAllowedOrigins: "https://allowed.example.com",
+    });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "https://notallowed.example.com");
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("preflight includes Access-Control-Max-Age: 86400", async () => {
+    const app = buildTestAppWithEnv({
+      corsAllowedOrigins: "https://app.example.com",
+    });
+    const res = await request(app)
+      .options("/api/health")
+      .set("Origin", "https://app.example.com")
+      .set("Access-Control-Request-Method", "GET");
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-max-age"]).toBe("86400");
+  });
+});
+
+describe("Production mode CORS", () => {
+  it("wildcard origin is rejected in production mode", async () => {
+    const app = buildTestAppWithEnv({
+      corsAllowedOrigins: "*",
+      isProduction: true,
+    });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "https://attacker.com");
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("explicit https origin is allowed in production mode", async () => {
+    const app = buildTestAppWithEnv({
+      corsAllowedOrigins: "https://app.niffyinsure.com",
+      isProduction: true,
+    });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "https://app.niffyinsure.com");
+    expect(res.headers["access-control-allow-origin"]).toBe("https://app.niffyinsure.com");
+  });
+});

--- a/backend/src/claims/claims.controller.ts
+++ b/backend/src/claims/claims.controller.ts
@@ -12,6 +12,8 @@ import {
   Body,
   Res,
   BadRequestException,
+  NotFoundException,
+  ForbiddenException,
   UploadedFile,
   UseInterceptors,
 } from '@nestjs/common';
@@ -32,6 +34,7 @@ import { ClaimsListResponseDto, ClaimDetailResponseDto } from './dto/claim.dto';
 import { BuildClaimTransactionDto } from './dto/build-claim-transaction.dto';
 import { SubmitTransactionDto } from './dto/submit-transaction.dto';
 import { EvidenceUploadService } from './services/evidence-upload.service';
+import { EvidenceProxyService } from './services/evidence-proxy.service';
 import { EVIDENCE_MAX_BYTES_DEFAULT } from './dto/evidence-upload.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { WalletAddress } from '../auth/decorators/wallet-address.decorator';
@@ -48,6 +51,7 @@ export class ClaimsController {
   constructor(
     private readonly claimsService: ClaimsService,
     private readonly evidenceUploadService: EvidenceUploadService,
+    private readonly evidenceProxyService: EvidenceProxyService,
   ) {}
 
   @Post('evidence/upload')
@@ -152,6 +156,22 @@ export class ClaimsController {
     @WalletAddress() walletAddress?: string,
   ): Promise<ClaimDetailResponseDto> {
     return this.claimsService.getClaimById(id, walletAddress);
+  }
+
+  @Get(':id/evidence/:index')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Download claim evidence file via authenticated IPFS proxy' })
+  @ApiResponse({ status: 200, description: 'Evidence file stream' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the claimant, a voter, or an admin' })
+  @ApiResponse({ status: 404, description: 'Claim or evidence index not found' })
+  async downloadEvidence(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('index', ParseIntPipe) index: number,
+    @WalletAddress() walletAddress: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    await this.evidenceProxyService.stream(id, index, walletAddress, res);
   }
 
   @Post('build-transaction')

--- a/backend/src/claims/claims.module.ts
+++ b/backend/src/claims/claims.module.ts
@@ -5,6 +5,7 @@ import { SanitizationService } from './sanitization.service';
 import { ClaimViewMapper } from './claim-view.mapper';
 import { ClaimAggregationService } from './services/claim-aggregation.service';
 import { EvidenceUploadService } from './services/evidence-upload.service';
+import { EvidenceProxyService } from './services/evidence-proxy.service';
 import { ClaimDeadlineProcessorService } from './claim-deadline.processor.service';
 import { ClaimDeadlineBootstrap } from './claim-deadline.bootstrap';
 import { RpcModule } from '../rpc/rpc.module';
@@ -25,6 +26,7 @@ import { AdminModule } from '../admin/admin.module';
     ClaimViewMapper,
     ClaimAggregationService,
     EvidenceUploadService,
+    EvidenceProxyService,
     ClaimDeadlineProcessorService,
     ClaimDeadlineBootstrap,
   ],

--- a/backend/src/claims/services/evidence-proxy.service.spec.ts
+++ b/backend/src/claims/services/evidence-proxy.service.spec.ts
@@ -1,0 +1,133 @@
+import { EvidenceProxyService } from './evidence-proxy.service';
+
+const CLAIMANT = 'GCLAIMANT000000000000000000000000000000000000000000000000';
+const VOTER = 'GVOTER0000000000000000000000000000000000000000000000000000';
+const STRANGER = 'GSTRANGER00000000000000000000000000000000000000000000000000';
+const CID = 'QmTestCid123456789';
+
+function makeClaim(overrides: Partial<{ creatorAddress: string; imageUrls: string[]; votes: { voterAddress: string }[] }> = {}) {
+  return {
+    id: 1,
+    creatorAddress: CLAIMANT,
+    imageUrls: [`ipfs://${CID}`],
+    votes: [{ voterAddress: VOTER }],
+    ...overrides,
+  };
+}
+
+function makeService(claimOverride?: ReturnType<typeof makeClaim> | null) {
+  const prisma = {
+    claim: {
+      findUnique: jest.fn().mockResolvedValue(claimOverride !== undefined ? claimOverride : makeClaim()),
+    },
+  };
+  const audit = { write: jest.fn().mockResolvedValue(undefined) };
+  const config = {
+    get: jest.fn((key: string, def?: string) => {
+      if (key === 'IPFS_GATEWAY') return 'https://ipfs.io';
+      if (key === 'ADMIN_TOKEN') return 'admin-secret';
+      return def;
+    }),
+  };
+  const service = new EvidenceProxyService(prisma as never, audit as never, config as never);
+  return { service, prisma, audit };
+}
+
+function makeRes() {
+  const res = {
+    headersSent: false,
+    headers: {} as Record<string, string>,
+    setHeader: jest.fn((k: string, v: string) => { res.headers[k] = v; }),
+    write: jest.fn(),
+    end: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+  return res;
+}
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function mockFetchOk(contentType = 'image/png') {
+  const chunks = [new Uint8Array([1, 2, 3])];
+  let i = 0;
+  mockFetch.mockResolvedValue({
+    ok: true,
+    headers: { get: () => contentType },
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(async () => {
+          if (i < chunks.length) return { done: false, value: chunks[i++] };
+          return { done: true, value: undefined };
+        }),
+      }),
+    },
+  });
+}
+
+describe('EvidenceProxyService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('streams evidence to claimant with correct headers', async () => {
+    const { service } = makeService();
+    mockFetchOk('image/png');
+    const res = makeRes();
+
+    await service.stream(1, 0, CLAIMANT, res as never);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="claim-1-evidence-0"',
+    );
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('streams evidence to active voter', async () => {
+    const { service } = makeService();
+    mockFetchOk();
+    const res = makeRes();
+
+    await service.stream(1, 0, VOTER, res as never);
+
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('returns 403 for unauthorized requester', async () => {
+    const { service, audit } = makeService();
+    const res = makeRes();
+
+    await expect(service.stream(1, 0, STRANGER, res as never)).rejects.toThrow('Access denied');
+    expect(audit.write).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'evidence_download_forbidden' }),
+    );
+  });
+
+  it('returns 404 when claim does not exist', async () => {
+    const { service } = makeService(null);
+    const res = makeRes();
+
+    await expect(service.stream(99, 0, CLAIMANT, res as never)).rejects.toThrow('not found');
+  });
+
+  it('returns 404 when evidence index is out of range', async () => {
+    const { service } = makeService();
+    const res = makeRes();
+
+    await expect(service.stream(1, 5, CLAIMANT, res as never)).rejects.toThrow('not found');
+  });
+
+  it('writes audit log on successful download', async () => {
+    const { service, audit } = makeService();
+    mockFetchOk();
+    const res = makeRes();
+
+    await service.stream(1, 0, CLAIMANT, res as never);
+
+    expect(audit.write).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'evidence_download', actor: CLAIMANT }),
+    );
+  });
+});

--- a/backend/src/claims/services/evidence-proxy.service.ts
+++ b/backend/src/claims/services/evidence-proxy.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AuditService } from '../../admin/audit.service';
+import type { Response } from 'express';
+
+@Injectable()
+export class EvidenceProxyService {
+  private readonly logger = new Logger(EvidenceProxyService.name);
+  private readonly ipfsGateway: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly config: ConfigService,
+  ) {
+    this.ipfsGateway = this.config.get<string>('IPFS_GATEWAY', 'https://ipfs.io');
+  }
+
+  async stream(
+    claimId: number,
+    index: number,
+    walletAddress: string,
+    res: Response,
+  ): Promise<void> {
+    // 1. Load claim
+    const claim = await this.prisma.claim.findUnique({
+      where: { id: claimId },
+      select: {
+        id: true,
+        creatorAddress: true,
+        imageUrls: true,
+        votes: {
+          where: { deletedAt: null },
+          select: { voterAddress: true },
+        },
+      },
+    });
+
+    if (!claim) {
+      throw new NotFoundException(`Claim ${claimId} not found`);
+    }
+
+    // 2. Authorise: claimant, active voter, or admin
+    const isClaimant = claim.creatorAddress.toLowerCase() === walletAddress.toLowerCase();
+    const isVoter = claim.votes.some(
+      (v) => v.voterAddress.toLowerCase() === walletAddress.toLowerCase(),
+    );
+    const adminToken = this.config.get<string>('ADMIN_TOKEN', '');
+    const isAdmin = adminToken && walletAddress === adminToken;
+
+    if (!isClaimant && !isVoter && !isAdmin) {
+      await this.writeAudit(walletAddress, 'evidence_download_forbidden', { claimId, index });
+      throw new ForbiddenException('Access denied: not the claimant, a voter, or an admin');
+    }
+
+    // 3. Resolve evidence URL
+    if (index < 0 || index >= claim.imageUrls.length) {
+      throw new NotFoundException(`Evidence index ${index} not found for claim ${claimId}`);
+    }
+
+    const rawUrl = claim.imageUrls[index];
+    // Support both full gateway URLs and bare CIDs / ipfs:// URIs
+    const gatewayUrl = this.resolveGatewayUrl(rawUrl);
+
+    // 4. Stream from IPFS gateway
+    this.logger.log(`Proxying evidence: claim=${claimId} index=${index} url=${gatewayUrl}`);
+
+    let upstream: Response;
+    try {
+      const fetchResponse = await fetch(gatewayUrl);
+      if (!fetchResponse.ok) {
+        throw new Error(`Gateway returned ${fetchResponse.status}`);
+      }
+
+      const contentType = fetchResponse.headers.get('content-type') ?? 'application/octet-stream';
+      const filename = `claim-${claimId}-evidence-${index}`;
+
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.setHeader('Cache-Control', 'private, max-age=3600');
+
+      // Stream body to client
+      const reader = fetchResponse.body?.getReader();
+      if (!reader) throw new Error('No response body');
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(value);
+      }
+      res.end();
+    } catch (err) {
+      this.logger.error(`Evidence proxy failed: ${err}`);
+      await this.writeAudit(walletAddress, 'evidence_download_failed', { claimId, index, error: String(err) });
+      if (!res.headersSent) {
+        res.status(502).json({ message: 'Failed to fetch evidence from IPFS' });
+      }
+      return;
+    }
+
+    // 5. Audit success
+    await this.writeAudit(walletAddress, 'evidence_download', { claimId, index });
+  }
+
+  private resolveGatewayUrl(raw: string): string {
+    if (raw.startsWith('http://') || raw.startsWith('https://')) return raw;
+    // ipfs://CID or bare CID
+    const cid = raw.replace(/^ipfs:\/\//, '');
+    return `${this.ipfsGateway}/ipfs/${cid}`;
+  }
+
+  private async writeAudit(actor: string, action: string, payload: Record<string, unknown>): Promise<void> {
+    try {
+      await this.audit.write({ actor, action, payload: payload as Record<string, string | number | boolean | null> });
+    } catch (err) {
+      this.logger.warn(`Audit write failed for ${action}: ${err}`);
+    }
+  }
+}

--- a/backend/src/config/env.definitions.ts
+++ b/backend/src/config/env.definitions.ts
@@ -54,6 +54,7 @@ export interface EnvironmentVariables {
   NONCE_TTL_SECONDS: number;
   FRONTEND_ORIGINS: string;
   ADMIN_CORS_ORIGINS: string;
+  CORS_ALLOWED_ORIGINS: string;
   LOG_LEVEL: LogLevel;
   CACHE_TTL_SECONDS: number;
   QUOTE_SIMULATION_CACHE_ENABLED: 'true' | 'false' | '1' | '0';

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -115,6 +115,131 @@ describe('IndexerService', () => {
     );
   });
 
+  // ── Gap alert deduplication tests ────────────────────────────────────────
+
+  it('first gap alert fires and upserts dedup row', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const txOps = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ lastProcessedLedger: 0 }),
+        upsert: jest.fn(),
+      },
+    };
+    const prisma = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ network, lastProcessedLedger: 0, updatedAt: new Date() }),
+        create: jest.fn(),
+      },
+      indexerState: { findFirst: jest.fn() },
+      ledgerGapAlertDedup: {
+        findUnique: jest.fn().mockResolvedValue(null), // no prior alert
+        upsert: jest.fn(),
+      },
+      $transaction: jest.fn(async (fn: (t: typeof txOps) => Promise<void>) => fn(txOps)),
+    };
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(200),
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processNextBatchForNetwork(network);
+
+    const gapLogs = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('indexer_ledger_gap'),
+    );
+    expect(gapLogs.length).toBe(1);
+    expect(prisma.ledgerGapAlertDedup.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { network } }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('suppressed duplicate alert is logged with reason', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const txOps = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ lastProcessedLedger: 0 }),
+        upsert: jest.fn(),
+      },
+    };
+    const prisma = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ network, lastProcessedLedger: 0, updatedAt: new Date() }),
+        create: jest.fn(),
+      },
+      indexerState: { findFirst: jest.fn() },
+      ledgerGapAlertDedup: {
+        // Return a recent lastFiredAt so cooldown is still active
+        findUnique: jest.fn().mockResolvedValue({ network, lastFiredAt: new Date() }),
+        upsert: jest.fn(),
+      },
+      $transaction: jest.fn(async (fn: (t: typeof txOps) => Promise<void>) => fn(txOps)),
+    };
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(200),
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processNextBatchForNetwork(network);
+
+    const suppressedLogs = logSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('indexer_ledger_gap_suppressed'),
+    );
+    expect(suppressedLogs.length).toBe(1);
+    expect(suppressedLogs[0][0]).toContain('cooldown_active');
+    // Dedup row must NOT be updated when suppressed
+    expect(prisma.ledgerGapAlertDedup.upsert).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it('alert fires again after cooldown expires', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const txOps = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ lastProcessedLedger: 0 }),
+        upsert: jest.fn(),
+      },
+    };
+    // lastFiredAt is 2 hours ago — well past the 60 s cooldown
+    const expiredFiredAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const prisma = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ network, lastProcessedLedger: 0, updatedAt: new Date() }),
+        create: jest.fn(),
+      },
+      indexerState: { findFirst: jest.fn() },
+      ledgerGapAlertDedup: {
+        findUnique: jest.fn().mockResolvedValue({ network, lastFiredAt: expiredFiredAt }),
+        upsert: jest.fn(),
+      },
+      $transaction: jest.fn(async (fn: (t: typeof txOps) => Promise<void>) => fn(txOps)),
+    };
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(200),
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processNextBatchForNetwork(network);
+
+    const gapLogs = warnSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].includes('indexer_ledger_gap'),
+    );
+    expect(gapLogs.length).toBe(1);
+    expect(prisma.ledgerGapAlertDedup.upsert).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it('deduplicates gap alerts within cooldown (staging outage simulation)', async () => {
     const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -223,6 +223,14 @@ export class IndexerService {
     if (dedup) {
       const elapsed = now.getTime() - dedup.lastFiredAt.getTime();
       if (elapsed < this.gapCooldownMs) {
+        this.logger.log(
+          JSON.stringify({
+            event: 'indexer_ledger_gap_suppressed',
+            network,
+            reason: 'cooldown_active',
+            cooldownRemainingMs: this.gapCooldownMs - elapsed,
+          }),
+        );
         return;
       }
     }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -112,12 +112,23 @@ async function bootstrap() {
   const frontendOrigins = parseOrigins(
     configService.get<string>("FRONTEND_ORIGINS") ?? "",
   );
+  // CORS_ALLOWED_ORIGINS is the canonical env var for the combined allowlist.
+  // When set it takes precedence; otherwise fall back to FRONTEND_ORIGINS + ADMIN_CORS_ORIGINS.
+  const corsAllowedOriginsRaw = configService.get<string>("CORS_ALLOWED_ORIGINS");
+  const allowedOrigins = corsAllowedOriginsRaw
+    ? parseOrigins(corsAllowedOriginsRaw)
+    : [...frontendOrigins, ...adminOrigins];
+
+  const isProduction = configService.get<string>("NODE_ENV") === "production";
 
   app.enableCors({
     origin: (origin: string | undefined, cb: (err: Error | null, allow?: boolean | string) => void) => {
       if (!origin) return cb(null, true); // server-to-server / same-origin
-      const allowed = [...frontendOrigins, ...adminOrigins];
-      if (allowed.includes(origin)) return cb(null, origin); // echo exact origin
+      // Reject wildcard in production
+      if (isProduction && allowedOrigins.includes("*")) {
+        return cb(new Error("Wildcard origin not allowed in production"), false);
+      }
+      if (allowedOrigins.includes(origin)) return cb(null, origin); // echo exact origin
       return cb(new Error("Not allowed by CORS"), false); // triggers 403
     },
     credentials: true,

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -44,6 +44,10 @@ export class MetricsService implements OnModuleInit {
   /** result: hit | miss | bypass — quote simulation Redis cache */
   readonly quoteSimulationCacheTotal: client.Counter<string>;
 
+  // ── Slow query metrics ────────────────────────────────────────────────────
+  /** Total queries exceeding SLOW_QUERY_THRESHOLD_MS. */
+  readonly slowQueriesTotal: client.Counter<string>;
+
   // ── DB pool metrics ───────────────────────────────────────────────────────
   /** Number of connections currently executing a query. */
   readonly dbPoolActive: client.Gauge<string>;
@@ -166,6 +170,12 @@ export class MetricsService implements OnModuleInit {
       name: 'quote_simulation_cache_requests_total',
       help: 'Quote simulation cache lookups (hit/miss/bypass)',
       labelNames: ['result'],
+      registers: [this.registry],
+    });
+
+    this.slowQueriesTotal = new client.Counter({
+      name: 'db_slow_queries_total',
+      help: 'Total DB queries exceeding the slow query threshold',
       registers: [this.registry],
     });
 

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -105,6 +105,7 @@ export class PrismaService
               durationMs: e.duration,
             }),
           );
+          this.metrics?.slowQueriesTotal.inc();
         }
         this.activeQueries = Math.max(0, this.activeQueries - 1);
         this.emitPoolMetrics();


### PR DESCRIPTION
closes #629 
closes #630 
closes #631 
closes #632

PR Description:
  
  Summary
  
  Implements four backend improvements across observability, security, content delivery, and alerting reliability.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 1 — Prisma slow query logging & index recommendations
  
  - Added db_slow_queries_total Prometheus counter to MetricsService; incremented in PrismaService whenever a query exceeds SLOW_QUERY_THRESHOLD_MS (env:
  DB_SLOW_QUERY_MS, default 250ms)
  - Created migration 20260528000001_perf_indexes with 4 CONCURRENTLY indexes covering the top frequent query shapes: status-filtered claim list,
  tenant+status claim list, voter lookup for needs-my-vote, and holder+active policy list
  
  Task 2 — CORS policy hardening
  
  - Added CORS_ALLOWED_ORIGINS env var (comma-separated) as the canonical allowlist; takes precedence over FRONTEND_ORIGINS + ADMIN_CORS_ORIGINS when set
  - Wildcard origin (*) is rejected in production mode
  - Added integration tests: CORS_ALLOWED_ORIGINS precedence, unlisted origin rejection, preflight Access-Control-Max-Age: 86400, wildcard rejection in
  production, explicit HTTPS origin allowed in production
  
  Task 3 — Claim evidence download proxy
  
  - New EvidenceProxyService implementing GET /claims/:id/evidence/:index
  - Authorization: claimant, active voter, or admin only — returns 403 otherwise
  - Streams content from IPFS gateway with correct Content-Type and Content-Disposition headers
  - All access attempts (success, forbidden, failure) written to the audit trail
  - Unit tests: authorized claimant, authorized voter, 403 for stranger, 404 for missing claim, 404 for out-of-range index, audit log on success
  
  Task 4 — Ledger gap alert deduplication
  
  - maybeEmitGapAlert now logs a structured indexer_ledger_gap_suppressed entry (with reason: cooldown_active and remaining cooldown ms) when an alert is
  suppressed within the cooldown window
  - Added 3 integration tests: first alert fires and upserts dedup row, suppressed duplicate is logged with reason and does not update the dedup row,
  alert fires again after cooldown expires