### PR TITLE
fix(contract): add approved-claim payout timeout auto-rejection

### DIFF
--- a/contracts/deployment-registry.json
+++ b/contracts/deployment-registry.json
@@ -10,7 +10,7 @@
           "expectedVersion": "${NIFFYINSURE_EXPECTED_VERSION}",
           "deployedVersion": "",
           "deployedAt": "",
-          "notes": "Testnet deployment. Set CONTRACT_ID_TESTNET env var. Run `sha256sum niffyinsure.wasm` after each build. After deploy, simulate version() and record result in deployedVersion."
+          "notes": "Testnet deployment. Set CONTRACT_ID_TESTNET env var. Run `sha256sum niffyinsure.wasm` after each build. After deploy, invoke `get_wasm_hash()` and compare it with `expectedWasmHash`, then record the deployed version in deployedVersion."
         }
       ]
     },
@@ -23,7 +23,7 @@
           "expectedVersion": "${NIFFYINSURE_EXPECTED_VERSION}",
           "deployedVersion": "",
           "deployedAt": "",
-          "notes": "Mainnet deployment. CONTRACT_ID_MAINNET is REQUIRED at startup — server refuses to start without it. After deploy, simulate version() and record result in deployedVersion. Alert if deployedVersion != expectedVersion."
+          "notes": "Mainnet deployment. CONTRACT_ID_MAINNET is REQUIRED at startup — server refuses to start without it. After deploy, invoke `get_wasm_hash()` and compare it with `expectedWasmHash`, then record the deployed version in deployedVersion. Alert if deployedVersion != expectedVersion."
         }
       ]
     },
@@ -36,7 +36,7 @@
           "expectedVersion": "${NIFFYINSURE_EXPECTED_VERSION}",
           "deployedVersion": "",
           "deployedAt": "",
-          "notes": "Futurenet deployment. Set CONTRACT_ID_FUTURENET env var. After deploy, simulate version() and record result in deployedVersion."
+          "notes": "Futurenet deployment. Set CONTRACT_ID_FUTURENET env var. After deploy, invoke `get_wasm_hash()` and compare it with `expectedWasmHash`, then record the deployed version in deployedVersion."
         }
       ]
     }

--- a/contracts/niffyinsure/docs/wasm-release.md
+++ b/contracts/niffyinsure/docs/wasm-release.md
@@ -94,11 +94,13 @@ After deploying, verify the on-chain wasm hash matches the expected value:
 # 1. Get the wasm hash from the artifact sidecar
 EXPECTED=$(awk '{print $1}' artifacts/niffyinsure-<version>-<tag>.wasm.sha256)
 
-# 2. Fetch the on-chain wasm hash via Stellar RPC
-ONCHAIN=$(stellar contract info --id <CONTRACT_ID> --network mainnet \
-  | jq -r '.wasm_hash')
+# 2. Read the on-chain wasm hash directly from the contract entrypoint
+ONCHAIN=$(stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  -- get_wasm_hash)
 
-# 3. Compare
+# 3. Compare against the artifact-sidecar hash
 if [ "$EXPECTED" = "$ONCHAIN" ]; then
   echo "✅ Hash match: $ONCHAIN"
 else
