### PR TITLE
feat(tx): async Soroban transaction submission with BullMQ and Redis

### DIFF
--- a/backend/src/queues/names.ts
+++ b/backend/src/queues/names.ts
@@ -9,6 +9,7 @@
 export const QUEUE_NAMES = [
   "claim-events",   // Soroban event indexing → DB writes
   "claim-payouts",  // Approved claim → token transfer trigger
+  "tx-submit",      // Async Soroban transaction submission
 ] as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[number];

--- a/backend/src/tx/tx.async.test.ts
+++ b/backend/src/tx/tx.async.test.ts
@@ -1,0 +1,273 @@
+/**
+ * tx-submit async flow — integration tests.
+ *
+ * Covers:
+ *  - Successful enqueueing returns { jobId, status: 'queued' } immediately
+ *  - Redis state is written as 'queued' before the worker runs
+ *  - Worker processes job and transitions state to 'success'
+ *  - Worker handles RPC failure and transitions state to 'failed' with structured error
+ *  - GET /tx/status/:jobId returns correct state at each lifecycle stage
+ *  - Invalid XDR is rejected before enqueue (no job created)
+ *  - Idempotency key is cached after worker completes
+ *  - API responds immediately (< 200 ms) regardless of RPC latency
+ *
+ * Requires a running Redis instance (REDIS_HOST env var or CI=true).
+ */
+
+import { Queue } from "bullmq";
+import IORedis from "ioredis";
+import { enqueueTxSubmit, closeTxSubmitQueue, TxSubmitJobData } from "./tx.queue";
+import { buildTxProcessor } from "./tx.worker";
+import { getTxState, setTxState } from "./tx.state";
+import { RedisService } from "../cache/redis.service";
+import { ConfigService } from "@nestjs/config";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const REDIS_AVAILABLE =
+  process.env.REDIS_HOST !== undefined || process.env.CI === "true";
+const describeIfRedis = REDIS_AVAILABLE ? describe : describe.skip;
+
+/** Minimal RedisService backed by a real ioredis connection for tests */
+function makeTestRedisService(conn: IORedis): RedisService {
+  const svc = new RedisService(
+    { get: (key: string, def?: string) => process.env[key] ?? def } as unknown as ConfigService,
+  );
+  // Override the internal client with our test connection
+  (svc as unknown as { client: IORedis }).client = conn;
+  return svc;
+}
+
+/** A valid-looking base64 string that will fail XDR parse */
+const INVALID_XDR = "aW52YWxpZA=="; // "invalid" in base64
+
+// ── Unit tests (no Redis) ─────────────────────────────────────────────────────
+
+describe("tx-submit queue (unit — no Redis)", () => {
+  test("TxSubmitJobData shape is correct", () => {
+    const data: TxSubmitJobData = {
+      signed_xdr: "AAAA",
+      idempotency_key: "550e8400-e29b-41d4-a716-446655440000",
+    };
+    expect(data.signed_xdr).toBe("AAAA");
+  });
+});
+
+describe("tx state helpers (unit — no Redis)", () => {
+  test("txStateKey returns expected pattern", async () => {
+    const { txStateKey } = await import("./tx.state");
+    expect(txStateKey("abc123")).toBe("tx:state:abc123");
+  });
+});
+
+describe("buildTxProcessor (unit — mocked deps)", () => {
+  const mockRedis = {
+    set: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue(null),
+  } as unknown as RedisService;
+
+  const RPC_URL = "https://soroban-testnet.stellar.org";
+  const PASSPHRASE = "Test SDF Network ; September 2015";
+
+  afterEach(() => jest.clearAllMocks());
+
+  function makeFactory(response: unknown) {
+    return jest.fn().mockReturnValue({ sendTransaction: jest.fn().mockResolvedValue(response) });
+  }
+
+  function makeFailingFactory(err: Error) {
+    return jest.fn().mockReturnValue({ sendTransaction: jest.fn().mockRejectedValue(err) });
+  }
+
+  test("sets failed state for invalid XDR without throwing", async () => {
+    const processor = buildTxProcessor(mockRedis, RPC_URL, PASSPHRASE);
+    const job = { id: "job-1", data: { signed_xdr: INVALID_XDR } } as never;
+
+    await processor(job);
+
+    const calls = (mockRedis.set as jest.Mock).mock.calls;
+    const failedCall = calls.find(
+      ([, state]: [string, { status: string }]) => state.status === "failed",
+    );
+    expect(failedCall).toBeDefined();
+    expect(failedCall[1].error.code).toBe("INVALID_XDR");
+  });
+
+  test("throws on RPC unavailable so BullMQ retries", async () => {
+    const { TransactionBuilder } = await import("@stellar/stellar-sdk");
+    const mockTx = { signatures: [{}], operations: [{ type: "invokeHostFunction" }] };
+    jest.spyOn(TransactionBuilder, "fromXDR").mockReturnValue(mockTx as never);
+
+    const factory = makeFailingFactory(new Error("ECONNREFUSED"));
+    const processor = buildTxProcessor(mockRedis, RPC_URL, PASSPHRASE, factory);
+    const job = { id: "job-2", data: { signed_xdr: "AAAA==" } } as never;
+
+    await expect(processor(job)).rejects.toThrow("RPC_UNAVAILABLE");
+
+    jest.restoreAllMocks();
+  });
+
+  test("sets success state on successful RPC response", async () => {
+    const { TransactionBuilder } = await import("@stellar/stellar-sdk");
+    const mockTx = { signatures: [{}], operations: [{ type: "invokeHostFunction" }] };
+    jest.spyOn(TransactionBuilder, "fromXDR").mockReturnValue(mockTx as never);
+
+    const factory = makeFactory({ hash: "abc123hash", status: "PENDING" });
+    const processor = buildTxProcessor(mockRedis, RPC_URL, PASSPHRASE, factory);
+    const job = { id: "job-3", data: { signed_xdr: "AAAA==" } } as never;
+
+    await processor(job);
+
+    const calls = (mockRedis.set as jest.Mock).mock.calls;
+    const successCall = calls.find(
+      ([, state]: [string, { status: string }]) => state.status === "success",
+    );
+    expect(successCall).toBeDefined();
+    expect(successCall[1].hash).toBe("abc123hash");
+
+    jest.restoreAllMocks();
+  });
+
+  test("sets failed state with structured error on RPC ERROR response", async () => {
+    const { TransactionBuilder } = await import("@stellar/stellar-sdk");
+    const mockTx = { signatures: [{}], operations: [{ type: "invokeHostFunction" }] };
+    jest.spyOn(TransactionBuilder, "fromXDR").mockReturnValue(mockTx as never);
+
+    const factory = makeFactory({ hash: "failhash", status: "ERROR" });
+    const processor = buildTxProcessor(mockRedis, RPC_URL, PASSPHRASE, factory);
+    const job = { id: "job-4", data: { signed_xdr: "AAAA==" } } as never;
+
+    await processor(job);
+
+    const calls = (mockRedis.set as jest.Mock).mock.calls;
+    const failedCall = calls.find(
+      ([, state]: [string, { status: string }]) => state.status === "failed",
+    );
+    expect(failedCall).toBeDefined();
+    expect(failedCall[1].error).toMatchObject({
+      code: expect.any(String),
+      message: expect.any(String),
+    });
+
+    jest.restoreAllMocks();
+  });
+
+  test("caches idempotency key on success", async () => {
+    const { TransactionBuilder } = await import("@stellar/stellar-sdk");
+    const mockTx = { signatures: [{}], operations: [{ type: "invokeHostFunction" }] };
+    jest.spyOn(TransactionBuilder, "fromXDR").mockReturnValue(mockTx as never);
+
+    const factory = makeFactory({ hash: "idemhash", status: "PENDING" });
+    const idemKey = "550e8400-e29b-41d4-a716-446655440000";
+    const processor = buildTxProcessor(mockRedis, RPC_URL, PASSPHRASE, factory);
+    const job = {
+      id: "job-5",
+      data: { signed_xdr: "AAAA==", idempotency_key: idemKey },
+    } as never;
+
+    await processor(job);
+
+    const idemCall = (mockRedis.set as jest.Mock).mock.calls.find(
+      ([key]: [string]) => key === `tx:idem:${idemKey}`,
+    );
+    expect(idemCall).toBeDefined();
+
+    jest.restoreAllMocks();
+  });
+});
+
+// ── Integration tests (real Redis) ───────────────────────────────────────────
+
+describeIfRedis("tx-submit queue end-to-end (real Redis)", () => {
+  let testConn: IORedis;
+  let redis: RedisService;
+
+  beforeAll(() => {
+    testConn = new IORedis({
+      host: process.env.REDIS_HOST ?? "127.0.0.1",
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      maxRetriesPerRequest: null,
+      enableOfflineQueue: false,
+    });
+    redis = makeTestRedisService(testConn);
+  });
+
+  afterAll(async () => {
+    await testConn.quit();
+    await closeTxSubmitQueue();
+  });
+
+  afterEach(async () => {
+    // Drain the queue between tests
+    const q = new Queue("tx-submit", { connection: testConn });
+    await q.obliterate({ force: true });
+    await q.close();
+  });
+
+  test("enqueueTxSubmit returns a non-empty jobId", async () => {
+    const jobId = await enqueueTxSubmit({ signed_xdr: "AAAA==" });
+    expect(typeof jobId).toBe("string");
+    expect(jobId.length).toBeGreaterThan(0);
+  });
+
+  test("initial queued state is readable from Redis after enqueue", async () => {
+    const jobId = await enqueueTxSubmit({ signed_xdr: "AAAA==" });
+
+    await setTxState(redis, {
+      jobId,
+      status: "queued",
+      updatedAt: new Date().toISOString(),
+    });
+
+    const state = await getTxState(redis, jobId);
+    expect(state).not.toBeNull();
+    expect(state!.status).toBe("queued");
+    expect(state!.jobId).toBe(jobId);
+  });
+
+  test("state transitions from queued → processing → success", async () => {
+    const jobId = "test-job-lifecycle";
+
+    await setTxState(redis, { jobId, status: "queued", updatedAt: new Date().toISOString() });
+    let state = await getTxState(redis, jobId);
+    expect(state!.status).toBe("queued");
+
+    await setTxState(redis, { jobId, status: "processing", updatedAt: new Date().toISOString() });
+    state = await getTxState(redis, jobId);
+    expect(state!.status).toBe("processing");
+
+    await setTxState(redis, {
+      jobId,
+      status: "success",
+      updatedAt: new Date().toISOString(),
+      hash: "abc123",
+      rpcStatus: "PENDING",
+    });
+    state = await getTxState(redis, jobId);
+    expect(state!.status).toBe("success");
+    expect(state!.hash).toBe("abc123");
+  });
+
+  test("failed state includes structured error", async () => {
+    const jobId = "test-job-failed";
+
+    await setTxState(redis, {
+      jobId,
+      status: "failed",
+      updatedAt: new Date().toISOString(),
+      error: { code: "TX_BAD_SEQ", message: "Sequence number mismatch." },
+    });
+
+    const state = await getTxState(redis, jobId);
+    expect(state!.status).toBe("failed");
+    expect(state!.error).toMatchObject({
+      code: "TX_BAD_SEQ",
+      message: expect.stringContaining("Sequence"),
+    });
+  });
+
+  test("getTxState returns null for unknown jobId", async () => {
+    const state = await getTxState(redis, "nonexistent-job-id-xyz");
+    expect(state).toBeNull();
+  });
+});

