### PR TITLE
feat: implement issues #578 and #579 - policy metadata URI and claim …

### DIFF
--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -194,6 +194,15 @@ pub struct PayoutTimedOut {
     pub at_ledger: u32,
 }
 
+/// Emitted when admin disputes an approved claim during the dispute window.
+#[contractevent(topics = ["niffyinsure", "claim_disputed"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimDisputed {
+    #[topic]
+    pub claim_id: u64,
+    pub at_ledger: u32,
+}
+
 /// Emitted every time a rejection increments the policy's strike counter.
 /// Indexers should use this event to notify holders of accumulating strikes
 /// before the threshold triggers deactivation.
@@ -333,6 +342,7 @@ pub fn file_claim(
         appeal_approve_votes: 0,
         appeal_reject_votes: 0,
         status_history,
+        dispute_deadline_ledger: 0,
     };
 
     storage::set_claim(env, &claim);
@@ -566,6 +576,8 @@ fn finalize_claim_inner(env: &Env, claim_id: u64) -> Result<ClaimStatus, Error> 
     if claim.status != status_before {
         if claim.status == ClaimStatus::Approved && claim.payout_deadline_ledger == 0 {
             claim.payout_deadline_ledger = now.saturating_add(ledger::PAYOUT_TIMEOUT_LEDGERS);
+            // Set dispute deadline after approval
+            claim.dispute_deadline_ledger = now.saturating_add(ledger::DEFAULT_DISPUTE_WINDOW_LEDGERS);
         }
         push_status_transition(&mut claim.status_history, claim.status.clone(), now);
     }
@@ -666,8 +678,13 @@ pub fn process_claim(env: &Env, claim_id: u64) -> Result<(), Error> {
         return Err(Error::ClaimNotApproved);
     }
 
-    payout(env, &claim)?;
+    // Check dispute deadline: payout cannot execute until dispute window closes
     let now = env.ledger().sequence();
