### PR TITLE
feat(indexer): resumable reindex with progress tracking

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -297,3 +297,25 @@ enum TicketStatus {
   RESOLVED
   CLOSED
 }
+
+/// Tracks progress of an operator-initiated reindex job.
+/// One row per BullMQ job ID; updated atomically with each processed batch.
+model ReindexProgress {
+  jobId           String   @id @map("job_id")
+  network         String
+  startLedger     Int      @default(0) @map("start_ledger")
+  targetLedger    Int      @default(0) @map("target_ledger")
+  currentLedger   Int      @default(0) @map("current_ledger")
+  totalEvents     Int      @default(0) @map("total_events")
+  processedEvents Int      @default(0) @map("processed_events")
+  startTime       DateTime @default(now()) @map("start_time")
+  lastUpdate      DateTime @default(now()) @updatedAt @map("last_update")
+  status          String   @default("running") /// "running" | "completed" | "failed"
+  errorCount      Int      @default(0) @map("error_count")
+  lastError       String?  @map("last_error")
+
+  @@index([network])
+  @@index([status])
+  @@index([lastUpdate])
+  @@map("reindex_progress")
+}

--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -19,6 +19,7 @@ const mockAdminService = {
   getBackfillJob: jest.fn(),
   setFeatureFlag: jest.fn(),
   getFeatureFlags: jest.fn(),
+  getReindexStatus: jest.fn(),
 };
 const mockAdminPoliciesService = {
   listPolicies: jest.fn(),
@@ -121,7 +122,39 @@ describe('AdminController', () => {
     });
   });
 