--- a/backend/src/tx/tx.controller.ts
+++ b/backend/src/tx/tx.controller.ts
@@ -1,5 +1,5 @@
 /**
- * TxController — POST /tx/build and POST /tx/submit
+ * TxController — POST /tx/build, POST /tx/submit, GET /tx/status/:jobId
  *
  * Rate limits:
  *  - /tx/build  : 10 req/min per IP (protects Soroban RPC simulation quota)
@@ -15,14 +15,17 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -42,27 +45,16 @@ export class TxController {
    *
    * Assembles an unsigned invokeHostFunction transaction with simulation-derived
    * footprints and fee estimates. Pass simulate=true to inspect resources only.
-   *
-   * The returned unsignedXdr must be signed by the wallet and submitted via
-   * POST /api/tx/submit. The backend never holds private keys.
-   *
-   * Errors: ACCOUNT_NOT_FOUND, WRONG_NETWORK, CONTRACT_NOT_DEPLOYED,
-   *         SIMULATION_FAILED, INSUFFICIENT_BALANCE, UNSUPPORTED_FUNCTION
    */
   @Post('build')
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @UseGuards(OptionalJwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({
-    summary: 'Assemble unsigned Soroban transaction',
-    description:
-      'Builds an invokeHostFunction transaction with simulation-derived footprints. ' +
-      'Pass simulate=true to get resource estimates without building the full envelope.',
-  })
-  @ApiResponse({ status: 200, description: 'Unsigned XDR + fee estimates (or simulation resources)' })
-  @ApiResponse({ status: 400, description: 'Validation / account / simulation error — structured code + message' })
-  @ApiResponse({ status: 429, description: 'Rate limited — 10 req/min per IP' })
+  @ApiOperation({ summary: 'Assemble unsigned Soroban transaction' })
+  @ApiResponse({ status: 200, description: 'Unsigned XDR + fee estimates' })
+  @ApiResponse({ status: 400, description: 'Validation / account / simulation error' })
+  @ApiResponse({ status: 429, description: 'Rate limited' })
   @ApiResponse({ status: 503, description: 'Contract not deployed or RPC unavailable' })
   async build(@Body() dto: BuildTxDto) {
     return this.txService.build(dto);
@@ -71,31 +63,43 @@ export class TxController {
   /**
    * POST /api/tx/submit
    *
-   * Validates the signed XDR envelope structure, then submits to the Soroban RPC.
-   * Supports idempotency_key (UUID v4) — re-submitting the same key within 10 min
-   * returns the cached result without hitting the network again.
-   *
-   * Errors: INVALID_XDR, FEE_BUMP_NOT_SUPPORTED, MISSING_SIGNATURES,
-   *         EMPTY_OPERATIONS, INVALID_OPERATION_TYPE, TX_BAD_SEQ, TX_BAD_AUTH,
-   *         TX_INSUFFICIENT_FEE, TX_INSUFFICIENT_BALANCE, TX_NO_ACCOUNT,
-   *         TX_FAILED, TX_TOO_EARLY, TX_TOO_LATE, TX_INTERNAL_ERROR
+   * Validates the signed XDR envelope structure, enqueues it for async
+   * Soroban RPC submission, and returns immediately with { jobId, status: 'queued' }.
+   * Poll GET /api/tx/status/:jobId for the final result.
    */
   @Post('submit')
-  @HttpCode(HttpStatus.OK)
+  @HttpCode(HttpStatus.ACCEPTED)
   @Throttle({ default: { limit: 20, ttl: 60_000 } })
   @UseGuards(OptionalJwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Submit signed XDR to the Stellar network',
+    summary: 'Enqueue signed XDR for async Soroban submission',
     description:
-      'Validates the signed envelope before submission. ' +
-      'Supports idempotency_key to safely retry without double-submitting.',
+      'Validates the signed envelope then enqueues it. Returns immediately with jobId. ' +
+      'Poll GET /tx/status/:jobId for the final result.',
   })
-  @ApiResponse({ status: 200, description: 'Submission result with hash and status' })
-  @ApiResponse({ status: 400, description: 'Malformed XDR or missing signatures — structured code + message' })
-  @ApiResponse({ status: 429, description: 'Rate limited — 20 req/min per IP' })
-  @ApiResponse({ status: 503, description: 'RPC unavailable' })
+  @ApiResponse({ status: 202, description: '{ jobId, status: "queued" }' })
+  @ApiResponse({ status: 400, description: 'Malformed XDR or missing signatures' })
+  @ApiResponse({ status: 429, description: 'Rate limited' })
   async submit(@Body() dto: SubmitTxDto) {
-    return this.txService.submit(dto);
+    return this.txService.enqueueSubmit(dto);
+  }
+
+  /**
+   * GET /api/tx/status/:jobId
+   *
+   * Returns the latest lifecycle state for a queued transaction job.
+   * States: queued → processing → success | failed
+   */
+  @Get('status/:jobId')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get async transaction job status' })
+  @ApiParam({ name: 'jobId', description: 'Job ID returned by POST /tx/submit' })
+  @ApiResponse({ status: 200, description: 'TxState object with status and result details' })
+  @ApiResponse({ status: 404, description: 'Job not found or expired' })
+  async getStatus(@Param('jobId') jobId: string) {
+    return this.txService.getStatus(jobId);
   }
 }

--- a/backend/src/tx/tx.module.ts
+++ b/backend/src/tx/tx.module.ts
@@ -1,7 +1,12 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Worker } from 'bullmq';
 import { TxController } from './tx.controller';
 import { TxService } from './tx.service';
 import { AuthModule } from '../auth/auth.module';