@@ -106,6 +108,8 @@ else
   exit 1
 fi
 ```
+
+The contract hash returned by `get_wasm_hash()` is the canonical 32-byte WASM identifier used by Stellar RPC and the deployment registry. The hash is stored as a hex string in the artifact sidecar and should be compared byte-for-byte with the value returned by `get_wasm_hash()` after each upgrade.
 
 Record the expected hash in `contracts/deployment-registry.json` under `expectedWasmHash` for each network.
 

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -184,6 +184,16 @@ pub struct ClaimRejected {
     pub at_ledger: u32,
 }
 
+/// Emitted when an approved payout is still unprocessed after its deadline.
+#[contractevent(topics = ["niffyinsure", "payout_timed_out"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PayoutTimedOut {
+    #[topic]
+    pub claim_id: u64,
+    pub deadline_ledger: u32,
+    pub at_ledger: u32,
+}
+
 /// Emitted every time a rejection increments the policy's strike counter.
 /// Indexers should use this event to notify holders of accumulating strikes
 /// before the threshold triggers deactivation.
@@ -309,6 +319,7 @@ pub fn file_claim(
         evidence: evidence.clone(),
         status: ClaimStatus::Processing,
         voting_deadline_ledger,
+        payout_deadline_ledger: 0,
         approve_votes: 0,
         reject_votes: 0,
         filed_at: now,
@@ -470,6 +481,9 @@ pub fn vote_on_claim(
     }
 
     if claim.status != status_before {
+        if claim.status == ClaimStatus::Approved && claim.payout_deadline_ledger == 0 {
+            claim.payout_deadline_ledger = now.saturating_add(ledger::PAYOUT_TIMEOUT_LEDGERS);
+        }
         push_status_transition(&mut claim.status_history, claim.status.clone(), now);
     }
 
@@ -548,6 +562,9 @@ fn finalize_claim_inner(env: &Env, claim_id: u64) -> Result<ClaimStatus, Error> 
     }
 
     if claim.status != status_before {
+        if claim.status == ClaimStatus::Approved && claim.payout_deadline_ledger == 0 {
+            claim.payout_deadline_ledger = now.saturating_add(ledger::PAYOUT_TIMEOUT_LEDGERS);
+        }
         push_status_transition(&mut claim.status_history, claim.status.clone(), now);
     }
 
@@ -592,6 +609,35 @@ pub fn process_deadline(env: &Env, claim_id: u64) -> Result<ClaimStatus, Error> 
         return Err(Error::ClaimNotProcessing);
     }
     finalize_claim_inner(env, claim_id)
+}
+
+/// Permissionless keeper: auto-reject an approved claim once its payout deadline has passed.
+pub fn process_payout_timeout(env: &Env, claim_id: u64) -> Result<ClaimStatus, Error> {
+    let mut claim = storage::get_claim(env, claim_id).ok_or(Error::ClaimNotFound)?;
+
+    if claim.status != ClaimStatus::Approved {
+        return Err(Error::ClaimNotApproved);
+    }
+
+    let now = env.ledger().sequence();
+    if now <= claim.payout_deadline_ledger {
+        return Err(Error::PayoutDeadlineNotReached);
+    }
+
+    claim.status = ClaimStatus::PayoutTimeout;
+    push_status_transition(&mut claim.status_history, ClaimStatus::PayoutTimeout, now);
+    storage::set_open_claim(env, &claim.claimant, claim.policy_id, false);
+    storage::remove_claim_rate_limit_prev(env, claim_id);
+    storage::set_claim(env, &claim);
+
+    PayoutTimedOut {
+        claim_id,
+        deadline_ledger: claim.payout_deadline_ledger,
+        at_ledger: now,
+    }
+    .publish(env);
+
+    Ok(claim.status)
 }
 
 // ── process_claim (admin payout trigger) ─────────────────────────────────────

--- a/contracts/niffyinsure/src/ledger.rs
+++ b/contracts/niffyinsure/src/ledger.rs
@@ -72,6 +72,9 @@ pub const LEDGERS_PER_WEEK: u32 = 120_960;
 /// Default policy duration: ~30 days.
 pub const POLICY_DURATION_LEDGERS: u32 = 30 * LEDGERS_PER_DAY; // 518_400
 
+/// Default payout timeout for an approved but unpaid claim: ~7 days.
+pub const PAYOUT_TIMEOUT_LEDGERS: u32 = 7 * LEDGERS_PER_DAY; // 120_960
+
 /// Voting window: ~7 days from claim filing.
 /// Default value for [`crate::storage::get_voting_duration_ledgers`] and historical
 /// behaviour: new claims use `voting_deadline_ledger = filed_at + duration` where

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -99,6 +99,12 @@ impl NiffyInsure {
         soroban_sdk::String::from_str(&env, env!("CARGO_PKG_VERSION"))
     }
 
+    /// Read-only: on-chain WASM hash for this deployed contract.
+    /// The returned value is the canonical hash used by the deployment registry and RPC tooling.
+    pub fn get_wasm_hash(env: Env) -> soroban_sdk::BytesN<32> {
+        env.deployer().current_contract_wasm_hash()
+    }
+
     /// Read-only: balance of the default payout token held by this contract (payout reserve).
     /// Matches funds available for `process_claim` for the configured default asset.
     pub fn get_treasury_balance(env: Env) -> i128 {

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -175,6 +175,7 @@ impl NiffyInsure {
             52 => validate::Error::NonceMismatch,
             53 => validate::Error::ClaimNotProcessing,
             54 => validate::Error::RollingClaimCapExceeded,
+            55 => validate::Error::PayoutDeadlineNotReached,
             _ => validate::Error::ClaimNotApproved,
         };
         policy::map_quote_error(&env, err)
@@ -281,6 +282,14 @@ impl NiffyInsure {
         claim_id: u64,
     ) -> Result<types::ClaimStatus, validate::Error> {
         claim::process_deadline(&env, claim_id)
+    }
+
+    /// Permissionless keeper: auto-reject an approved claim once its payout deadline has elapsed.
+    pub fn process_payout_timeout(
+        env: Env,
+        claim_id: u64,
+    ) -> Result<types::ClaimStatus, validate::Error> {
+        claim::process_payout_timeout(&env, claim_id)
     }
 
     pub fn get_claim_history(

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -243,6 +243,9 @@ pub fn map_quote_error(env: &Env, err: Error) -> QuoteFailure {
         Error::RollingClaimCapExceeded => {
             "rolling claim cap exceeded: total paid claims for this policy exceed the configured cap for this window"
         },
+        Error::PayoutDeadlineNotReached => {
+            "payout timeout is not yet due: the approved claim must wait for its deadline to pass"
+        },
     };
     QuoteFailure {
         code: err as u32,

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -114,6 +114,7 @@ pub type CoverageType = CoverageTier;
 ///   Processing  → Rejected      (participation quorum met + reject wins or tie; or deadline with no quorum)
 ///   Processing  → Withdrawn     (claimant calls `withdraw_claim` before any vote is cast)
 ///   Approved    → Paid          (admin calls process_claim)
+///   Approved    → PayoutTimeout (keeper calls `process_payout_timeout` after `payout_deadline_ledger`)
 ///
 /// Appeal-flow transitions (requires Rejected status + open appeal window):
 ///   Rejected    → UnderAppeal   (claimant calls open_appeal within window)
@@ -129,6 +130,7 @@ pub enum ClaimStatus {
     Processing,
     Pending,
     Approved,
+    PayoutTimeout,
     Paid,
     Rejected,
     /// Claimant has opened an appeal; fresh vote round in progress.
@@ -181,6 +183,7 @@ impl ClaimStatus {
         matches!(
             self,
             ClaimStatus::Approved
+                | ClaimStatus::PayoutTimeout
                 | ClaimStatus::Paid
                 | ClaimStatus::Rejected
                 | ClaimStatus::AppealApproved
@@ -517,6 +520,8 @@ pub struct Claim {
     pub evidence: Vec<ClaimEvidenceEntry>,
     pub status: ClaimStatus,
     pub voting_deadline_ledger: u32,
+    /// Ledger by which an approved payout must be executed or the claim auto-times out.
+    pub payout_deadline_ledger: u32,
     pub approve_votes: u32,
     pub reject_votes: u32,
     /// Ledger sequence at which this claim was filed (voting window anchor).

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -67,6 +67,8 @@ pub enum Error {
     ClaimNotProcessing = 53,
     /// New claim would exceed the rolling per-policy paid-amount cap for the current window.
     RollingClaimCapExceeded = 54,
+    /// Keeper `process_payout_timeout` called before the approved payout deadline elapsed.
+    PayoutDeadlineNotReached = 55,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {


### PR DESCRIPTION
## Checklist

This PR adds contract-side WASM hash verification support via [get_wasm_hash()](https://special-waffle-qvqv46rjrrpwhrv4.github.dev/) and updates the deployment-registry guidance to use the on-chain hash after upgrades.


## Closes
Closes #590 
Closes #591 