-  // ── POST /admin/indexer/backfill ─────────────────────────────────────────
+  // ── GET /admin/reindex/status ────────────────────────────────────────────
+
+  describe('GET /admin/reindex/status', () => {
+    it('returns progress for the default network', async () => {
+      const mockStatus = {
+        jobId: 'reindex-testnet-500-ts',
+        network: 'testnet',
+        currentLedger: 750,
+        targetLedger: 1000,
+        percentage: 50,
+        status: 'running',
+        startedAt: new Date('2026-01-01'),
+      };
+      mockAdminService.getReindexStatus.mockResolvedValue(mockStatus);
+      const result = await controller.getReindexStatus(undefined);
+      expect(result).toEqual(mockStatus);
+      expect(mockAdminService.getReindexStatus).toHaveBeenCalledWith('testnet');
+    });
+
+    it('uses explicit network query param', async () => {
+      mockAdminService.getReindexStatus.mockResolvedValue({
+        jobId: 'j', network: 'mainnet', currentLedger: 100, targetLedger: 200,
+        percentage: 50, status: 'running', startedAt: new Date(),
+      });
+      await controller.getReindexStatus('mainnet');
+      expect(mockAdminService.getReindexStatus).toHaveBeenCalledWith('mainnet');
+    });
+
+    it('throws NotFoundException when no progress row exists', async () => {
+      mockAdminService.getReindexStatus.mockResolvedValue(null);
+      await expect(controller.getReindexStatus(undefined)).rejects.toThrow('No reindex progress');
+    });
+  });
 
   describe('POST /admin/indexer/backfill', () => {
     it('enqueues batched jobs and writes audit row', async () => {

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -90,6 +90,22 @@ export class AdminController {
   }
 
   /**
+   * GET /admin/reindex/status
+   *
+   * Returns the latest reindex progress for a network, including percentage complete.
+   */
+  @Get('reindex/status')
+  @ApiOperation({ summary: 'Get latest reindex progress for a network' })
+  async getReindexStatus(@Query('network') networkParam?: string) {
+    const network = networkParam ?? this.configService.get<string>('STELLAR_NETWORK', 'testnet');
+    const status = await this.adminService.getReindexStatus(network);
+    if (!status) {
+      throw new NotFoundException(`No reindex progress found for network ${network}`);
+    }
+    return status;
+  }
+
+  /**
    * POST /admin/indexer/backfill
    *
    * Validates the ledger range, splits it into batches, and enqueues one

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -23,9 +23,11 @@ describe('AdminService', () => {
   describe('enqueueReindex', () => {
     it('sets last_processed_ledger to fromLedger-1 and enqueues with network', async () => {
       const upsert = jest.fn();
+      const progressUpsert = jest.fn();
       const prisma = {
         $transaction: jest.fn(async (fn: (t: { ledgerCursor: { upsert: jest.Mock } }) => Promise<void>) =>
           fn({ ledgerCursor: { upsert } })),
+        reindexProgress: { upsert: progressUpsert },
       };
 
       const svc = new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
@@ -44,6 +46,12 @@ describe('AdminService', () => {
           jobId: expect.stringMatching(/^reindex-testnet-500-/),
         }),
       );
+      expect(progressUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { jobId: 'queued-job-id' },
+          create: expect.objectContaining({ network: 'testnet', status: 'running' }),
+        }),
+      );
     });
 
     it('clamps at 0 when fromLedger is 0', async () => {
@@ -51,6 +59,7 @@ describe('AdminService', () => {
       const prisma = {
         $transaction: jest.fn(async (fn: (t: { ledgerCursor: { upsert: jest.Mock } }) => Promise<void>) =>
           fn({ ledgerCursor: { upsert } })),
+        reindexProgress: { upsert: jest.fn() },
       };
       const svc = new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
       await svc.enqueueReindex(0, 'public');
@@ -151,6 +160,45 @@ describe('AdminService', () => {
         state: 'completed',
         data: { fromLedger: 100, toLedger: 149 },
       });
+    });
+  });
+
+  describe('getReindexStatus', () => {
+    function makeSvcWithProgress(row: unknown) {
+      const prisma = {
+        $transaction: jest.fn(),
+        reindexProgress: {
+          upsert: jest.fn(),
+          findFirst: jest.fn().mockResolvedValue(row),
+        },
+      };
+      return new AdminService(prisma as never, { refreshFlags: jest.fn() } as never);
+    }
+
+    it('returns null when no progress row exists', async () => {
+      const svc = makeSvcWithProgress(null);
+      expect(await svc.getReindexStatus('testnet')).toBeNull();
+    });
+
+    it('calculates percentage correctly', async () => {
+      const svc = makeSvcWithProgress({
+        jobId: 'j1', network: 'testnet',
+        startLedger: 500, targetLedger: 1000, currentLedger: 750,
+        status: 'running', startTime: new Date('2026-01-01'),
+      });
+      const result = await svc.getReindexStatus('testnet');
+      expect(result?.percentage).toBe(50);
+      expect(result?.status).toBe('running');
+    });
+
+    it('returns 100% when startLedger equals targetLedger', async () => {
+      const svc = makeSvcWithProgress({
+        jobId: 'j2', network: 'testnet',
+        startLedger: 1000, targetLedger: 1000, currentLedger: 1000,
+        status: 'completed', startTime: new Date(),
+      });
+      const result = await svc.getReindexStatus('testnet');
+      expect(result?.percentage).toBe(100);
     });
   });
 });

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -55,8 +55,47 @@ export class AdminService {
       { fromLedger, network },
       { jobId: `reindex-${network}-${fromLedger}-${Date.now()}` },
     );
-    this.logger.log(`Reindex job enqueued: ${job.id} network=${network} fromLedger=${fromLedger}`);
-    return job.id!;
+    const jobId = job.id!;
+
+    // Seed progress row so status is queryable immediately after enqueue.
+    await this.prisma.reindexProgress.upsert({
+      where: { jobId },
+      create: { jobId, network, startLedger: fromLedger, status: 'running' },
+      update: { status: 'running', startLedger: fromLedger },
+    });
+
+    this.logger.log(`Reindex job enqueued: ${jobId} network=${network} fromLedger=${fromLedger}`);
+    return jobId;
+  }
+
+  async getReindexStatus(network: string): Promise<{
+    jobId: string;
+    network: string;
+    currentLedger: number;
+    targetLedger: number;
+    percentage: number;
+    status: string;
+    startedAt: Date;
+  } | null> {
+    const row = await this.prisma.reindexProgress.findFirst({
+      where: { network },
+      orderBy: { startTime: 'desc' },
+    });
+    if (!row) return null;
+
+    const range = row.targetLedger - row.startLedger;
+    const done = row.currentLedger - row.startLedger;
+    const percentage = range > 0 ? Math.min(100, Math.round((done / range) * 100)) : 100;
+
+    return {
+      jobId: row.jobId,
+      network: row.network,
+      currentLedger: row.currentLedger,
+      targetLedger: row.targetLedger,
+      percentage,
+      status: row.status,
+      startedAt: row.startTime,
+    };
   }
 
   /**

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -162,3 +162,145 @@ describe('IndexerService', () => {
     warnSpy.mockRestore();
   });
 });
+
+// ── processUntilCaughtUp: progress tracking, interruption, resume ────────────
+
+describe('IndexerService.processUntilCaughtUp — progress tracking', () => {
+  const network = 'unittest';
+
+  function makeConfig() {
+    return {
+      get: jest.fn((key: string, def?: unknown) => {
+        if (key === 'STELLAR_NETWORK') return network;
+        if (key === 'INDEXER_GAP_ALERT_THRESHOLD_LEDGERS') return 50;
+        if (key === 'INDEXER_GAP_ALERT_COOLDOWN_MS') return 60_000;
+        return def;
+      }),
+    } as unknown as ConfigService;
+  }
+
+  function makePrisma(lastProcessed: number, progressUpsert = jest.fn(), progressUpdate = jest.fn()) {
+    const txOps = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ lastProcessedLedger: lastProcessed }),
+        upsert: jest.fn(),
+      },
+    };
+    return {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ network, lastProcessedLedger: lastProcessed, updatedAt: new Date() }),
+        create: jest.fn(),
+      },
+      indexerState: { findFirst: jest.fn() },
+      ledgerGapAlertDedup: { findUnique: jest.fn(), upsert: jest.fn() },
+      reindexProgress: {
+        upsert: progressUpsert,
+        update: progressUpdate,
+        findFirst: jest.fn(),
+      },
+      $transaction: jest.fn(async (fn: (t: typeof txOps) => Promise<void>) => fn(txOps)),
+    };
+  }
+
+  it('records progress row on start and marks completed when caught up', async () => {
+    const progressUpsert = jest.fn();
+    const progressUpdate = jest.fn();
+    const prisma = makePrisma(900, progressUpsert, progressUpdate);
+
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(900), // already caught up
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processUntilCaughtUp(network, 'job-abc');
+
+    expect(progressUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobId: 'job-abc' },
+        create: expect.objectContaining({ jobId: 'job-abc', network, status: 'running' }),
+      }),
+    );
+    // Final update marks completed
+    expect(progressUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobId: 'job-abc' },
+        data: expect.objectContaining({ status: 'completed' }),
+      }),
+    );
+  });
+
+  it('updates currentLedger after each batch', async () => {
+    const progressUpdate = jest.fn();
+    const txOps = {
+      ledgerCursor: {
+        findUnique: jest.fn().mockResolvedValue({ lastProcessedLedger: 901 }),
+        upsert: jest.fn(),
+      },
+      rawEvent: { upsert: jest.fn() },
+    };
+    // ledgerCursor.findUnique: first call for ensureCursor in processUntilCaughtUp,
+    // then once per processNextBatchForNetwork call (2 batches), then once per progress update (2)
+    const cursorFindUnique = jest.fn()
+      .mockResolvedValueOnce({ network, lastProcessedLedger: 900, updatedAt: new Date() }) // ensureCursor in processUntilCaughtUp
+      .mockResolvedValueOnce({ network, lastProcessedLedger: 900, updatedAt: new Date() }) // ensureCursor in batch 1
+      .mockResolvedValueOnce({ network, lastProcessedLedger: 901, updatedAt: new Date() }) // progress update after batch 1
+      .mockResolvedValueOnce({ network, lastProcessedLedger: 901, updatedAt: new Date() }) // ensureCursor in batch 2
+      .mockResolvedValueOnce({ network, lastProcessedLedger: 901, updatedAt: new Date() }); // progress update after batch 2
+
+    const prisma = {
+      ledgerCursor: { findUnique: cursorFindUnique, create: jest.fn() },
+      indexerState: { findFirst: jest.fn() },
+      ledgerGapAlertDedup: { findUnique: jest.fn(), upsert: jest.fn() },
+      reindexProgress: { upsert: jest.fn(), update: progressUpdate, findFirst: jest.fn() },
+      $transaction: jest.fn(async (fn: (t: typeof txOps) => Promise<void>) => fn(txOps)),
+    };
+
+    const event = {
+      txHash: 'tx1', ledger: 901, ledgerClosedAt: new Date().toISOString(),
+      topic: [], value: { _value: {} }, contractId: { toString: () => 'C' },
+    };
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(901),
+      getEvents: jest.fn()
+        .mockResolvedValueOnce({ events: [event] })
+        .mockResolvedValueOnce({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processUntilCaughtUp(network, 'job-xyz');
+
+    const batchUpdates = progressUpdate.mock.calls.filter(
+      (c) => c[0]?.data?.currentLedger !== undefined,
+    );
+    expect(batchUpdates.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('resumes from last recorded ledger after interruption', async () => {
+    // Cursor is at 950, latest is 960 — should fetch from 951
+    const prisma = makePrisma(950);
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(960),
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processUntilCaughtUp(network, 'job-resume');
+
+    expect(soroban.getEvents).toHaveBeenCalledWith(951, expect.any(Number));
+  });
+
+  it('works without jobId (no progress writes)', async () => {
+    const progressUpsert = jest.fn();
+    const prisma = makePrisma(900, progressUpsert);
+    const soroban = {
+      getLatestLedger: jest.fn().mockResolvedValue(900),
+      getEvents: jest.fn().mockResolvedValue({ events: [] }),
+    };
+
+    const service = new IndexerService(prisma as never, soroban as never, makeConfig());
+    await service.processUntilCaughtUp(network); // no jobId
+
+    expect(progressUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -111,22 +111,71 @@ export class IndexerService {
   }
 
   /** Bull reindex job: drain backlog for a network after cursor reset. */
-  async processUntilCaughtUp(network?: string): Promise<{ batches: number; events: number }> {
+  async processUntilCaughtUp(
+    network?: string,
+    jobId?: string,
+  ): Promise<{ batches: number; events: number }> {
     const net = network ?? this.networkId;
     let batches = 0;
     let events = 0;
+
+    const latestLedger = await this.soroban.getLatestLedger();
+    const cursorRow = await this.ensureCursor(net);
+    const startLedger = cursorRow.lastProcessedLedger + 1;
+    const totalLedgers = Math.max(0, latestLedger - cursorRow.lastProcessedLedger);
+
+    if (jobId) {
+      await this.prisma.reindexProgress.upsert({
+        where: { jobId },
+        create: {
+          jobId,
+          network: net,
+          startLedger,
+          targetLedger: latestLedger,
+          currentLedger: cursorRow.lastProcessedLedger,
+          totalEvents: totalLedgers,
+          status: 'running',
+        },
+        update: {
+          startLedger,
+          targetLedger: latestLedger,
+          currentLedger: cursorRow.lastProcessedLedger,
+          totalEvents: totalLedgers,
+          status: 'running',
+        },
+      });
+    }
+
     for (;;) {
       const r = await this.processNextBatchForNetwork(net);
       batches += 1;
       events += r.processed;
-      if (r.processed === 0) {
-        break;
+
+      if (jobId) {
+        const cursor = await this.prisma.ledgerCursor.findUnique({ where: { network: net } });
+        await this.prisma.reindexProgress.update({
+          where: { jobId },
+          data: {
+            currentLedger: cursor?.lastProcessedLedger ?? 0,
+            processedEvents: events,
+          },
+        });
       }
+
+      if (r.processed === 0) break;
       if (batches > 10_000) {
         this.logger.warn(`processUntilCaughtUp stopped after ${batches} batches (safety cap)`);
         break;
       }
     }
+
+    if (jobId) {
+      await this.prisma.reindexProgress.update({
+        where: { jobId },
+        data: { status: 'completed' },
+      });
+    }
+
     this.logger.log(`Reindex catch-up finished for ${net}: ${events} events in ${batches} batches`);
     return { batches, events };
   }

--- a/backend/src/indexer/reindex.worker.ts
+++ b/backend/src/indexer/reindex.worker.ts
@@ -63,7 +63,7 @@ export class ReindexWorkerService implements OnModuleInit, OnModuleDestroy {
 
     this.logger.log(`Starting reindex job ${job.id} for network ${net}`);
 
-    const result = await this.indexer.processUntilCaughtUp(net);
+    const result = await this.indexer.processUntilCaughtUp(net, job.id);
 
     this.logger.log(
       `Reindex job ${job.id} complete: ${result.events} events in ${result.batches} batches`,


### PR DESCRIPTION
closes #616 


- Add ReindexProgress model to Prisma schema (aligned with existing 011_add_reindex_progress.sql migration)
- Update IndexerService.processUntilCaughtUp to accept optional jobId; upserts progress row on start, updates currentLedger atomically after each batch, marks status=completed when caught up
- Update ReindexWorkerService to pass job.id to processUntilCaughtUp
- Update AdminService.enqueueReindex to seed progress row immediately after job enqueue so status is queryable before the worker starts
- Add AdminService.getReindexStatus returning percentage, currentLedger, targetLedger, and status for the latest job on a network
- Add GET /admin/reindex/status endpoint to AdminController
- Add integration tests: progress recording, batch updates, interruption resume, no-op without jobId, getReindexStatus percentage calculation, and controller 404 when no progress row exists

## Checklist

- [ ] Branding follows `docs/BRANDING.md` for product naming, palette, typography, and assets.
