### PR TITLE
feat: implement issues #580, #582, #584, #586

### DIFF
--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -595,7 +595,107 @@ pub fn finalize_claim(env: &Env, claim_id: u64) -> Result<ClaimStatus, Error> {
     finalize_claim_inner(env, claim_id)
 }
 
-/// Permissionless keeper: same outcome as [`finalize_claim`] when voting has ended, but returns
+// ── Batch finalization constants ──────────────────────────────────────────────
+
+/// Maximum number of claim IDs accepted in a single `finalize_expired_batch` call.
+///
+/// Sized to stay within Soroban's default instruction budget for a single transaction.
+/// Each claim requires at least one persistent read + write; 20 matches the existing
+/// `PAGE_SIZE_MAX` pagination cap used elsewhere in this contract.
+///
+/// Callers that need to process more claims must split into multiple transactions.
+pub const BATCH_FINALIZE_MAX: u32 = 20;
+
+// ── BatchFinalized event ──────────────────────────────────────────────────────
+
+/// Summary event emitted once per `finalize_expired_batch` call after all eligible
+/// claims have been processed.
+///
+/// topics: ("niffyinsure", "batch_finalized")
+/// payload: { processed, skipped, at_ledger }
+///
+/// `processed` = number of claims that transitioned out of `Processing`.
+/// `skipped`   = number of claim IDs that were already terminal or not found.
+#[contractevent(topics = ["niffyinsure", "batch_finalized"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchFinalized {
+    pub processed: u32,
+    pub skipped: u32,
+    pub at_ledger: u32,
+}
+
+/// Permissionless keeper: finalize multiple expired claims in one transaction.
+///
+/// For each `claim_id` in `claim_ids`:
+/// - If the claim is not found or already terminal → skip (no revert).
+/// - If the voting deadline has not passed → skip (no revert).
+/// - Otherwise → finalize via the same logic as `process_deadline`.
+///
+/// Reverts before any processing if `claim_ids.len() > BATCH_FINALIZE_MAX`.
+/// Reverts if `claims_paused` is set.
+///
+/// Emits individual finalization events per claim (via `finalize_claim_inner`)
+/// and one `BatchFinalized` summary event at the end.
+pub fn finalize_expired_batch(
+    env: &Env,
+    claim_ids: &soroban_sdk::Vec<u64>,
+) -> Result<(u32, u32), Error> {
+    if storage::get_pause_flags(env).claims_paused {
+        return Err(Error::CalculatorPaused);
+    }
+    if claim_ids.len() > BATCH_FINALIZE_MAX {
+        return Err(Error::PolicyBatchTooLarge);
+    }
+
+    let now = env.ledger().sequence();
+    let mut processed: u32 = 0;
+    let mut skipped: u32 = 0;
+
+    for i in 0..claim_ids.len() {
+        let claim_id = claim_ids.get(i).unwrap();
+
+        let claim = match storage::get_claim(env, claim_id) {
+            Some(c) => c,
+            None => {
+                skipped += 1;
+                continue;
+            }
+        };
+
+        // Skip already-finalized claims without reverting.
+        if claim.status.is_terminal() {
+            skipped += 1;
+            continue;
+        }
+
+        // Skip claims whose voting window is still open.
+        if !ledger::is_claim_past_voting_deadline(now, claim.voting_deadline_ledger) {
+            skipped += 1;
+            continue;
+        }
+
+        // Only finalize Processing claims (same guard as process_deadline).
+        if claim.status != ClaimStatus::Processing {
+            skipped += 1;
+            continue;
+        }
+
+        // finalize_claim_inner never panics for eligible claims; propagate unexpected errors.
+        finalize_claim_inner(env, claim_id)?;
+        processed += 1;
+    }
+
+    BatchFinalized {
+        processed,
+        skipped,
+        at_ledger: now,
+    }
+    .publish(env);
+
+    Ok((processed, skipped))
+}
+
+/// Permissionless keeper: same outcome as `finalize_claim` when voting has ended, but returns
 /// [`Error::CalculatorPaused`] if `claims_paused` is set instead of panicking.
 ///
 /// Only [`ClaimStatus::Processing`] claims are eligible so keepers cannot advance appeal or other flows.

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -60,6 +60,14 @@ struct QuorumUpdated {
     pub new_bps: u32,
 }
 
+#[contractevent(topics = ["niffyinsure", "policy_type_registered"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PolicyTypeRegistered {
+    pub policy_type: types::PolicyType,
+    /// `true` = registered/active, `false` = deregistered/inactive.
+    pub active: bool,
+}
+
 #[contractevent(topics = ["niffyinsure", "pause_toggled"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PauseToggled {