+    if now <= claim.dispute_deadline_ledger {
+        return Err(Error::DisputeWindowActive);
+    }
+
+    payout(env, &claim)?;
     crate::rolling_claim_cap::record_claim_paid(
         env,
         &claim.claimant,
@@ -841,6 +858,34 @@ fn payout(env: &Env, claim: &Claim) -> Result<(), Error> {
         gross_amount: gross,
         deductible,
         amount: net,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Admin-only: dispute an approved claim within the dispute window.
+/// Freezes payout and sets status to Disputed for review.
+pub fn dispute_claim(env: &Env, claim_id: u64) -> Result<(), Error> {
+    let mut claim = storage::get_claim(env, claim_id).ok_or(Error::ClaimNotFound)?;
+
+    if claim.status != ClaimStatus::Approved {
+        return Err(Error::ClaimNotApproved);
+    }
+
+    let now = env.ledger().sequence();
+    if now > claim.dispute_deadline_ledger {
+        return Err(Error::PayoutDeadlineNotReached);
+    }
+
+    let old_status = claim.status.clone();
+    claim.status = ClaimStatus::Disputed;
+    push_status_transition(&mut claim.status_history, ClaimStatus::Disputed, now);
+    storage::set_claim(env, &claim);
+
+    ClaimDisputed {
+        claim_id,
+        at_ledger: now,
     }
     .publish(env);
 

--- a/contracts/niffyinsure/src/ledger.rs
+++ b/contracts/niffyinsure/src/ledger.rs
@@ -128,6 +128,10 @@ pub const APPEAL_VOTE_WINDOW_LEDGERS: u32 = 7 * LEDGERS_PER_DAY; // 120_960
 /// Claimants get exactly one appeal after a Rejected outcome.
 pub const MAX_APPEALS_PER_CLAIM: u32 = 1;
 
+/// Dispute window after finalization: ~1 day. Admin may dispute approved claims
+/// during this window to freeze payout and set status to Disputed for review.
+pub const DEFAULT_DISPUTE_WINDOW_LEDGERS: u32 = LEDGERS_PER_DAY; // 17_280
+
 // ── Core window helpers ───────────────────────────────────────────────────────
 
 /// Returns `true` if `now` falls in the half-open interval `[start, end)`.

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -406,6 +406,13 @@ impl NiffyInsure {
         claim::process_claim(&env, claim_id)
     }
 
+    /// Admin-only: dispute an approved claim during the dispute window.
+    pub fn admin_dispute_claim(env: Env, claim_id: u64) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        claim::dispute_claim(&env, claim_id)
+    }
+
     pub fn get_claim(env: Env, claim_id: u64) -> Result<types::Claim, validate::Error> {
         claim::get_claim(&env, claim_id)
     }
@@ -520,6 +527,7 @@ impl NiffyInsure {
             opts.beneficiary,
             opts.deductible,
             opts.expected_nonce,
+            opts.metadata_uri,
         )
     }
 
@@ -531,6 +539,18 @@ impl NiffyInsure {
         beneficiary: Option<Address>,
     ) -> Result<(), policy::PolicyError> {
         policy::set_beneficiary(&env, holder, policy_id, beneficiary)
+    }
+
+    /// Admin-only: update the policy metadata URI.
+    pub fn admin_update_policy_metadata_uri(
+        env: Env,
+        holder: Address,
+        policy_id: u32,
+        new_uri: soroban_sdk::String,
+    ) -> Result<(), policy::PolicyError> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        policy::update_policy_metadata_uri(&env, holder, policy_id, new_uri)
     }
 
     /// Read-only: retrieve a persisted policy by (holder, policy_id).

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -30,8 +30,8 @@ pub enum PolicyError {
     LedgerOverflow = 105,
     /// Policy struct failed internal validation.
     PolicyValidation = 106,
-    /// Deductible missing, negative, or greater than coverage cap.
-    InvalidDeductible = 120,
+    /// Invalid or empty metadata URI.
+    InvalidMetadataUri = 121,
     /// Caller is not authorized.
     Unauthorized = 107,
     /// Age out of range (1..=120).
@@ -96,6 +96,18 @@ pub struct BeneficiaryUpdated {
     pub policy_id: u32,
     pub old_beneficiary: Option<Address>,
     pub new_beneficiary: Option<Address>,
+}
+
+/// Emitted when the policy metadata URI is updated.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyMetadataUpdated {
+    #[topic]
+    pub holder: Address,
+    #[topic]
+    pub policy_id: u32,
+    pub old_uri: String,
+    pub new_uri: String,
 }
 
 /// Event emitted by `renew_policy`.