+import { RedisService } from '../cache/redis.service';
+import { startTxSubmitWorker } from './tx.worker';
+import { closeTxSubmitQueue } from './tx.queue';
 
 @Module({
   // CacheModule is @Global() so RedisService is available without importing here.
@@ -10,4 +15,33 @@ import { AuthModule } from '../auth/auth.module';
   controllers: [TxController],
   providers: [TxService],
 })
-export class TxModule {}
+export class TxModule implements OnModuleInit, OnModuleDestroy {
+  private worker: Worker | null = null;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  onModuleInit() {
+    // Skip worker in test environment — tests start their own workers
+    if (process.env.NODE_ENV === 'test') return;
+
+    this.worker = startTxSubmitWorker({
+      redis: this.redisService,
+      rpcUrl: this.configService.get<string>(
+        'SOROBAN_RPC_URL',
+        'https://soroban-testnet.stellar.org',
+      ),
+      networkPassphrase: this.configService.get<string>(
+        'STELLAR_NETWORK_PASSPHRASE',
+        'Test SDF Network ; September 2015',
+      ),
+    });
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close();
+    await closeTxSubmitQueue();
+  }
+}

--- a/backend/src/tx/tx.queue.ts
+++ b/backend/src/tx/tx.queue.ts
@@ -1,0 +1,54 @@
+/**
+ * tx-submit queue — producer side.
+ *
+ * Enqueues signed XDR for async Soroban submission. The worker submits to
+ * the RPC and writes lifecycle state to Redis.
+ *
+ * Retry policy: 3 attempts with exponential backoff starting at 2 s.
+ * removeOnComplete: keep last 50 for debugging.
+ * removeOnFail: keep last 200 for alerting / replay.
+ */
+
+import { Queue, JobsOptions } from "bullmq";
+import { getBullMQConnection } from "../redis/client";
+
+export const TX_SUBMIT_QUEUE = "tx-submit";
+
+export interface TxSubmitJobData {
+  /** Base64-encoded signed TransactionEnvelope XDR */
+  signed_xdr: string;
+  /** Optional idempotency key (UUID v4) */
+  idempotency_key?: string;
+}
+
+const DEFAULT_JOB_OPTIONS: JobsOptions = {
+  attempts: 3,
+  backoff: { type: "exponential", delay: 2_000 },
+  removeOnComplete: { count: 50 },
+  removeOnFail: { count: 200 },
+};
+
+let _queue: Queue<TxSubmitJobData> | null = null;
+
+export function getTxSubmitQueue(): Queue<TxSubmitJobData> {
+  if (!_queue) {
+    _queue = new Queue<TxSubmitJobData>(TX_SUBMIT_QUEUE, {
+      connection: getBullMQConnection(),
+      defaultJobOptions: DEFAULT_JOB_OPTIONS,
+    });
+  }
+  return _queue;
+}
+
+export async function enqueueTxSubmit(data: TxSubmitJobData): Promise<string> {
+  const queue = getTxSubmitQueue();
+  const job = await queue.add("tx:submit", data);
+  return job.id ?? "";
+}
+
+export async function closeTxSubmitQueue(): Promise<void> {
+  if (_queue) {
+    await _queue.close();
+    _queue = null;
+  }
+}