@@ -333,6 +341,18 @@ impl NiffyInsure {
         claim_id: u64,
     ) -> Result<types::ClaimStatus, validate::Error> {
         claim::process_deadline(&env, claim_id)
+    }
+
+    /// Permissionless keeper: finalize multiple expired claims in one transaction.
+    ///
+    /// Processes each claim independently; skips already-finalized or ineligible claims.
+    /// Reverts before any processing if `claim_ids.len() > BATCH_FINALIZE_MAX` (20).
+    /// Returns `(processed, skipped)` counts.
+    pub fn finalize_expired_batch(
+        env: Env,
+        claim_ids: soroban_sdk::Vec<u64>,
+    ) -> Result<(u32, u32), validate::Error> {
+        claim::finalize_expired_batch(&env, &claim_ids)
     }
 
     /// Permissionless keeper: auto-reject an approved claim once its payout deadline has elapsed.
@@ -832,6 +852,61 @@ impl NiffyInsure {
         asset: Address,
     ) -> Option<types::MultiplierTable> {
         storage::get_asset_premium_table(&env, &asset)
+    }
+
+    // ── Policy type registry ──────────────────────────────────────────────────
+
+    /// Admin-only: register or update a policy type in the registry.
+    ///
+    /// Once registered and active, `initiate_policy` will accept this type.
+    /// Emits `PolicyTypeRegistered`.
+    pub fn admin_register_policy_type(
+        env: Env,
+        policy_type: types::PolicyType,
+        config: types::PolicyTypeConfig,
+    ) -> Result<(), admin::AdminError> {
+        admin::require_admin(&env);
+        storage::bump_instance(&env);
+        storage::set_policy_type_config(&env, &policy_type, &config);
+        storage::set_policy_type_active(&env, &policy_type, true);
+        PolicyTypeRegistered {
+            policy_type,
+            active: true,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Admin-only: deregister a policy type (marks it inactive).
+    ///
+    /// Existing policies of this type remain valid; only new initiations are blocked.
+    /// Emits `PolicyTypeRegistered` with `active = false`.
+    pub fn admin_deregister_policy_type(
+        env: Env,
+        policy_type: types::PolicyType,
+    ) -> Result<(), admin::AdminError> {
+        admin::require_admin(&env);
+        storage::bump_instance(&env);
+        storage::set_policy_type_active(&env, &policy_type, false);
+        PolicyTypeRegistered {
+            policy_type,
+            active: false,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Read-only: returns `true` if the policy type is registered and active.
+    pub fn is_policy_type_active(env: Env, policy_type: types::PolicyType) -> bool {
+        storage::is_policy_type_active(&env, &policy_type)
+    }
+
+    /// Read-only: returns the config for a policy type, or `None` if not registered.
+    pub fn get_policy_type_config(
+        env: Env,
+        policy_type: types::PolicyType,
+    ) -> Option<types::PolicyTypeConfig> {
+        storage::get_policy_type_config(&env, &policy_type)
     }
 
     // ═════════════════════════════════════════════════════════════════════════════

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -281,6 +281,15 @@ pub fn initiate_policy(
     // Check granular pause: policy binding should be blocked if bind_paused
     storage::assert_bind_not_paused(env);
 
+    // Policy type registry check: if the registry is enabled, the requested type
+    // must be registered and active. If the registry has never been used, all types
+    // are allowed for backward compatibility with pre-registry deployments.
+    if storage::is_policy_type_registry_enabled(env)
+        && !storage::is_policy_type_active(env, &policy_type)
+    {
+        return Err(PolicyError::AssetNotAllowed);
+    }
+
     // Asset allowlist check — before auth so callers get a clear error.
     if !storage::is_allowed_asset(env, &asset) {
         return Err(PolicyError::AssetNotAllowed);

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -159,6 +159,16 @@ pub enum DataKey {
     CommitRevealPhases(u64),
     /// Voter's 32-byte commitment hash: SHA-256(vote_byte || salt).
     VoteCommitment(u64, Address),
+    // ── Policy type registry ──────────────────────────────────────────────────
+    /// Admin-managed per-policy-type configuration (payout override, active flag).
+    PolicyTypeConfig(crate::types::PolicyType),
+    /// Whether a policy type is registered and active in the registry.
+    PolicyTypeActive(crate::types::PolicyType),
+    /// Whether the policy type registry is enabled (set on first registration).
+    PolicyTypeRegistryEnabled,
+    // ── Per-asset premium table ───────────────────────────────────────────────
+    /// Asset-specific multiplier table (falls back to global default when absent).
+    AssetPremiumTable(Address),
 }
 pub fn has_open_claim(env: &Env, holder: &Address, policy_id: u32) -> bool {
     env.storage()
@@ -1222,6 +1232,35 @@ pub fn set_policy_type_config(
     env.storage()
         .instance()
         .set(&DataKey::PolicyTypeConfig(policy_type.clone()), config);
+}
+
+/// Returns `true` if the policy type is registered and active in the registry.
+pub fn is_policy_type_active(env: &Env, policy_type: &crate::types::PolicyType) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::PolicyTypeActive(policy_type.clone()))
+        .unwrap_or(false)
+}
+
+/// Set the active flag for a policy type in the registry.
+pub fn set_policy_type_active(env: &Env, policy_type: &crate::types::PolicyType, active: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PolicyTypeActive(policy_type.clone()), &active);
+    // Mark the registry as enabled on first registration.
+    if active {
+        env.storage()
+            .instance()
+            .set(&DataKey::PolicyTypeRegistryEnabled, &true);
+    }
+}
+
+/// Returns `true` if the policy type registry has been activated (at least one type registered).
+pub fn is_policy_type_registry_enabled(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::PolicyTypeRegistryEnabled)
+        .unwrap_or(false)
 }
 
 // ── Per-asset premium table (instance) ───────────────────────────────────────

--- a/contracts/niffyinsure/tests/batch_finalization.rs
+++ b/contracts/niffyinsure/tests/batch_finalization.rs
@@ -1,0 +1,183 @@
+//! #580 — Batch claim finalization: keeper processes multiple expired deadlines in one call.
+
+#![cfg(test)]
+
+use niffyinsure::{
+    types::{ClaimStatus, VoteOption},
+    validate::Error,
+    NiffyInsureClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+fn seed(client: &NiffyInsureClient, holder: &Address, end_ledger: u32) {
+    client.test_seed_policy(holder, &1u32, &1_000_000i128, &end_ledger);
+}
+
+fn file(
+    env: &Env,
+    client: &NiffyInsureClient,
+    holder: &Address,
+) -> u64 {
+    let details = String::from_str(env, "batch test");
+    let urls = vec![env];
+    client.file_claim(holder, &1u32, &100_000i128, &details, &urls, &None)
+}
+
+// ── Over-cap reverts before any processing ────────────────────────────────────
+
+#[test]
+fn over_cap_reverts_before_processing() {
+    let (env, client, _, _) = setup();
+    // Build a vec of 21 claim IDs (cap is 20).
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for i in 1u64..=21 {
+        ids.push_back(i);
+    }
+    let err = client
+        .try_finalize_expired_batch(&ids)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyBatchTooLarge);
+}
+
+// ── Batch processes eligible claims and skips ineligible ones ─────────────────
+
+#[test]
+fn batch_processes_eligible_skips_ineligible() {
+    let (env, client, _, _) = setup();
+
+    let h1 = Address::generate(&env);
+    let h2 = Address::generate(&env);
+    let h3 = Address::generate(&env);
+    seed(&client, &h1, 50_000);
+    seed(&client, &h2, 50_000);
+    seed(&client, &h3, 50_000);
+    client.admin_set_quorum_bps(&10_000u32);
+
+    // File two claims; leave h3 without a claim.
+    let cid1 = file(&env, &client, &h1);
+    let cid2 = file(&env, &client, &h2);
+
+    // Advance past voting deadline.
+    let deadline = client.get_claim(&cid1).voting_deadline_ledger;
+    env.ledger()
+        .with_mut(|l| l.sequence_number = deadline.saturating_add(1));
+
+    // Batch: cid1 (eligible), cid2 (eligible), 999 (not found).
+    let mut ids = soroban_sdk::Vec::new(&env);
+    ids.push_back(cid1);
+    ids.push_back(cid2);
+    ids.push_back(999u64);
+
+    let (processed, skipped) = client.finalize_expired_batch(&ids);
+    assert_eq!(processed, 2);
+    assert_eq!(skipped, 1);
+
+    assert_ne!(
+        client.get_claim(&cid1).status,
+        ClaimStatus::Processing
+    );
+    assert_ne!(
+        client.get_claim(&cid2).status,
+        ClaimStatus::Processing
+    );
+}
+
+// ── Already-finalized claims are skipped without reverting ───────────────────
+
+#[test]
+fn already_finalized_claims_are_skipped() {
+    let (env, client, _, _) = setup();
+
+    let h1 = Address::generate(&env);
+    let h2 = Address::generate(&env);
+    seed(&client, &h1, 50_000);
+    seed(&client, &h2, 50_000);
+    client.admin_set_quorum_bps(&10_000u32);
+
+    let cid1 = file(&env, &client, &h1);
+
+    // Finalize cid1 via vote (terminal before batch).
+    client.vote_on_claim(&h1, &cid1, &VoteOption::Approve);
+    client.vote_on_claim(&h2, &cid1, &VoteOption::Approve);
+    assert_eq!(client.get_claim(&cid1).status, ClaimStatus::Approved);
+
+    let deadline = client.get_claim(&cid1).voting_deadline_ledger;
+    env.ledger()
+        .with_mut(|l| l.sequence_number = deadline.saturating_add(1));
+
+    let mut ids = soroban_sdk::Vec::new(&env);
+    ids.push_back(cid1);
+
+    // Should not revert; cid1 is already terminal → skipped.
+    let (processed, skipped) = client.finalize_expired_batch(&ids);
+    assert_eq!(processed, 0);
+    assert_eq!(skipped, 1);
+}
+
+// ── Empty batch succeeds with zero counts ─────────────────────────────────────
+
+#[test]
+fn empty_batch_succeeds() {
+    let (env, client, _, _) = setup();
+    let ids = soroban_sdk::Vec::new(&env);
+    let (processed, skipped) = client.finalize_expired_batch(&ids);
+    assert_eq!(processed, 0);
+    assert_eq!(skipped, 0);
+}
+
+// ── Batch reverts when claims_paused ─────────────────────────────────────────
+
+#[test]
+fn batch_reverts_when_claims_paused() {
+    let (env, client, admin, _) = setup();
+    client.pause_claims(&admin, &0u32);
+
+    let ids = soroban_sdk::Vec::new(&env);
+    let err = client
+        .try_finalize_expired_batch(&ids)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::CalculatorPaused);
+}
+
+// ── Claims with voting window still open are skipped ─────────────────────────
+
+#[test]
+fn claims_with_open_voting_window_are_skipped() {
+    let (env, client, _, _) = setup();
+
+    let h1 = Address::generate(&env);
+    let h2 = Address::generate(&env);
+    seed(&client, &h1, 50_000);
+    seed(&client, &h2, 50_000);
+    client.admin_set_quorum_bps(&10_000u32);
+
+    let cid = file(&env, &client, &h1);
+
+    // Do NOT advance past deadline — voting window still open.
+    let mut ids = soroban_sdk::Vec::new(&env);
+    ids.push_back(cid);
+
+    let (processed, skipped) = client.finalize_expired_batch(&ids);
+    assert_eq!(processed, 0);
+    assert_eq!(skipped, 1);
+    assert_eq!(client.get_claim(&cid).status, ClaimStatus::Processing);
+}

--- a/contracts/niffyinsure/tests/expiry_boundary.rs
+++ b/contracts/niffyinsure/tests/expiry_boundary.rs
@@ -1,0 +1,254 @@
+//! #586 — Coverage gap detection: revert on policy lapse before renewal.
+//!
+//! Boundary semantics: `[start, end)` — `now == end` means expired.
+//!
+//! Acceptance criteria:
+//! - Claims at the exact expiry ledger revert.
+//! - Claims one ledger before expiry succeed.
+//! - Boundary semantics are consistent across all policy validity checks.
+
+#![cfg(test)]
+
+use niffyinsure::{
+    types::{AgeBand, CoverageType},
+    validate::Error,
+    NiffyInsureClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+fn seed(client: &NiffyInsureClient, holder: &Address, end_ledger: u32) {
+    client.test_seed_policy(holder, &1u32, &1_000_000i128, &end_ledger);
+}
+
+fn file_claim(env: &Env, client: &NiffyInsureClient, holder: &Address) -> u64 {
+    let details = String::from_str(env, "boundary test");
+    let urls = vec![env];
+    client.file_claim(holder, &1u32, &100_000i128, &details, &urls, &None)
+}
+
+// ── file_claim boundary: end_ledger - 1 succeeds ─────────────────────────────
+
+#[test]
+fn file_claim_one_before_expiry_succeeds() {
+    let (env, client, _, _) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    // now = end - 1: still within [start, end)
+    env.ledger().with_mut(|l| l.sequence_number = end - 1);
+    let cid = file_claim(&env, &client, &holder);
+    assert!(cid > 0);
+}
+
+// ── file_claim boundary: at end_ledger reverts ────────────────────────────────
+
+#[test]
+fn file_claim_at_expiry_ledger_reverts() {
+    let (env, client, _, _) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    // now == end: expired (exclusive end)
+    env.ledger().with_mut(|l| l.sequence_number = end);
+    let err = client
+        .try_file_claim(
+            &holder,
+            &1u32,
+            &100_000i128,
+            &String::from_str(&env, "x"),
+            &vec![&env],
+            &None,
+        )
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyExpired);
+}
+
+// ── file_claim boundary: end_ledger + 1 reverts ───────────────────────────────
+
+#[test]
+fn file_claim_one_after_expiry_reverts() {
+    let (env, client, _, _) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    env.ledger().with_mut(|l| l.sequence_number = end + 1);
+    let err = client
+        .try_file_claim(
+            &holder,
+            &1u32,
+            &100_000i128,
+            &String::from_str(&env, "x"),
+            &vec![&env],
+            &None,
+        )
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::PolicyExpired);
+}
+
+// ── process_expired boundary: at end_ledger succeeds (policy is expired) ─────
+
+#[test]
+fn process_expired_at_end_ledger_succeeds() {
+    let (env, client, _, _) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    // now == end: is_expired returns true (now >= end)
+    env.ledger().with_mut(|l| l.sequence_number = end);
+    // process_expired should succeed (policy is expired at end_ledger)
+    client.process_expired(&holder, &1u32);
+}
+
+// ── process_expired boundary: one before end_ledger reverts ──────────────────
+
+#[test]
+fn process_expired_one_before_end_ledger_reverts() {
+    let (env, client, _, _) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    env.ledger().with_mut(|l| l.sequence_number = end - 1);
+    let err = client
+        .try_process_expired(&holder, &1u32)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, niffyinsure::policy::PolicyError::NotYetExpired);
+}
+
+// ── Renewal boundary: one before end_ledger is in renewal window ─────────────
+
+#[test]
+fn renew_one_before_end_ledger_is_in_window() {
+    use niffyinsure::types::{DEFAULT_GRACE_PERIOD_LEDGERS, RENEWAL_WINDOW_LEDGERS};
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    // Use a large end_ledger so renewal window opens before it.
+    let end = 100_000u32;
+    seed(&client, &holder, end);
+
+    // Mint tokens for renewal premium.
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&holder, &1_000_000_000i128);
+    soroban_sdk::token::Client::new(&env, &token).approve(
+        &holder,
+        &client.address,
+        &1_000_000_000i128,
+        &(end + DEFAULT_GRACE_PERIOD_LEDGERS + 1000),
+    );
+
+    // now = end - 1: inside renewal window [end - RENEWAL_WINDOW, end)
+    let renewal_start = end.saturating_sub(RENEWAL_WINDOW_LEDGERS);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = renewal_start.max(end - 1));
+
+    let result = client.try_renew_policy(
+        &holder,
+        &1u32,
+        &AgeBand::Adult,
+        &CoverageType::Standard,
+        &80u32,
+    );
+    // Should succeed (in renewal window).
+    match result {
+        Ok(Ok(_)) => {}
+        other => panic!("expected renewal to succeed near end_ledger, got {other:?}"),
+    }
+}
+
+// ── Renewal boundary: at end_ledger is in grace period ───────────────────────
+
+#[test]
+fn renew_at_end_ledger_is_in_grace_period() {
+    use niffyinsure::types::DEFAULT_GRACE_PERIOD_LEDGERS;
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let end = 100_000u32;
+    seed(&client, &holder, end);
+
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&holder, &1_000_000_000i128);
+    soroban_sdk::token::Client::new(&env, &token).approve(
+        &holder,
+        &client.address,
+        &1_000_000_000i128,
+        &(end + DEFAULT_GRACE_PERIOD_LEDGERS + 1000),
+    );
+
+    // now == end: policy expired but within grace period
+    env.ledger().with_mut(|l| l.sequence_number = end);
+
+    let result = client.try_renew_policy(
+        &holder,
+        &1u32,
+        &AgeBand::Adult,
+        &CoverageType::Standard,
+        &80u32,
+    );
+    // Should succeed (within grace period).
+    match result {
+        Ok(Ok(_)) => {}
+        other => panic!("expected renewal to succeed at end_ledger (grace period), got {other:?}"),
+    }
+}
+
+// ── Renewal boundary: past grace period reverts ───────────────────────────────
+
+#[test]
+fn renew_past_grace_period_returns_lapsed() {
+    use niffyinsure::types::{DEFAULT_GRACE_PERIOD_LEDGERS, RenewPolicyOutcome};
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let end = 1_000u32;
+    seed(&client, &holder, end);
+
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&holder, &1_000_000_000i128);
+    soroban_sdk::token::Client::new(&env, &token).approve(
+        &holder,
+        &client.address,
+        &1_000_000_000i128,
+        &(end + DEFAULT_GRACE_PERIOD_LEDGERS + 1000),
+    );
+
+    // now = end + grace + 1: past grace period
+    let lapsed = end.saturating_add(DEFAULT_GRACE_PERIOD_LEDGERS).saturating_add(1);
+    env.ledger().with_mut(|l| l.sequence_number = lapsed);
+
+    let result = client.try_renew_policy(
+        &holder,
+        &1u32,
+        &AgeBand::Adult,
+        &CoverageType::Standard,
+        &80u32,
+    );
+    // Returns Ok(Lapsed) — not an error, but no renewal.
+    match result {
+        Ok(Ok(RenewPolicyOutcome::Lapsed)) => {}
+        other => panic!("expected Lapsed, got {other:?}"),
+    }
+}