@@ -277,9 +289,15 @@ pub fn initiate_policy(
     beneficiary: Option<Address>,
     deductible: Option<i128>,
     expected_nonce: Option<u64>,
+    metadata_uri: String,
 ) -> Result<Policy, PolicyError> {
     // Check granular pause: policy binding should be blocked if bind_paused
     storage::assert_bind_not_paused(env);
+
+    // Validate metadata_uri is non-empty
+    if metadata_uri.is_empty() {
+        return Err(PolicyError::InvalidMetadataUri);
+    }
 
     // Asset allowlist check — before auth so callers get a clear error.
     if !storage::is_allowed_asset(env, &asset) {
@@ -363,6 +381,7 @@ pub fn initiate_policy(
         termination_reason: crate::types::TerminationReason::None,
         terminated_by_admin: false,
         strike_count: 0,
+        metadata_uri,
     };
 
     validate::check_policy(&policy).map_err(|_| PolicyError::PolicyValidation)?;
@@ -429,6 +448,39 @@ pub fn set_beneficiary(
         policy_id,
         old_beneficiary,
         new_beneficiary,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Admin-only: update the policy metadata URI. Must be non-empty.
+pub fn update_policy_metadata_uri(
+    env: &Env,
+    holder: Address,
+    policy_id: u32,
+    new_uri: String,
+) -> Result<(), PolicyError> {
+    // Validate new_uri is non-empty
+    if new_uri.is_empty() {
+        return Err(PolicyError::InvalidMetadataUri);
+    }
+
+    let mut policy = storage::get_policy(env, &holder, policy_id).ok_or(PolicyError::NotFound)?;
+
+    let old_uri = policy.metadata_uri.clone();
+    if old_uri == new_uri {
+        return Ok(());
+    }
+
+    policy.metadata_uri = new_uri.clone();
+    storage::set_policy(env, &holder, policy_id, &policy);
+
+    PolicyMetadataUpdated {
+        holder: holder.clone(),
+        policy_id,
+        old_uri,
+        new_uri,
     }
     .publish(env);
 

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -156,6 +156,8 @@ pub enum ClaimStatus {
     AppealRejected,
     /// Claimant withdrew before voting began; record kept for audit; no payout.
     Withdrawn,
+    /// Admin disputed the claim after approval; payout is frozen pending review.
+    Disputed,
     /// RESERVED — appeal in progress; not yet implemented.
     ///
     /// This variant is declared to **reserve the discriminant** in the on-chain
@@ -203,7 +205,8 @@ impl ClaimStatus {
                 | ClaimStatus::Rejected
                 | ClaimStatus::AppealApproved
                 | ClaimStatus::AppealRejected
-                | ClaimStatus::Withdrawn // NOTE: ClaimStatus::Appealed is intentionally absent — an appeal
+                | ClaimStatus::Withdrawn
+                | ClaimStatus::Disputed // NOTE: ClaimStatus::Appealed is intentionally absent — an appeal
                                          // in progress is NOT terminal.  Adding it here would allow
                                          // process_claim / finalize_claim to close an appealed claim without
                                          // resolving the appeal round, which would be incorrect.
@@ -379,6 +382,8 @@ pub struct InitiatePolicyOptions {
     /// Opt-in replay-protection nonce. Pass `None` to skip the check.
     /// Supplementary to Stellar sequence numbers — not a replacement.
     pub expected_nonce: Option<u64>,
+    /// Off-chain URI to the policy governing document. Must be non-empty.
+    pub metadata_uri: String,
 }
 
 #[contracttype]
@@ -498,6 +503,9 @@ pub struct Policy {
     /// readable via `get_policy`. It carries only a count — no allegation
     /// narratives, no claimant-identifying data.
     pub strike_count: u32,
+    /// Off-chain URI to the policy governing document.
+    /// Must be non-empty at policy creation. Admin can update via `update_policy_metadata_uri`.
+    pub metadata_uri: String,
 }
 
 /// Return value of [`crate::policy::renew_policy`].
@@ -561,6 +569,10 @@ pub struct Claim {
     /// [`CLAIM_STATUS_HISTORY_MAX`]; on overflow the oldest entries are removed.
     /// May be incomplete if the cap is exceeded; `status` is authoritative.
     pub status_history: Vec<ClaimStatusHistoryEntry>,
+    /// Ledger by which admin must dispute the claim (set after finalization).
+    /// After this ledger passes, payout executes automatically for approved claims.
+    /// Set to 0 if no dispute window is active.
+    pub dispute_deadline_ledger: u32,
 }
 
 /// Per-policy rolling window accumulator for **paid** claim amounts (same ledger window for all policies).

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -71,6 +71,8 @@ pub enum Error {
     RollingClaimCapExceeded = 54,
     /// Keeper `process_payout_timeout` called before the approved payout deadline elapsed.
     PayoutDeadlineNotReached = 55,
+    /// Admin dispute window is still active; payout cannot execute yet.
+    DisputeWindowActive = 56,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {


### PR DESCRIPTION
…dispute window

closes #578 - Contract — Policy metadata URI: off-chain document link stored on-chain
- Add metadata_uri: String field to Policy struct
- Validate non-empty metadata_uri at initiate_policy
- Add admin entrypoint update_policy_metadata_uri with authentication and event
- Emit PolicyMetadataUpdated event with old and new URI values

closes #579 - Contract — Claim dispute window: post-finalization challenge period
- Add dispute_window_ledgers config (DEFAULT_DISPUTE_WINDOW_LEDGERS = 1 day)
- Add dispute_deadline_ledger: u32 per claim
- After finalization, set dispute deadline for approved claims
- Add Disputed status to ClaimStatus enum
- Add admin entrypoint admin_dispute_claim to freeze payout during dispute window
- Modify process_claim to check dispute deadline before executing payout
- Add ClaimDisputed event for dispute operations
- Add DisputeWindowActive error type

## Checklist

- [ ] Branding follows `docs/BRANDING.md` for product naming, palette, typography, and assets.