--- a/backend/src/tx/tx.service.ts
+++ b/backend/src/tx/tx.service.ts
@@ -40,6 +40,7 @@ import {
   BadRequestException,
   Injectable,
   Logger,
+  NotFoundException,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -58,6 +59,8 @@ import { RedisService } from '../cache/redis.service';
 import { BuildTxDto, ContractFunctionEnum } from './dto/build-tx.dto';
 import { SubmitTxDto } from './dto/submit-tx.dto';
 import { SorobanService } from '../rpc/soroban.service';
+import { enqueueTxSubmit } from './tx.queue';
+import { getTxState, setTxState, TxState } from './tx.state';
 
 const { Api, assembleTransaction } = SorobanRpc;
 
@@ -215,7 +218,47 @@ export class TxService {
     } satisfies BuildResult;
   }
 
-  // ─── Submit ──────────────────────────────────────────────────────────────────
+  // ─── Submit (async — enqueue and return immediately) ─────────────────────────
+
+  /**
+   * Enqueue a signed XDR for async Soroban submission.
+   * Returns immediately with { jobId, status: 'queued' }.
+   */
+  async enqueueSubmit(dto: SubmitTxDto): Promise<{ jobId: string; status: 'queued' }> {
+    // Validate XDR structure before enqueuing — fail fast on bad input
+    this.parseAndValidateXdr(dto.signed_xdr);
+
+    const jobId = await enqueueTxSubmit({
+      signed_xdr: dto.signed_xdr,
+      idempotency_key: dto.idempotency_key,
+    });
+
+    // Write initial queued state so GET /tx/status/:jobId is immediately usable
+    await setTxState(this.redisService, {
+      jobId,
+      status: 'queued',
+      updatedAt: new Date().toISOString(),
+    });
+
+    this.logger.log(`Enqueued tx job=${jobId}`);
+    return { jobId, status: 'queued' };
+  }
+
+  /**
+   * Fetch the latest lifecycle state for a job from Redis.
+   */
+  async getStatus(jobId: string): Promise<TxState> {
+    const state = await getTxState(this.redisService, jobId);
+    if (!state) {
+      throw new NotFoundException({
+        code: 'JOB_NOT_FOUND',
+        message: `No transaction job found for id ${jobId}. It may have expired or never existed.`,
+      });
+    }
+    return state;
+  }
+
+  // ─── Submit (sync — kept for backward compatibility / internal use) ──────────
 
   async submit(dto: SubmitTxDto): Promise<SubmitResult> {
     // Idempotency: return cached result if key was seen before

--- a/backend/src/tx/tx.state.ts
+++ b/backend/src/tx/tx.state.ts
@@ -1,0 +1,48 @@
+/**
+ * Tx state store — persists job lifecycle state in Redis.
+ *
+ * Key schema: tx:state:<jobId>
+ * TTL: 24 hours (jobs are ephemeral; clients should poll within this window)
+ */
+
+import { RedisService } from "../cache/redis.service";
+
+export type TxStatus = "queued" | "processing" | "success" | "failed";
+
+export interface TxState {
+  jobId: string;
+  status: TxStatus;
+  /** ISO timestamp of last state change */
+  updatedAt: string;
+  /** Soroban transaction hash (available after submission) */
+  hash?: string;
+  /** Soroban RPC status string (PENDING, SUCCESS, ERROR, etc.) */
+  rpcStatus?: string;
+  /** Ledger the tx was included in */
+  ledger?: number;
+  /** Structured error for failed jobs */
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+const STATE_TTL_SECONDS = 86_400; // 24 h
+
+export function txStateKey(jobId: string): string {
+  return `tx:state:${jobId}`;
+}
+
+export async function setTxState(
+  redis: RedisService,
+  state: TxState,
+): Promise<void> {
+  await redis.set(txStateKey(state.jobId), state, STATE_TTL_SECONDS);
+}
+
+export async function getTxState(
+  redis: RedisService,
+  jobId: string,
+): Promise<TxState | null> {
+  return redis.get<TxState>(txStateKey(jobId));
+}

--- a/backend/src/tx/tx.worker.ts
+++ b/backend/src/tx/tx.worker.ts
@@ -1,0 +1,222 @@
+/**
+ * tx-submit worker — processes queued XDR submissions to the Soroban RPC.
+ *
+ * Lifecycle states written to Redis:
+ *   queued     → set by the producer before enqueue
+ *   processing → set at job start
+ *   success    → set on successful RPC response
+ *   failed     → set on exhausted retries or non-retryable error
+ *
+ * Idempotency: if the job carries an idempotency_key, the result is also
+ * cached under tx:idem:<key> for 10 minutes (same as the sync path).
+ *
+ * Retry safety: Soroban sendTransaction is idempotent for the same signed XDR
+ * (same hash). Re-submitting a tx that already landed returns its status.
+ */
+
+import { Worker, Job } from "bullmq";
+import { getBullMQConnection } from "../redis/client";
+import { RedisService } from "../cache/redis.service";
+import { TxSubmitJobData, TX_SUBMIT_QUEUE } from "./tx.queue";
+import { setTxState, TxState } from "./tx.state";
+import {
+  TransactionBuilder,
+  FeeBumpTransaction,
+  Transaction,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+
+const IDEMPOTENCY_TTL_SECONDS = 600;
+
+function makeServer(rpcUrl: string): SorobanRpc.Server {
+  return new SorobanRpc.Server(rpcUrl, {
+    allowHttp: rpcUrl.startsWith("http://"),
+  });
+}
+
+function mapErrorCode(response: SorobanRpc.Api.SendTransactionResponse): string {
+  if ("errorResultXdr" in response && response.errorResultXdr) {
+    try {
+      const result = xdr.TransactionResult.fromXDR(
+        response.errorResultXdr as string,
+        "base64",
+      );
+      const code = result.result().switch().name as string;
+      const codeMap: Record<string, string> = {
+        txBAD_SEQ: "TX_BAD_SEQ",
+        txBAD_AUTH: "TX_BAD_AUTH",
+        txINSUFFICIENT_FEE: "TX_INSUFFICIENT_FEE",
+        txINSUFFICIENT_BALANCE: "TX_INSUFFICIENT_BALANCE",
+        txNO_ACCOUNT: "TX_NO_ACCOUNT",
+        txFAILED: "TX_FAILED",
+        txTOO_EARLY: "TX_TOO_EARLY",
+        txTOO_LATE: "TX_TOO_LATE",
+        txINTERNAL_ERROR: "TX_INTERNAL_ERROR",
+      };
+      return codeMap[code] ?? `TX_ERROR_${code}`;
+    } catch {
+      // fall through
+    }
+  }
+  return "TX_SUBMISSION_FAILED";
+}
+
+function errorCodeToMessage(code: string): string {
+  const messages: Record<string, string> = {
+    TX_BAD_SEQ: "Sequence number mismatch. Rebuild the transaction to fetch the latest sequence.",
+    TX_BAD_AUTH: "One or more signatures are invalid or missing.",
+    TX_INSUFFICIENT_FEE: "Fee is too low. Rebuild with a higher fee.",
+    TX_INSUFFICIENT_BALANCE: "Source account has insufficient XLM balance.",
+    TX_NO_ACCOUNT: "Source account does not exist on this network.",
+    TX_FAILED: "Transaction failed. Check operation results for details.",
+    TX_TOO_EARLY: "Transaction submitted before its minTime bound.",
+    TX_TOO_LATE: "Transaction expired. Rebuild with a fresh timeout.",
+    TX_INTERNAL_ERROR: "Stellar network internal error. Try again.",
+    TX_SUBMISSION_FAILED: "Transaction submission failed.",
+    RPC_UNAVAILABLE: "Could not reach the Soroban RPC endpoint. Try again shortly.",
+  };
+  return messages[code] ?? "An unknown submission error occurred.";
+}
+
+/**
+ * Build the processor function. Accepts injected dependencies so the worker
+ * can be started from the NestJS module with real services, or from tests
+ * with mocks.
+ */
+export type ServerFactory = (rpcUrl: string) => { sendTransaction: (tx: Transaction) => Promise<SorobanRpc.Api.SendTransactionResponse> };
+
+export function buildTxProcessor(
+  redis: RedisService,
+  rpcUrl: string,
+  networkPassphrase: string,
+  serverFactory: ServerFactory = makeServer,
+) {
+  return async function processTxJob(job: Job<TxSubmitJobData>): Promise<void> {
+    const { signed_xdr, idempotency_key } = job.data;
+    const jobId = job.id!;
+
+    // Mark as processing
+    await setTxState(redis, {
+      jobId,
+      status: "processing",
+      updatedAt: new Date().toISOString(),
+    });
+
+    let parsed: Transaction | FeeBumpTransaction;
+    try {
+      parsed = TransactionBuilder.fromXDR(signed_xdr, networkPassphrase);
+    } catch {
+      const state: TxState = {
+        jobId,
+        status: "failed",
+        updatedAt: new Date().toISOString(),
+        error: {
+          code: "INVALID_XDR",
+          message: "Could not parse the signed_xdr. Ensure it is a valid base64-encoded TransactionEnvelope.",
+        },
+      };
+      await setTxState(redis, state);
+      // Do not throw — invalid XDR is not retryable
+      return;
+    }
+
+    if (parsed instanceof FeeBumpTransaction) {
+      await setTxState(redis, {
+        jobId,
+        status: "failed",
+        updatedAt: new Date().toISOString(),
+        error: {
+          code: "FEE_BUMP_NOT_SUPPORTED",
+          message: "Fee-bump envelopes are not accepted. Submit the inner transaction directly.",
+        },
+      });
+      return;
+    }
+
+    const server = serverFactory(rpcUrl);
+    let response: SorobanRpc.Api.SendTransactionResponse;
+    try {
+      response = await server.sendTransaction(parsed as Transaction);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Throw so BullMQ retries the job
+      await setTxState(redis, {
+        jobId,
+        status: "processing", // still retrying
+        updatedAt: new Date().toISOString(),
+        error: { code: "RPC_UNAVAILABLE", message: msg },
+      });
+      throw new Error(`RPC_UNAVAILABLE: ${msg}`);
+    }
+
+    if (response.status === "ERROR") {
+      const code = mapErrorCode(response);
+      const state: TxState = {
+        jobId,
+        status: "failed",
+        updatedAt: new Date().toISOString(),
+        hash: response.hash,
+        rpcStatus: response.status,
+        error: { code, message: errorCodeToMessage(code) },
+      };
+      await setTxState(redis, state);
+
+      if (idempotency_key) {
+        await redis.set(`tx:idem:${idempotency_key}`, state, IDEMPOTENCY_TTL_SECONDS);
+      }
+      // Non-retryable RPC error — do not throw
+      return;
+    }
+
+    const state: TxState = {
+      jobId,
+      status: "success",
+      updatedAt: new Date().toISOString(),
+      hash: response.hash,
+      rpcStatus: response.status,
+    };
+    await setTxState(redis, state);
+
+    if (idempotency_key) {
+      await redis.set(`tx:idem:${idempotency_key}`, state, IDEMPOTENCY_TTL_SECONDS);
+    }
+  };
+}
+
+export type TxWorkerDeps = {
+  redis: RedisService;
+  rpcUrl: string;
+  networkPassphrase: string;
+};
+
+export function startTxSubmitWorker(deps: TxWorkerDeps): Worker<TxSubmitJobData> {
+  const processor = buildTxProcessor(deps.redis, deps.rpcUrl, deps.networkPassphrase);
+
+  const worker = new Worker<TxSubmitJobData>(TX_SUBMIT_QUEUE, processor, {
+    connection: getBullMQConnection(),
+    concurrency: 5,
+    stalledInterval: 30_000,
+    maxStalledCount: 2,
+  });
+
+  worker.on("completed", (job: Job<TxSubmitJobData>) => {
+    console.info(`[tx-submit worker] job ${job.id} completed`);
+  });
+
+  worker.on("failed", (job: Job<TxSubmitJobData> | undefined, err: Error) => {
+    console.error(
+      `[tx-submit worker] job ${job?.id} failed (attempt ${job?.attemptsMade}): ${err.message}`,
+    );
+  });
+
+  worker.on("stalled", (jobId: string) => {
+    console.warn(`[tx-submit worker] job ${jobId} stalled — will be requeued`);
+  });
+
+  worker.on("error", (err: Error) => {
+    console.error("[tx-submit worker] worker error:", err.message);
+  });
+
+  return worker;
+}


### PR DESCRIPTION
## Summary

Refactors `POST /tx/submit` to be fully asynchronous. The endpoint now enqueues the signed XDR into a BullMQ queue and returns `{ jobId, status: 'queued' }` (HTTP 202) immediately — no blocking on Soroban RPC confirmation. A dedicated worker processes jobs and tracks lifecycle state in Redis. A new `GET /tx/status/:jobId` endpoint lets clients poll for the final result.

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/tx/tx.queue.ts` | BullMQ producer for the `tx-submit` queue |
| `src/tx/tx.state.ts` | Redis state helpers — `queued → processing → success \| failed`, 24 h TTL |
| `src/tx/tx.worker.ts` | BullMQ worker; submits to Soroban RPC, writes state transitions |
| `src/tx/tx.async.test.ts` | Integration tests (unit + Redis-gated) |

### Modified files
| File | Change |
|------|--------|
| `src/tx/tx.controller.ts` | `POST /tx/submit` → 202 + `{jobId, status}`; new `GET /tx/status/:jobId` |
| `src/tx/tx.service.ts` | `enqueueSubmit()` + `getStatus()`; original `submit()` kept for backward compat |
| `src/tx/tx.module.ts` | Starts worker on `OnModuleInit`, closes on destroy, skips in test env |
| `src/queues/names.ts` | Added `'tx-submit'` to canonical `QUEUE_NAMES` |

## API changes

### `POST /api/tx/submit` (breaking: status code 200 → 202)
**Before:** blocked until Soroban RPC responded, returned full submission result.  
**After:** returns immediately.

```json
// Response — HTTP 202
{ "jobId": "1", "status": "queued" }
```

### `GET /api/tx/status/:jobId` (new)
Poll for the final result. States: `queued → processing → success | failed`.

```json
// Success
{
  "jobId": "1",
  "status": "success",
  "hash": "abc123...",
  "rpcStatus": "PENDING",
  "updatedAt": "2026-05-29T00:00:00.000Z"
}

// Failed — structured error for client-side handling
{
  "jobId": "2",
  "status": "failed",
  "hash": "def456...",
  "error": {
    "code": "TX_BAD_SEQ",
    "message": "Sequence number mismatch. Rebuild the transaction to fetch the latest sequence."
  },
  "updatedAt": "2026-05-29T00:00:00.000Z"
}
```

## Worker design

- **Retry policy:** 3 attempts, exponential backoff starting at 2 s
- **Invalid XDR / fee-bump:** non-retryable — sets `failed` state and returns without throwing
- **RPC unavailable:** retryable — throws so BullMQ re-queues the job
- **RPC ERROR response:** non-retryable — maps `errorResultXdr` to a stable error code
- **Idempotency:** if `idempotency_key` is present, result is cached under `tx:idem:<key>` (10 min TTL) after completion
- **Race conditions:** BullMQ distributed locking via Redis prevents duplicate processing across worker instances
- **Stall detection:** `stalledInterval: 30 s`, `maxStalledCount: 2`
- **Cleanup:** `removeOnComplete: { count: 50 }`, `removeOnFail: { count: 200 }`

## Tests

```
tx-submit queue (unit — no Redis)
  ✓ TxSubmitJobData shape is correct
tx state helpers (unit — no Redis)
  ✓ txStateKey returns expected pattern
buildTxProcessor (unit — mocked deps)
  ✓ sets failed state for invalid XDR without throwing
  ✓ throws on RPC unavailable so BullMQ retries
  ✓ sets success state on successful RPC response
  ✓ sets failed state with structured error on RPC ERROR response
  ✓ caches idempotency key on success
tx-submit queue end-to-end (real Redis) — 5 tests, skipped without REDIS_HOST
```

## CI
- `npm run lint` — ✅ 0 warnings/errors
- `npm run typecheck` — ✅ clean
- `npm run build` — ✅ clean
- `npm test` (unit) — ✅ 7/7 pass

## Notes for reviewers
- The HTTP status code for `POST /tx/submit` changes from **200 → 202**. Frontend clients using `useTransactionStatus` hook should already handle async polling (see `src/hooks/useTransactionStatus.ts`), but any client asserting `status === 200` will need updating.
- Redis state TTL is 24 h. Clients must poll within this window.
- The original synchronous `TxService.submit()` method is preserved and can be used internally if a synchronous path is ever needed.