--- a/contracts/niffyinsure/tests/policy_type_registry.rs
+++ b/contracts/niffyinsure/tests/policy_type_registry.rs
@@ -1,0 +1,233 @@
+//! #582 — Policy type registry: admin-managed coverage product catalog.
+//!
+//! Acceptance criteria:
+//! - Unregistered policy types revert at initiation.
+//! - Existing policies of a deregistered type remain valid.
+//! - Registry changes are authenticated and emit events.
+
+#![cfg(test)]
+
+use niffyinsure::{
+    types::{AgeBand, CoverageType, InitiatePolicyOptions, PolicyType, PolicyTypeConfig, RegionTier},
+    NiffyInsureClient, PolicyError,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let tok = env.register_stellar_asset_contract_v2(issuer).address();
+    client.initialize(&admin, &tok);
+    (env, client, admin, tok)
+}
+
+fn mint_and_approve(env: &Env, client: &NiffyInsureClient, holder: &Address, token: &Address) {
+    token::StellarAssetClient::new(env, token).mint(holder, &10_000_000_000i128);
+    token::Client::new(env, token).approve(
+        holder,
+        &client.address,
+        &10_000_000_000i128,
+        &6_312_000u32,
+    );
+}
+
+fn initiate(
+    client: &NiffyInsureClient,
+    holder: &Address,
+    policy_type: &PolicyType,
+    token: &Address,
+) -> Result<niffyinsure::types::Policy, niffyinsure::PolicyError> {
+    match client.try_initiate_policy(
+        holder,
+        policy_type,
+        &RegionTier::Medium,
+        &AgeBand::Adult,
+        &CoverageType::Standard,
+        &80u32,
+        &1_000_000i128,
+        token,
+        &InitiatePolicyOptions {
+            beneficiary: None,
+            deductible: None,
+            expected_nonce: None,
+        },
+    ) {
+        Ok(Ok(policy)) => Ok(policy),
+        Err(Ok(e)) => Err(e),
+        Ok(Err(e)) => panic!("conversion error: {e:?}"),
+        Err(Err(e)) => panic!("invoke error: {e:?}"),
+    }
+}
+
+// ── Before registry is enabled, all types are allowed ────────────────────────
+
+#[test]
+fn all_types_allowed_before_registry_enabled() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    // No registry configured — all types should pass.
+    assert!(initiate(&client, &holder, &PolicyType::Auto, &token).is_ok());
+}
+
+// ── Registered type is allowed ────────────────────────────────────────────────
+
+#[test]
+fn registered_type_is_allowed() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    client.admin_register_policy_type(
+        &PolicyType::Auto,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+
+    assert!(initiate(&client, &holder, &PolicyType::Auto, &token).is_ok());
+}
+
+// ── Unregistered type reverts after registry is enabled ──────────────────────
+
+#[test]
+fn unregistered_type_reverts_after_registry_enabled() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    // Register only Auto — Health is unregistered.
+    client.admin_register_policy_type(
+        &PolicyType::Auto,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+
+    let err = initiate(&client, &holder, &PolicyType::Health, &token)
+        .err()
+        .unwrap();
+    // AssetNotAllowed is the error returned for registry rejection.
+    assert_eq!(err, PolicyError::AssetNotAllowed);
+}
+
+// ── Deregistered type reverts at initiation ───────────────────────────────────
+
+#[test]
+fn deregistered_type_reverts_at_initiation() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    client.admin_register_policy_type(
+        &PolicyType::Auto,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+    client.admin_deregister_policy_type(&PolicyType::Auto);
+
+    let err = initiate(&client, &holder, &PolicyType::Auto, &token)
+        .err()
+        .unwrap();
+    assert_eq!(err, PolicyError::AssetNotAllowed);
+}
+
+// ── Existing policies of a deregistered type remain valid ────────────────────
+
+#[test]
+fn existing_policies_of_deregistered_type_remain_valid() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    // Register Auto and create a policy.
+    client.admin_register_policy_type(
+        &PolicyType::Auto,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+    let policy = initiate(&client, &holder, &PolicyType::Auto, &token).unwrap();
+
+    // Deregister Auto.
+    client.admin_deregister_policy_type(&PolicyType::Auto);
+
+    // Existing policy should still be readable and active.
+    let stored = client.get_policy(&holder, &policy.policy_id).unwrap();
+    assert!(stored.is_active);
+    assert_eq!(stored.policy_type, PolicyType::Auto);
+}
+
+// ── is_policy_type_active reflects registry state ────────────────────────────
+
+#[test]
+fn is_policy_type_active_reflects_registry() {
+    let (env, client, _, _) = setup();
+
+    assert!(!client.is_policy_type_active(&PolicyType::Auto));
+
+    client.admin_register_policy_type(
+        &PolicyType::Auto,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+    assert!(client.is_policy_type_active(&PolicyType::Auto));
+
+    client.admin_deregister_policy_type(&PolicyType::Auto);
+    assert!(!client.is_policy_type_active(&PolicyType::Auto));
+}
+
+// ── get_policy_type_config returns stored config ──────────────────────────────
+
+#[test]
+fn get_policy_type_config_returns_stored_config() {
+    let (env, client, _, _) = setup();
+
+    assert!(client.get_policy_type_config(&PolicyType::Health).is_none());
+
+    let config = PolicyTypeConfig {
+        payout_asset_override: None,
+    };
+    client.admin_register_policy_type(&PolicyType::Health, &config);
+
+    let stored = client.get_policy_type_config(&PolicyType::Health).unwrap();
+    assert_eq!(stored.payout_asset_override, None);
+}
+
+// ── Re-registering a deregistered type re-enables it ─────────────────────────
+
+#[test]
+fn re_registering_deregistered_type_re_enables_it() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    mint_and_approve(&env, &client, &holder, &token);
+
+    client.admin_register_policy_type(
+        &PolicyType::Property,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+    client.admin_deregister_policy_type(&PolicyType::Property);
+
+    // Re-register.
+    client.admin_register_policy_type(
+        &PolicyType::Property,
+        &PolicyTypeConfig {
+            payout_asset_override: None,
+        },
+    );
+
+    assert!(initiate(&client, &holder, &PolicyType::Property, &token).is_ok());
+}

--- a/contracts/niffyinsure/tests/voter_snapshot.rs
+++ b/contracts/niffyinsure/tests/voter_snapshot.rs
@@ -1,0 +1,128 @@
+//! #584 — Voter eligibility snapshot: block-height-anchored eligibility freeze.
+//!
+//! Voters eligible at filing but not at vote time can still vote.
+//! Voters not eligible at filing cannot vote even if they become eligible later.
+//! Snapshot is immutable after claim creation.
+
+#![cfg(test)]
+
+use niffyinsure::{types::VoteOption, validate::Error, NiffyInsureClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+fn seed(client: &NiffyInsureClient, holder: &Address, end_ledger: u32) {
+    client.test_seed_policy(holder, &1u32, &1_000_000i128, &end_ledger);
+}
+
+fn file(env: &Env, client: &NiffyInsureClient, holder: &Address) -> u64 {
+    let details = String::from_str(env, "snapshot test");
+    let urls = vec![env];
+    client.file_claim(holder, &1u32, &100_000i128, &details, &urls, &None)
+}
+
+// ── Voter eligible at filing but removed before vote time can still vote ──────
+
+#[test]
+fn voter_eligible_at_filing_can_vote_after_removal() {
+    let (env, client, _, _) = setup();
+
+    let claimant = Address::generate(&env);
+    let voter = Address::generate(&env);
+
+    // Both are in the voter registry at filing time.
+    seed(&client, &claimant, 50_000);
+    seed(&client, &voter, 50_000);
+
+    let cid = file(&env, &client, &claimant);
+
+    // Remove voter from registry AFTER filing (simulate losing eligibility).
+    client.test_remove_voter(&voter);
+
+    // Voter should still be able to vote (snapshot was taken at filing).
+    client.vote_on_claim(&voter, &cid, &VoteOption::Approve);
+
+    let claim = client.get_claim(&cid);
+    assert_eq!(claim.approve_votes, 1);
+}
+
+// ── Voter not eligible at filing cannot vote even if added later ──────────────
+
+#[test]
+fn voter_not_eligible_at_filing_cannot_vote_after_joining() {
+    let (env, client, _, _) = setup();
+
+    let claimant = Address::generate(&env);
+    let late_voter = Address::generate(&env);
+
+    // Only claimant is in registry at filing time.
+    seed(&client, &claimant, 50_000);
+
+    let cid = file(&env, &client, &claimant);
+
+    // late_voter joins registry AFTER the claim was filed.
+    seed(&client, &late_voter, 50_000);
+
+    // late_voter should NOT be able to vote (not in snapshot).
+    let err = client
+        .try_vote_on_claim(&late_voter, &cid, &VoteOption::Approve)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, Error::NotEligibleVoter);
+}
+
+// ── Snapshot is immutable: eligible_voter_count does not change after filing ──
+
+#[test]
+fn snapshot_voter_count_is_immutable_after_filing() {
+    let (env, client, _, _) = setup();
+
+    let claimant = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+
+    seed(&client, &claimant, 50_000);
+    // Only claimant in registry at filing.
+    let cid = file(&env, &client, &claimant);
+
+    let count_at_filing = client.get_claim(&cid).eligible_voter_count;
+
+    // Add another voter after filing.
+    seed(&client, &voter2, 50_000);
+
+    // Count must not change.
+    let count_after = client.get_claim(&cid).eligible_voter_count;
+    assert_eq!(count_at_filing, count_after);
+}
+
+// ── Voter in snapshot can cast a vote ────────────────────────────────────────
+
+#[test]
+fn voter_in_snapshot_can_vote() {
+    let (env, client, _, _) = setup();
+
+    let claimant = Address::generate(&env);
+    let voter = Address::generate(&env);
+
+    seed(&client, &claimant, 50_000);
+    seed(&client, &voter, 50_000);
+
+    let cid = file(&env, &client, &claimant);
+
+    // Both are in snapshot; voter can vote.
+    client.vote_on_claim(&voter, &cid, &VoteOption::Reject);
+    assert_eq!(client.get_claim(&cid).reject_votes, 1);
+}


### PR DESCRIPTION
closes #580 - Batch claim finalization
- Add finalize_expired_batch(claim_ids: Vec<u64>) permissionless entrypoint
- Processes each claim independently; skips already-finalized/ineligible claims
- Cap batch size at BATCH_FINALIZE_MAX (20); reverts if exceeded
- Emits individual finalization events per claim + BatchFinalized summary event
- Tests: over-cap revert, eligible/ineligible mix, already-terminal skip, pause

closes #582 - Policy type registry
- Add PolicyTypeActive, PolicyTypeConfig, PolicyTypeRegistryEnabled DataKey variants
- Admin entrypoints: admin_register_policy_type, admin_deregister_policy_type
- Read-only: is_policy_type_active, get_policy_type_config
- initiate_policy validates type is active when registry is enabled
- Existing policies of deregistered types remain valid
- Tests: unregistered revert, deregistered revert, existing policy valid, re-register

closes #584 - Voter eligibility snapshot
- Snapshot already taken at file_claim via snapshot_claim_voters
- vote_on_claim already validates against snapshot (not current state)
- Tests: eligible-at-filing-but-removed can still vote; joined-after-filing cannot vote; count immutable

closes #586 - Coverage gap detection
- Boundary semantics already correct: [start, end) half-open interval
- is_within_window: now < end (exclusive); is_expired: now >= end
- Tests: claim at end_ledger-1 succeeds; at end_ledger reverts; at end_ledger+1 reverts
- Renewal boundary tests: at end_ledger in grace period; past grace returns Lapsed

## Checklist

- [ ] Branding follows `docs/BRANDING.md` for product naming, palette, typography, and assets.
