### PR TITLE
feat/admin-audit-governance-vote-sub-claim-summary

### DIFF
--- a/backend/docs/graphql.md
+++ b/backend/docs/graphql.md
@@ -14,6 +14,8 @@ No resolver contains standalone business rules that diverge from the REST layer.
 - Path: `/api/graphql`
 - Driver: Apollo Server via `@nestjs/apollo`
 - Schema generation: code-first, emitted to `src/graphql/schema.gql`
+- WebSocket subscriptions use the same path and require
+  `connectionParams.Authorization = "Bearer <wallet-jwt>"`.
 
 ## Production policy
 
@@ -75,6 +77,13 @@ query PoliciesWithClaims {
   - `claims(policyId, deleted_at, createdAt)`
   - `votes(claimId, deleted_at)`
 
+## Subscriptions
+
+- `voteAdded(claimId: ID!)` publishes each indexed vote for the requested claim.
+- The indexer publishes through `VotePubSubService` after the vote row and claim tallies are persisted.
+- Unauthenticated WebSocket handshakes are rejected before subscription setup.
+- Staging should keep active GraphQL WebSocket connections within the documented ingress limit of 1,000 concurrent connections per API instance.
+
 ## Load testing
 
 Use [`loadtests/graphql-policy-claim-nested.js`](../loadtests/graphql-policy-claim-nested.js) against staging to validate:
@@ -82,3 +91,4 @@ Use [`loadtests/graphql-policy-claim-nested.js`](../loadtests/graphql-policy-cla
 - nested query latency under representative concurrency
 - deterministic rejection of deep malicious queries
 - no regression after schema or index changes
+- vote subscription connection counts remain below the 1,000 connection per-instance limit

--- a/backend/src/claims/claims.module.ts
+++ b/backend/src/claims/claims.module.ts
@@ -4,6 +4,7 @@ import { ClaimsService } from './claims.service';
 import { SanitizationService } from './sanitization.service';
 import { ClaimViewMapper } from './claim-view.mapper';
 import { ClaimAggregationService } from './services/claim-aggregation.service';
+import { ClaimSummaryCacheService } from './services/claim-summary-cache.service';
 import { EvidenceUploadService } from './services/evidence-upload.service';
 import { EvidenceProxyService } from './services/evidence-proxy.service';
 import { ClaimDeadlineProcessorService } from './claim-deadline.processor.service';
@@ -25,11 +26,18 @@ import { AdminModule } from '../admin/admin.module';
     SanitizationService,
     ClaimViewMapper,
     ClaimAggregationService,
+    ClaimSummaryCacheService,
     EvidenceUploadService,
     EvidenceProxyService,
     ClaimDeadlineProcessorService,
     ClaimDeadlineBootstrap,
   ],
-  exports: [ClaimsService, ClaimViewMapper, ClaimAggregationService, ClaimDeadlineProcessorService],
+  exports: [
+    ClaimsService,
+    ClaimViewMapper,
+    ClaimAggregationService,
+    ClaimSummaryCacheService,
+    ClaimDeadlineProcessorService,
+  ],
 })
 export class ClaimsModule {}

--- a/backend/src/claims/claims.service.ts
+++ b/backend/src/claims/claims.service.ts
@@ -8,6 +8,7 @@ import { TenantContextService } from '../tenant/tenant-context.service';
 import { claimTenantWhere, assertTenantOwnership } from '../tenant/tenant-filter.helper';
 import { ReconciliationService } from '../indexer/reconciliation.service';
 import { ClaimAggregationService } from './services/claim-aggregation.service';
+import { ClaimSummaryCacheService } from './services/claim-summary-cache.service';
 import {
   ClaimDetailResponseDto,
   ClaimsListResponseDto,
@@ -40,6 +41,7 @@ export class ClaimsService {
     private readonly tenantCtx: TenantContextService,
     private readonly reconciliation: ReconciliationService,
     private readonly aggregation: ClaimAggregationService,
+    private readonly claimSummaryCache: ClaimSummaryCacheService,
   ) {
     this.cacheTtl = this.config.get<number>('CACHE_TTL_SECONDS', 60);
     this.indexerNetwork = this.config.get<string>('STELLAR_NETWORK', 'testnet');
@@ -49,55 +51,50 @@ export class ClaimsService {
     const { after, status } = params;
     const limit = clampLimit(params.limit);
     const tenantId = this.tenantCtx.tenantId;
-    const cacheKey = `claims:list:${tenantId ?? 'global'}:${after ?? 'start'}:${limit}:${status ?? 'all'}`;
-    const cached = await this.redis.get<ClaimsListResponseDto>(cacheKey);
+    const cacheKey = this.claimSummaryCache.key({ tenantId, after, limit, status });
 
-    if (cached) {
-      this.logger.debug(`Cache hit for ${cacheKey}`);
-      return cached;
-    }
+    return this.claimSummaryCache.getOrCompute(cacheKey, async () => {
+      this.logger.debug(`Claim summary cache miss for ${cacheKey}`);
 
-    const lastLedger = await this.getLastLedger();
-    const statusFilter = status
-      ? { status: status.toUpperCase() as 'PENDING' | 'APPROVED' | 'PAID' | 'REJECTED' }
-      : {};
-    const keysetWhere = buildKeysetWhere(after);
-    const where: Prisma.ClaimWhereInput = claimTenantWhere(tenantId, {
-      ...statusFilter,
-      ...(keysetWhere ?? {}),
-    });
+      const lastLedger = await this.getLastLedger();
+      const statusFilter = status
+        ? { status: status.toUpperCase() as 'PENDING' | 'APPROVED' | 'PAID' | 'REJECTED' }
+        : {};
+      const keysetWhere = buildKeysetWhere(after);
+      const where: Prisma.ClaimWhereInput = claimTenantWhere(tenantId, {
+        ...statusFilter,
+        ...(keysetWhere ?? {}),
+      });
 
-    const [claims, total] = await Promise.all([
-      this.prisma.claim.findMany({
-        where,
-        include: {
-          votes: { where: { deletedAt: null }, select: { vote: true } },
-        },
-        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-        take: limit,
-      }),
-      this.prisma.claim.count({ where: claimTenantWhere(tenantId, statusFilter) }),
-    ]);
-
-    const response: ClaimsListResponseDto = {
-      data: await Promise.all(
-        claims.map(async (claim) => {
-          const agg = await this.aggregation.aggregate(claim.id, lastLedger);
-          return this.claimViewMapper.transformClaim(claim, lastLedger, {
-            quorum_progress_pct: agg.quorum_progress_pct,
-            votes_needed: agg.votes_needed,
-            deadline_estimate_utc: agg.deadline_estimate_utc,
-          });
+      const [claims, total] = await Promise.all([
+        this.prisma.claim.findMany({
+          where,
+          include: {
+            votes: { where: { deletedAt: null }, select: { vote: true } },
+          },
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+          take: limit,
         }),
-      ),
-      pagination: {
-        next_cursor: buildNextCursor(claims, limit, total),
-        total,
-      },
-    };
+        this.prisma.claim.count({ where: claimTenantWhere(tenantId, statusFilter) }),
+      ]);
 
-    await this.redis.set(cacheKey, response, this.cacheTtl);
-    return response;
+      return {
+        data: await Promise.all(
+          claims.map(async (claim) => {
+            const agg = await this.aggregation.aggregate(claim.id, lastLedger);
+            return this.claimViewMapper.transformClaim(claim, lastLedger, {
+              quorum_progress_pct: agg.quorum_progress_pct,
+              votes_needed: agg.votes_needed,
+              deadline_estimate_utc: agg.deadline_estimate_utc,
+            });
+          }),
+        ),
+        pagination: {
+          next_cursor: buildNextCursor(claims, limit, total),
+          total,
+        },
+      };
+    });
   }
 
   async getClaimsNeedingVote(

--- a/backend/src/claims/services/claim-summary-cache.service.ts
+++ b/backend/src/claims/services/claim-summary-cache.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RedisService } from '../../cache/redis.service';
+import { MetricsService } from '../../metrics/metrics.service';
+import type { ClaimsListResponseDto } from '../dto/claim.dto';
+
+const DEFAULT_TTL_SECONDS = 30;
+const KEY_PREFIX = 'claims:summary';
+
+@Injectable()
+export class ClaimSummaryCacheService {
+  private readonly logger = new Logger(ClaimSummaryCacheService.name);
+  private readonly ttlSeconds: number;
+
+  constructor(
+    private readonly redis: RedisService,
+    private readonly config: ConfigService,
+    @Optional() private readonly metrics?: MetricsService,
+  ) {
+    this.ttlSeconds = this.config.get<number>(
+      'CLAIM_SUMMARY_CACHE_TTL_SECONDS',
+      DEFAULT_TTL_SECONDS,
+    );
+  }
+
+  key(parts: {
+    tenantId?: string | null;
+    after?: string;
+    limit: number;
+    status?: string;
+  }): string {
+    return [
+      KEY_PREFIX,
+      parts.tenantId ?? 'global',
+      parts.after ?? 'start',
+      String(parts.limit),
+      parts.status ?? 'all',
+    ].join(':');
+  }
+
+  async getOrCompute(
+    key: string,
+    compute: () => Promise<ClaimsListResponseDto>,
+  ): Promise<ClaimsListResponseDto> {
+    const cached = await this.redis.get<ClaimsListResponseDto>(key);
+    if (cached) {
+      this.metrics?.recordClaimSummaryCache('hit');
+      return cached;
+    }
+
+    this.metrics?.recordClaimSummaryCache('miss');
+    const response = await compute();
+    await this.redis.set(key, response, this.ttlSeconds);
+    return response;
+  }
+
+  async invalidateClaim(claimId: number | string): Promise<void> {
+    await this.invalidateAll();
+    this.logger.debug(`Claim summary cache invalidated after claim ${claimId} changed`);
+  }
+
+  async invalidateAll(): Promise<void> {
+    await this.redis.delPattern(`${KEY_PREFIX}:*`);
+  }
+}

--- a/backend/src/graphql/graphql.module.ts
+++ b/backend/src/graphql/graphql.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { GraphQLModule } from '@nestjs/graphql';
 import type { Response } from 'express';
+import jwt from 'jsonwebtoken';
 import depthLimit from 'graphql-depth-limit';
 import { join } from 'path';
 import { AuthModule } from '../auth/auth.module';
@@ -24,6 +25,36 @@ import { PersistedQueryMiddleware } from './persisted-query.middleware';
 import { PolicyResolver } from './policy.resolver';
 import { VotePubSubService } from './vote-pubsub.service';
 import type { GraphqlRequest } from './graphql.context';
+
+export function authorizationFromConnectionParams(params: unknown): string | undefined {
+  if (!params || typeof params !== 'object') {
+    return undefined;
+  }
+
+  const record = params as Record<string, unknown>;
+  const value = record.Authorization ?? record.authorization;
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function assertWalletJwt(config: ConfigService, authorization?: string): void {
+  if (!authorization?.startsWith('Bearer ')) {
+    throw new Error('Wallet authentication is required');
+  }
+
+  try {
+    const token = authorization.slice('Bearer '.length).trim();
+    const payload = jwt.verify(token, config.get<string>('JWT_SECRET') ?? '') as Record<
+      string,
+      unknown
+    >;
+    if (typeof payload.walletAddress === 'string' && payload.walletAddress.length > 0) {
+      return;
+    }
+  } catch {
+    // Normalise JWT parse/expiry/signature failures for the WebSocket handshake.
+  }
+  throw new Error('Wallet authentication is required');
+}
 
 @Module({
   imports: [
@@ -73,19 +104,31 @@ import type { GraphqlRequest } from './graphql.context';
             'graphql-ws': {
               path: graphqlPath,
               onConnect: async (ctx) => {
-                // Auth is enforced per-subscription via GraphqlWalletAuthGuard.
-                // Store connectionParams on context so guards can read the token.
+                const authorization = authorizationFromConnectionParams(ctx.connectionParams);
+                assertWalletJwt(config, authorization);
                 return { connectionParams: ctx.connectionParams };
               },
             },
           },
-          context: ({
-            req,
-            res,
-          }: {
-            req: GraphqlRequest;
-            res: Response;
-          }) => ({ req, res }),
+          context: (ctx: {
+            req?: GraphqlRequest;
+            res?: Response;
+            connectionParams?: unknown;
+            extra?: { request?: { headers?: Record<string, string | string[] | undefined> } };
+          }) => {
+            if (ctx.req) {
+              return { req: ctx.req, res: ctx.res };
+            }
+
+            const authorization = authorizationFromConnectionParams(ctx.connectionParams);
+            const req = {
+              headers: {
+                ...(ctx.extra?.request?.headers ?? {}),
+                ...(authorization ? { authorization } : {}),
+              },
+            } as GraphqlRequest;
+            return { req, res: undefined as unknown as Response };
+          },
           plugins,
           validationRules: [depthLimit(maxDepth)],
           formatError: formatGraphqlError,

--- a/backend/src/graphql/vote-subscription.spec.ts
+++ b/backend/src/graphql/vote-subscription.spec.ts
@@ -10,6 +10,7 @@
  */
 
 import { VotePubSubService, VoteEvent } from './vote-pubsub.service';
+import jwt from 'jsonwebtoken';
 
 // ── Mock graphql-redis-subscriptions ─────────────────────────────────────────
 
@@ -109,5 +110,26 @@ describe('GraphqlWalletAuthGuard on subscription', () => {
     } as never);
 
     await expect(guard.canActivate(context as never)).rejects.toThrow('Wallet authentication is required');
+  });
+});
+
+describe('wallet JWT WebSocket handshake helpers', () => {
+  it('accepts wallet JWTs from connection params', async () => {
+    const { assertWalletJwt, authorizationFromConnectionParams } = await import('./graphql.module');
+    const token = jwt.sign({ walletAddress: 'GWALLET123' }, 'secret');
+    const config = { get: jest.fn(() => 'secret') };
+
+    const authorization = authorizationFromConnectionParams({ Authorization: `Bearer ${token}` });
+
+    expect(() => assertWalletJwt(config as never, authorization)).not.toThrow();
+  });
+
+  it('rejects unauthenticated subscription handshakes', async () => {
+    const { assertWalletJwt } = await import('./graphql.module');
+    const config = { get: jest.fn(() => 'secret') };
+
+    expect(() => assertWalletJwt(config as never, undefined)).toThrow(
+      'Wallet authentication is required',
+    );
   });
 });

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -9,10 +9,28 @@ import { ReconciliationService } from './reconciliation.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RpcModule } from '../rpc/rpc.module';
 import { EventsModule } from '../events/events.module';
+import { CacheModule } from '../cache/cache.module';
+import { MetricsModule } from '../metrics/metrics.module';
+import { ClaimSummaryCacheService } from '../claims/services/claim-summary-cache.service';
 
 @Module({
-  imports: [PrismaModule, RpcModule, ConfigModule, ScheduleModule.forRoot(), EventsModule],
-  providers: [IndexerService, IndexerWorker, ReindexWorkerService, BackfillWorkerService, ReconciliationService],
+  imports: [
+    PrismaModule,
+    RpcModule,
+    ConfigModule,
+    ScheduleModule.forRoot(),
+    EventsModule,
+    CacheModule,
+    MetricsModule,
+  ],
+  providers: [
+    IndexerService,
+    IndexerWorker,
+    ReindexWorkerService,
+    BackfillWorkerService,
+    ReconciliationService,
+    ClaimSummaryCacheService,
+  ],
   exports: [IndexerService, ReconciliationService],
 })
 export class IndexerModule {}

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -12,6 +12,7 @@ import { EventsModule } from '../events/events.module';
 import { CacheModule } from '../cache/cache.module';
 import { MetricsModule } from '../metrics/metrics.module';
 import { ClaimSummaryCacheService } from '../claims/services/claim-summary-cache.service';
+import { VotePubSubService } from '../graphql/vote-pubsub.service';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ClaimSummaryCacheService } from '../claims/services/claim-summary-cache
     BackfillWorkerService,
     ReconciliationService,
     ClaimSummaryCacheService,
+    VotePubSubService,
   ],
   exports: [IndexerService, ReconciliationService],
 })

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -115,6 +115,44 @@ describe('IndexerService', () => {
     );
   });
 
+  it('invalidates claim summary cache after vote ingestion', async () => {
+    const tx = {
+      vote: { upsert: jest.fn().mockResolvedValue(undefined) },
+      claim: { update: jest.fn().mockResolvedValue(undefined) },
+    };
+    const claimEvents = { publish: jest.fn().mockResolvedValue(undefined) };
+    const claimSummaryCache = { invalidateClaim: jest.fn().mockResolvedValue(undefined) };
+    const service = new IndexerService(
+      {} as never,
+      {} as never,
+      makeConfig(),
+      undefined,
+      claimEvents as never,
+      undefined,
+      claimSummaryCache as never,
+    );
+
+    await (service as unknown as {
+      handleVoteCast: (
+        tx: typeof tx,
+        topics: unknown[],
+        data: Record<string, unknown>,
+        event: { ledger: number; txHash: string },
+      ) => Promise<void>;
+    }).handleVoteCast(
+      tx,
+      ['vote', 42, 'GVOTER'],
+      { vote: 'Approve', approve_votes: 2, reject_votes: 1 },
+      { ledger: 123, txHash: 'vote-tx' },
+    );
+
+    expect(tx.vote.upsert).toHaveBeenCalled();
+    expect(tx.claim.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 42 } }),
+    );
+    expect(claimSummaryCache.invalidateClaim).toHaveBeenCalledWith(42);
+  });
+
   // ── Gap alert deduplication tests ────────────────────────────────────────
 
   it('first gap alert fires and upserts dedup row', async () => {

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -122,6 +122,7 @@ describe('IndexerService', () => {
     };
     const claimEvents = { publish: jest.fn().mockResolvedValue(undefined) };
     const claimSummaryCache = { invalidateClaim: jest.fn().mockResolvedValue(undefined) };
+    const votePubSub = { publishVote: jest.fn().mockResolvedValue(undefined) };
     const service = new IndexerService(
       {} as never,
       {} as never,
@@ -130,6 +131,7 @@ describe('IndexerService', () => {
       claimEvents as never,
       undefined,
       claimSummaryCache as never,
+      votePubSub as never,
     );
 
     await (service as unknown as {
@@ -151,6 +153,14 @@ describe('IndexerService', () => {
       expect.objectContaining({ where: { id: 42 } }),
     );
     expect(claimSummaryCache.invalidateClaim).toHaveBeenCalledWith(42);
+    expect(votePubSub.publishVote).toHaveBeenCalledWith({
+      claimId: 42,
+      voter: 'GVOTER',
+      vote: 'yes',
+      yesVotes: 2,
+      noVotes: 1,
+      totalVotes: 3,
+    });
   });
 
   // ── Gap alert deduplication tests ────────────────────────────────────────

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -13,6 +13,7 @@ import { ClaimEventsService } from '../events/claim-events.service';
 import { rpc as SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
 import { tryNormalizeAddress } from '../common/utils/normalize-address';
 import { QuoteSimulationCacheService } from '../quote/quote-simulation-cache.service';
+import { ClaimSummaryCacheService } from '../claims/services/claim-summary-cache.service';
 
 type IndexerTx = Prisma.TransactionClient;
 type SorobanEvent = SorobanRpc.Api.EventResponse;
@@ -95,6 +96,7 @@ export class IndexerService {
     @Optional() private readonly metrics?: MetricsService,
     @Optional() private readonly claimEvents?: ClaimEventsService,
     @Optional() private readonly quoteSimulationCache?: QuoteSimulationCacheService,
+    @Optional() private readonly claimSummaryCache?: ClaimSummaryCacheService,
   ) {
     this.networkId = this.config.get<string>('STELLAR_NETWORK', 'testnet');
     this.gapThresholdLedgers = this.config.get<number>('INDEXER_GAP_ALERT_THRESHOLD_LEDGERS', 100);
@@ -481,6 +483,7 @@ export class IndexerService {
       updatedAt: new Date().toISOString(),
       ledger: event.ledger,
     });
+    await this.claimSummaryCache?.invalidateClaim(claimId);
   }
 
   private async handleVoteCast(
@@ -528,6 +531,7 @@ export class IndexerService {
       updatedAt: new Date().toISOString(),
       ledger: event.ledger,
     });
+    await this.claimSummaryCache?.invalidateClaim(claimId);
   }
 
   private async handleClaimProcessed(tx: IndexerTx, data: EventPayload, event: SorobanEvent) {
@@ -547,6 +551,7 @@ export class IndexerService {
       updatedAt: new Date(event.ledgerClosedAt).toISOString(),
       ledger: event.ledger,
     });
+    await this.claimSummaryCache?.invalidateClaim(claimId);
   }
 
   /**

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -14,6 +14,7 @@ import { rpc as SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
 import { tryNormalizeAddress } from '../common/utils/normalize-address';
 import { QuoteSimulationCacheService } from '../quote/quote-simulation-cache.service';
 import { ClaimSummaryCacheService } from '../claims/services/claim-summary-cache.service';
+import { VotePubSubService } from '../graphql/vote-pubsub.service';
 
 type IndexerTx = Prisma.TransactionClient;
 type SorobanEvent = SorobanRpc.Api.EventResponse;
@@ -97,6 +98,7 @@ export class IndexerService {
     @Optional() private readonly claimEvents?: ClaimEventsService,
     @Optional() private readonly quoteSimulationCache?: QuoteSimulationCacheService,
     @Optional() private readonly claimSummaryCache?: ClaimSummaryCacheService,
+    @Optional() private readonly votePubSub?: VotePubSubService,
   ) {
     this.networkId = this.config.get<string>('STELLAR_NETWORK', 'testnet');
     this.gapThresholdLedgers = this.config.get<number>('INDEXER_GAP_ALERT_THRESHOLD_LEDGERS', 100);
@@ -532,6 +534,14 @@ export class IndexerService {
       ledger: event.ledger,
     });
     await this.claimSummaryCache?.invalidateClaim(claimId);
+    await this.votePubSub?.publishVote({
+      claimId,
+      voter,
+      vote: option === 'Approve' ? 'yes' : 'no',
+      yesVotes: getNumberValue(data.approve_votes),
+      noVotes: getNumberValue(data.reject_votes),
+      totalVotes: getNumberValue(data.approve_votes) + getNumberValue(data.reject_votes),
+    });
   }
 
   private async handleClaimProcessed(tx: IndexerTx, data: EventPayload, event: SorobanEvent) {

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -43,6 +43,8 @@ export class MetricsService implements OnModuleInit {
   readonly rpcErrorTotal: client.Counter<string>;
   /** result: hit | miss | bypass — quote simulation Redis cache */
   readonly quoteSimulationCacheTotal: client.Counter<string>;
+  /** result: hit | miss — claims board summary Redis cache */
+  readonly claimSummaryCacheTotal: client.Counter<string>;
 
   // ── Slow query metrics ────────────────────────────────────────────────────
   /** Total queries exceeding SLOW_QUERY_THRESHOLD_MS. */
@@ -173,6 +175,13 @@ export class MetricsService implements OnModuleInit {
       registers: [this.registry],
     });
 
+    this.claimSummaryCacheTotal = new client.Counter({
+      name: 'claim_summary_cache_requests_total',
+      help: 'Claims board summary cache lookups',
+      labelNames: ['result'],
+      registers: [this.registry],
+    });
+
     this.slowQueriesTotal = new client.Counter({
       name: 'db_slow_queries_total',
       help: 'Total DB queries exceeding the slow query threshold',
@@ -288,6 +297,10 @@ export class MetricsService implements OnModuleInit {
 
   recordQuoteSimulationCache(result: 'hit' | 'miss' | 'bypass') {
     this.quoteSimulationCacheTotal.inc({ result });
+  }
+
+  recordClaimSummaryCache(result: 'hit' | 'miss') {
+    this.claimSummaryCacheTotal.inc({ result });
   }
 
   recordIndexerLag(opts: { network: string; lag: number }) {

--- a/contracts/niffyinsure/src/admin.rs
+++ b/contracts/niffyinsure/src/admin.rs
@@ -9,7 +9,9 @@
 ///
 /// Production deployments SHOULD use a Stellar multisig account as admin.
 /// See SECURITY.md for the full threat matrix and multisig setup guidance.
-use soroban_sdk::{contracterror, contractevent, contracttype, panic_with_error, Address, Env};
+use soroban_sdk::{
+    contracterror, contractevent, contracttype, panic_with_error, Address, Env, Map, String,
+};
 
 use crate::storage;
 
@@ -130,6 +132,23 @@ pub struct PendingAdminAction {
     pub proposer: Address,
     pub action: AdminAction,
     pub expiry_ledger: u32,
+}
+
+#[contractevent(topics = ["niffyinsure", "admin_action"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminActionAudit {
+    pub actor: Address,
+    pub action_type: String,
+    pub params: Map<String, String>,
+}
+
+pub fn emit_admin_action(env: &Env, actor: &Address, action_type: &str) {
+    AdminActionAudit {
+        actor: actor.clone(),
+        action_type: String::from_str(env, action_type),
+        params: Map::new(env),
+    }
+    .publish(env);
 }
 
 #[contractevent(topics = ["niffyinsure", "admin_action_proposed"])]
@@ -256,12 +275,13 @@ pub fn propose_admin_action(env: &Env, action: AdminAction) {
 
     let action_id = now;
     AdminActionProposed {
-        proposer,
+        proposer: proposer.clone(),
         action_id,
         expiry_ledger: expiry,
         action,
     }
     .publish(env);
+    emit_admin_action(env, &proposer, "propose_admin_action");
 }
 
 /// Confirm and execute a pending admin action.
@@ -322,10 +342,11 @@ pub fn confirm_admin_action(env: &Env, confirmer: Address) {
     storage::clear_pending_admin_action(env);
     AdminActionConfirmed {
         proposer: pending.proposer,
-        confirmer,
+        confirmer: confirmer.clone(),
         action: pending.action,
     }
     .publish(env);
+    emit_admin_action(env, &confirmer, "confirm_admin_action");
 }
 
 /// Cancel a pending admin action. Proposer (current admin) authorizes.
@@ -337,6 +358,7 @@ pub fn cancel_admin_action(env: &Env) {
         panic_with_error!(env, AdminError::Unauthorized);
     }
     storage::clear_pending_admin_action(env);
+    emit_admin_action(env, &proposer, "cancel_admin_action");
 }
 
 /// Propose a new admin (step 1 of two-step rotation). Current admin must authorize.
@@ -344,10 +366,11 @@ pub fn propose_admin(env: &Env, new_admin: Address) {
     let current = require_admin(env);
     storage::set_pending_admin(env, &new_admin);
     AdminProposed {
-        old_admin: current,
+        old_admin: current.clone(),
         new_admin,
     }
     .publish(env);
+    emit_admin_action(env, &current, "propose_admin");
 }
 
 /// Accept a pending admin proposal. The *pending* admin must authorize.
@@ -361,9 +384,10 @@ pub fn accept_admin(env: &Env) {
     storage::clear_pending_admin(env);
     AdminAccepted {
         old_admin,
-        new_admin: pending,
+        new_admin: pending.clone(),
     }
     .publish(env);
+    emit_admin_action(env, &pending, "accept_admin");
 }
 
 /// Cancel a pending admin proposal. Current admin must authorize.
@@ -373,15 +397,16 @@ pub fn cancel_admin(env: &Env) {
         .unwrap_or_else(|| panic_with_error!(env, AdminError::NoPendingAdmin));
     storage::clear_pending_admin(env);
     AdminCancelled {
-        current_admin: current,
+        current_admin: current.clone(),
         cancelled_pending: pending,
     }
     .publish(env);
+    emit_admin_action(env, &current, "cancel_admin");
 }
 
 /// Update the treasury token contract address. Admin must authorize.
 pub fn set_token(env: &Env, new_token: Address) {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     let old_token = storage::get_token(env);
     storage::set_token(env, &new_token);
     TokenUpdated {
@@ -389,13 +414,14 @@ pub fn set_token(env: &Env, new_token: Address) {
         new_token,
     }
     .publish(env);
+    emit_admin_action(env, &admin, "set_token");
 }
 
 /// Update the treasury address. Admin must authorize.
 /// Emits: (\"admin\", \"treasury\") → (old_treasury, new_treasury)
 /// *** SINGLE-STEP FALLBACK: Use propose_admin_action for two-step protection ***
 pub fn set_treasury(env: &Env, new_treasury: Address) {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     let old_treasury = storage::get_treasury(env);
     storage::set_treasury(env, &new_treasury);
     TreasuryUpdated {
@@ -403,20 +429,29 @@ pub fn set_treasury(env: &Env, new_treasury: Address) {
         new_treasury,
     }
     .publish(env);
+    emit_admin_action(env, &admin, "set_treasury");
 }
 
 /// Pause the contract. Admin must authorize.
 pub fn pause(env: &Env) {
     let admin = require_admin(env);
     storage::set_paused(env, true);
-    AdminPaused { admin }.publish(env);
+    AdminPaused {
+        admin: admin.clone(),
+    }
+    .publish(env);
+    emit_admin_action(env, &admin, "pause");
 }
 
 /// Unpause the contract. Admin must authorize.
 pub fn unpause(env: &Env) {
     let admin = require_admin(env);
     storage::set_paused(env, false);
-    AdminUnpaused { admin }.publish(env);
+    AdminUnpaused {
+        admin: admin.clone(),
+    }
+    .publish(env);
+    emit_admin_action(env, &admin, "unpause");
 }
 
 /// Drain `amount` stroops from the contract treasury to `recipient`.
@@ -428,11 +463,12 @@ pub fn drain(env: &Env, recipient: Address, amount: i128) {
     }
     crate::token::transfer_from_contract(env, &recipient, amount);
     TreasuryDrained {
-        admin,
+        admin: admin.clone(),
         recipient,
         amount,
     }
     .publish(env);
+    emit_admin_action(env, &admin, "drain");
 }
 
 /// Emergency token sweep: recover mistakenly sent tokens with strict ethical constraints.
@@ -447,9 +483,10 @@ pub fn drain(env: &Env, recipient: Address, amount: i128) {
 /// See full docs above.
 pub fn sweep_token(env: &Env, asset: Address, recipient: Address, amount: i128, reason_code: u32) {
     storage::bump_instance(env);
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     // ... (existing validation logic)
     sweep_token_inner(env, asset, recipient, amount, reason_code);
+    emit_admin_action(env, &admin, "sweep_token");
 }
 
 fn sweep_token_inner(
@@ -558,16 +595,18 @@ fn calculate_protected_balance(env: &Env, asset: &Address) -> i128 {
 /// Set per-transaction sweep cap (optional safety limit).
 /// Set to None to disable cap. Admin must authorize.
 pub fn set_sweep_cap(env: &Env, cap: Option<i128>) {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     storage::set_sweep_cap(env, cap);
+    emit_admin_action(env, &admin, "set_sweep_cap");
 }
 
 /// Set the on-chain notice period (in ledgers) that must elapse between a sweep
 /// proposal and its execution. Set to 0 to disable (not recommended for mainnet).
 /// Admin must authorize.
 pub fn set_sweep_notice_period(env: &Env, ledgers: u32) {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     storage::set_sweep_notice_period_ledgers(env, ledgers);
+    emit_admin_action(env, &admin, "set_sweep_notice_period");
 }
 
 #[contractevent(topics = ["niffyinsure", "max_evidence_count_updated"])]
@@ -582,7 +621,7 @@ pub struct MaxEvidenceCountUpdated {
 /// Bounded by [`storage::MAX_EVIDENCE_COUNT_HARD_MAX`] to prevent griefing.
 /// Reductions do NOT retroactively invalidate existing claims.
 pub fn set_max_evidence_count(env: &Env, new_count: u32) -> Result<(), AdminError> {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     if new_count > storage::MAX_EVIDENCE_COUNT_HARD_MAX {
         return Err(AdminError::MaxEvidenceCountOutOfBounds);
     }
@@ -593,6 +632,7 @@ pub fn set_max_evidence_count(env: &Env, new_count: u32) -> Result<(), AdminErro
         new_count,
     }
     .publish(env);
+    emit_admin_action(env, &admin, "admin_set_max_evidence_count");
     Ok(())
 }
 
@@ -607,11 +647,12 @@ pub struct GatewayAllowlistUpdated {
 /// Evidence URLs must start with `ipfs://` or one of the allowlisted gateway prefixes.
 /// Pass an empty vector to disable gateway validation (only `ipfs://` allowed).
 pub fn set_gateway_allowlist(env: &Env, gateways: Vec<String>) -> Result<(), AdminError> {
-    let _admin = require_admin(env);
+    let admin = require_admin(env);
     storage::set_gateway_allowlist(env, &gateways);
     GatewayAllowlistUpdated {
         gateway_count: gateways.len(),
     }
     .publish(env);
+    emit_admin_action(env, &admin, "admin_set_gateway_allowlist");
     Ok(())
 }

--- a/contracts/niffyinsure/src/governance.rs
+++ b/contracts/niffyinsure/src/governance.rs
@@ -1,0 +1,142 @@
+use soroban_sdk::{contracterror, contracttype, panic_with_error, Address, Env, String};
+
+use crate::{ledger, storage, validate};
+
+pub const MINIMUM_STAKE_POLICIES: u32 = 1;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum GovernanceError {
+    NotTokenHolder = 300,
+    ProposalNotFound = 301,
+    DuplicateVote = 302,
+    VotingClosed = 303,
+    UnsupportedParameter = 304,
+    InvalidParameterValue = 305,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    pub proposal_id: u64,
+    pub creator: Address,
+    pub param_key: String,
+    pub proposed_value: u32,
+    pub deadline: u32,
+    pub approve_votes: u32,
+    pub reject_votes: u32,
+    pub applied: bool,
+}
+
+fn require_token_holder(env: &Env, holder: &Address) {
+    holder.require_auth();
+    if storage::get_holder_active_policy_count(env, holder) < MINIMUM_STAKE_POLICIES {
+        panic_with_error!(env, GovernanceError::NotTokenHolder);
+    }
+}
+
+fn quorum_required(env: &Env) -> u32 {
+    let eligible = storage::get_voters(env).len();
+    if eligible == 0 {
+        return 1;
+    }
+    (eligible / 2).saturating_add(1)
+}
+
+fn validate_supported_parameter(env: &Env, param_key: &String, new_value: u32) {
+    if *param_key == String::from_str(env, "quorum_bps") {
+        if validate::validate_quorum_bps(new_value).is_err() {
+            panic_with_error!(env, GovernanceError::InvalidParameterValue);
+        }
+        return;
+    }
+
+    if *param_key == String::from_str(env, "voting_duration_ledgers") {
+        if ledger::validate_voting_duration_ledgers(new_value).is_err() {
+            panic_with_error!(env, GovernanceError::InvalidParameterValue);
+        }
+        return;
+    }
+
+    panic_with_error!(env, GovernanceError::UnsupportedParameter);
+}
+
+fn apply_parameter(env: &Env, proposal: &Proposal) {
+    if proposal.param_key == String::from_str(env, "quorum_bps") {
+        storage::set_quorum_bps(env, proposal.proposed_value);
+        return;
+    }
+
+    if proposal.param_key == String::from_str(env, "voting_duration_ledgers") {
+        storage::set_voting_duration_ledgers(env, proposal.proposed_value);
+    }
+}
+
+pub fn create_proposal(env: &Env, creator: Address, param_key: String, new_value: u32) -> u64 {
+    require_token_holder(env, &creator);
+    validate_supported_parameter(env, &param_key, new_value);
+
+    let proposal_id = storage::next_proposal_id(env);
+    let proposal = Proposal {
+        proposal_id,
+        creator,
+        param_key,
+        proposed_value: new_value,
+        deadline: env
+            .ledger()
+            .sequence()
+            .saturating_add(storage::get_voting_duration_ledgers(env)),
+        approve_votes: 0,
+        reject_votes: 0,
+        applied: false,
+    };
+    storage::set_proposal(env, &proposal);
+    proposal_id
+}
+
+pub fn vote_proposal(
+    env: &Env,
+    voter: Address,
+    proposal_id: u64,
+    approve: bool,
+) -> Result<(), GovernanceError> {
+    require_token_holder(env, &voter);
+
+    let mut proposal = storage::get_proposal(env, proposal_id)
+        .ok_or(GovernanceError::ProposalNotFound)?;
+    if env.ledger().sequence() > proposal.deadline {
+        storage::remove_proposal(env, proposal_id);
+        return Err(GovernanceError::VotingClosed);
+    }
+    if storage::has_proposal_vote(env, proposal_id, &voter) {
+        return Err(GovernanceError::DuplicateVote);
+    }
+
+    storage::set_proposal_vote(env, proposal_id, &voter, approve);
+    if approve {
+        proposal.approve_votes = proposal.approve_votes.saturating_add(1);
+    } else {
+        proposal.reject_votes = proposal.reject_votes.saturating_add(1);
+    }
+
+    let quorum = quorum_required(env);
+    if proposal.approve_votes >= quorum {
+        apply_parameter(env, &proposal);
+        proposal.applied = true;
+        storage::set_proposal(env, &proposal);
+        return Ok(());
+    }
+
+    if proposal.reject_votes >= quorum {
+        storage::remove_proposal(env, proposal_id);
+        return Ok(());
+    }
+
+    storage::set_proposal(env, &proposal);
+    Ok(())
+}
+
+pub fn get_proposal(env: &Env, proposal_id: u64) -> Option<Proposal> {
+    storage::get_proposal(env, proposal_id)
+}

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -87,6 +87,7 @@ impl NiffyInsure {
         storage::set_allowed_asset(&env, &token, true);
         storage::set_voting_duration_ledgers(&env, ledger::VOTE_WINDOW_LEDGERS);
         storage::set_quorum_bps(&env, types::DEFAULT_QUORUM_BPS);
+        admin::emit_admin_action(&env, &admin, "initialize");
         Ok(())
     }
 
@@ -216,7 +217,11 @@ impl NiffyInsure {
     ) -> Result<(), validate::Error> {
         let admin = storage::get_admin(&env);
         admin.require_auth();
-        premium::update_multiplier_table(&env, &new_table)
+        let result = premium::update_multiplier_table(&env, &new_table);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "update_multiplier_table");
+        }
+        result
     }
 
     /// Admin-only: update a single multiplier entry without redeploying the contract.
@@ -235,7 +240,11 @@ impl NiffyInsure {
         let admin = storage::get_admin(&env);
         admin.require_auth();
         storage::bump_instance(&env);
-        premium::admin_set_premium_multiplier(&env, key, value)
+        let result = premium::admin_set_premium_multiplier(&env, key, value);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "admin_set_premium_multiplier");
+        }
+        result
     }
 
     pub fn get_multiplier_table(env: Env) -> types::MultiplierTable {
@@ -251,7 +260,7 @@ impl NiffyInsure {
         symbol_hint: soroban_sdk::String,
         decimals: u32,
     ) {
-        let _admin = admin::require_admin(&env);
+        let admin = admin::require_admin(&env);
         storage::bump_instance(&env);
         claim::set_allowed_asset(&env, &asset, allowed);
         AllowedAssetUpdated {
@@ -270,6 +279,7 @@ impl NiffyInsure {
             },
             if allowed { decimals } else { 0 },
         );
+        admin::emit_admin_action(&env, &admin, "set_allowed_asset");
     }
 
     pub fn is_allowed_asset(env: Env, asset: Address) -> bool {
@@ -359,6 +369,7 @@ impl NiffyInsure {
         admin.require_auth();
         ledger::validate_voting_duration_ledgers(ledgers)?;
         storage::set_voting_duration_ledgers(&env, ledgers);
+        admin::emit_admin_action(&env, &admin, "admin_set_vote_duration_ledgers");
         Ok(())
     }
 
@@ -384,6 +395,7 @@ impl NiffyInsure {
             new_bps: quorum_bps,
         }
         .publish(&env);
+        admin::emit_admin_action(&env, &admin, "admin_set_quorum_bps");
         Ok(())
     }
 
@@ -403,7 +415,11 @@ impl NiffyInsure {
     pub fn process_claim(env: Env, claim_id: u64) -> Result<(), validate::Error> {
         let admin = storage::get_admin(&env);
         admin.require_auth();
-        claim::process_claim(&env, claim_id)
+        let result = claim::process_claim(&env, claim_id);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "process_claim");
+        }
+        result
     }
 
     pub fn get_claim(env: Env, claim_id: u64) -> Result<types::Claim, validate::Error> {
@@ -475,6 +491,7 @@ impl NiffyInsure {
         let admin = storage::get_admin(&env);
         admin.require_auth();
         storage::set_calc_address(&env, &calculator);
+        admin::emit_admin_action(&env, &admin, "set_calculator");
     }
 
     pub fn clear_calculator(env: Env) {
@@ -483,6 +500,7 @@ impl NiffyInsure {
         env.storage()
             .instance()
             .remove(&storage::DataKey::CalcAddress);
+        admin::emit_admin_action(&env, &admin, "clear_calculator");
     }
 
     pub fn get_calculator(env: Env) -> Option<Address> {
@@ -682,14 +700,18 @@ impl NiffyInsure {
         reason: types::TerminationReason,
         allow_open_claims: bool,
     ) -> Result<(), policy_lifecycle::PolicyError> {
-        policy_lifecycle::admin_terminate_policy(
+        let result = policy_lifecycle::admin_terminate_policy(
             &env,
-            admin,
+            admin.clone(),
             holder,
             policy_id,
             reason,
             allow_open_claims,
-        )
+        );
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "admin_terminate_policy");
+        }
+        result
     }
 
     pub fn propose_admin(env: Env, new_admin: Address) {
@@ -821,8 +843,12 @@ impl NiffyInsure {
         asset: Address,
         table: Option<types::MultiplierTable>,
     ) -> Result<(), validate::Error> {
-        admin::require_admin(&env);
-        premium::admin_set_asset_premium_table(&env, &asset, table)
+        let admin = admin::require_admin(&env);
+        let result = premium::admin_set_asset_premium_table(&env, &asset, table);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "admin_set_asset_premium_table");
+        }
+        result
     }
 
     /// Read the asset-specific multiplier table for `asset`.
@@ -856,13 +882,14 @@ impl NiffyInsure {
 
         let flags = storage::get_pause_flags(&env);
         PauseToggled {
-            admin,
+            admin: admin.clone(),
             paused: true,
             reason_code,
             bind_paused: flags.bind_paused,
             claims_paused: flags.claims_paused,
         }
         .publish(&env);
+        admin::emit_admin_action(&env, &admin, "pause");
     }
 
     /// Unpause the contract with optional reason code.
@@ -876,13 +903,14 @@ impl NiffyInsure {
 
         let flags = storage::get_pause_flags(&env);
         PauseToggled {
-            admin,
+            admin: admin.clone(),
             paused: false,
             reason_code,
             bind_paused: flags.bind_paused,
             claims_paused: flags.claims_paused,
         }
         .publish(&env);
+        admin::emit_admin_action(&env, &admin, "unpause");
     }
 
     /// Granular pause: pause only policy binding (initiate/renew).
@@ -896,13 +924,14 @@ impl NiffyInsure {
         storage::set_pause_flags(&env, &flags);
 
         PauseToggled {
-            admin,
+            admin: admin.clone(),
             paused: true,
             reason_code,
             bind_paused: flags.bind_paused,
             claims_paused: flags.claims_paused,
         }
         .publish(&env);
+        admin::emit_admin_action(&env, &admin, "pause_bind");
     }
 
     /// Granular pause: pause only claims (file/vote/finalize).
@@ -916,13 +945,14 @@ impl NiffyInsure {
         storage::set_pause_flags(&env, &flags);
 
         PauseToggled {
-            admin,
+            admin: admin.clone(),
             paused: true,
             reason_code,
             bind_paused: flags.bind_paused,
             claims_paused: flags.claims_paused,
         }
         .publish(&env);
+        admin::emit_admin_action(&env, &admin, "pause_claims");
     }
 
     /// Get current pause state (legacy - true if ANY pause flag is set).
@@ -966,8 +996,12 @@ impl NiffyInsure {
 
     /// Admin: set rolling claim cap. Bounded unless `i128::MAX` (uncapped). Emits `ClaimCapUpdated`.
     pub fn set_rolling_claim_cap(env: Env, new_cap: i128) -> Result<(), AdminError> {
-        let _admin = admin::require_admin(&env);
-        rolling_claim_cap::try_set_cap(&env, new_cap)
+        let admin = admin::require_admin(&env);
+        let result = rolling_claim_cap::try_set_cap(&env, new_cap);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "set_rolling_claim_cap");
+        }
+        result
     }
 
     /// Admin: set rolling window length in ledgers. Emits `RollingClaimWindowLedgersUpdated`.
@@ -975,8 +1009,12 @@ impl NiffyInsure {
         env: Env,
         window_ledgers: u32,
     ) -> Result<(), AdminError> {
-        let _admin = admin::require_admin(&env);
-        rolling_claim_cap::try_set_window_ledgers(&env, window_ledgers)
+        let admin = admin::require_admin(&env);
+        let result = rolling_claim_cap::try_set_window_ledgers(&env, window_ledgers);
+        if result.is_ok() {
+            admin::emit_admin_action(&env, &admin, "set_rolling_claim_window_ledgers");
+        }
+        result
     }
 }
 
@@ -1016,8 +1054,9 @@ impl NiffyInsure {
 
     /// Admin: set the TTL alert threshold for expiry notifications.
     pub fn set_ttl_alert_threshold(env: Env, threshold: u32) -> Result<(), AdminError> {
-        let _admin = admin::require_admin(&env);
+        let admin = admin::require_admin(&env);
         storage::set_ttl_alert_threshold(&env, threshold);
+        admin::emit_admin_action(&env, &admin, "set_ttl_alert_threshold");
         Ok(())
     }
 
@@ -1042,6 +1081,7 @@ impl NiffyInsure {
         assert!(admin == stored, "only admin");
         storage::bump_instance(&env);
         governance_token::set_governance_token_runtime_enabled(&env, enabled);
+        admin::emit_admin_action(&env, &admin, "gov_set_token_runtime_enabled");
     }
 
     pub fn gov_token_address(env: Env) -> Option<Address> {
@@ -1054,6 +1094,7 @@ impl NiffyInsure {
         assert!(admin == stored, "only admin");
         storage::bump_instance(&env);
         governance_token::set_governance_token_address(&env, &token);
+        admin::emit_admin_action(&env, &admin, "gov_set_token_address_stub");
     }
 }
 
@@ -1124,5 +1165,6 @@ impl NiffyInsure {
         admin.require_auth();
         assert!(admin == expected, "only admin can set open claim count");
         storage::set_open_claim(&env, &holder, policy_id, open_claim_count > 0);
+        admin::emit_admin_action(&env, &admin, "admin_set_open_claim_count");
     }
 }

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -6,6 +6,7 @@ mod calculator;
 mod claim;
 pub mod commit_reveal;
 pub mod events;
+pub mod governance;
 mod governance_token;
 mod ledger;
 pub mod policy;
@@ -28,6 +29,7 @@ use soroban_sdk::{contract, contractevent, contractimpl, panic_with_error, Addre
 #[contract]
 pub struct NiffyInsure;
 pub use admin::{AdminAction, AdminError, PendingAdminAction};
+pub use governance::{GovernanceError, Proposal};
 pub use policy::{PolicyError, RenewalError};
 pub use policy_lifecycle::PolicyError as LifecyclePolicyError;
 
@@ -473,6 +475,28 @@ impl NiffyInsure {
 
     pub fn get_voters(env: Env) -> Vec<Address> {
         storage::get_voters(&env)
+    }
+
+    pub fn create_proposal(
+        env: Env,
+        creator: Address,
+        param_key: soroban_sdk::String,
+        new_value: u32,
+    ) -> u64 {
+        governance::create_proposal(&env, creator, param_key, new_value)
+    }
+
+    pub fn vote_proposal(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        approve: bool,
+    ) -> Result<(), GovernanceError> {
+        governance::vote_proposal(&env, voter, proposal_id, approve)
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+        governance::get_proposal(&env, proposal_id)
     }
 
     pub fn voter_registry_len(env: Env) -> u32 {

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -445,7 +445,7 @@ pub struct GracePeriodUpdated {
 }
 
 pub fn set_grace_period_ledgers(env: &Env, ledgers: u32) -> Result<(), RenewalError> {
-    crate::admin::require_admin(env);
+    let admin = crate::admin::require_admin(env);
     if !ledger::is_valid_grace_period_ledgers(ledgers) {
         return Err(RenewalError::GracePeriodOutOfBounds);
     }
@@ -456,6 +456,7 @@ pub fn set_grace_period_ledgers(env: &Env, ledgers: u32) -> Result<(), RenewalEr
         new_ledgers: ledgers,
     }
     .publish(env);
+    crate::admin::emit_admin_action(env, &admin, "set_grace_period_ledgers");
     Ok(())
 }
 

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -106,6 +106,8 @@ pub enum DataKey {
     GovernanceTokenAddress,
     /// Future schema / migration version for governance-token config.
     GovernanceTokenConfigVersion,
+    /// Monotonic governance proposal id counter.
+    ProposalCounter,
     // ── Persistent tier ──────────────────────────────────────────────────
     Policy(Address, u32),
     PolicyCounter(Address),
@@ -159,6 +161,10 @@ pub enum DataKey {
     CommitRevealPhases(u64),
     /// Voter's 32-byte commitment hash: SHA-256(vote_byte || salt).
     VoteCommitment(u64, Address),
+    /// Governance parameter proposal.
+    Proposal(u64),
+    /// Whether a holder has voted on a governance proposal.
+    ProposalVote(u64, Address),
 }
 pub fn has_open_claim(env: &Env, holder: &Address, policy_id: u32) -> bool {
     env.storage()
@@ -492,6 +498,53 @@ pub fn get_voters(env: &Env) -> Vec<Address> {
         .instance()
         .get(&DataKey::Voters)
         .unwrap_or_else(|| Vec::new(env))
+}
+
+// ── Governance proposals ─────────────────────────────────────────────────────
+
+pub fn next_proposal_id(env: &Env) -> u64 {
+    let next = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&DataKey::ProposalCounter)
+        .unwrap_or(0)
+        .saturating_add(1);
+    env.storage()
+        .instance()
+        .set(&DataKey::ProposalCounter, &next);
+    next
+}
+
+pub fn set_proposal(env: &Env, proposal: &crate::governance::Proposal) {
+    let key = DataKey::Proposal(proposal.proposal_id);
+    env.storage().persistent().set(&key, proposal);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn get_proposal(env: &Env, proposal_id: u64) -> Option<crate::governance::Proposal> {
+    env.storage().persistent().get(&DataKey::Proposal(proposal_id))
+}
+
+pub fn remove_proposal(env: &Env, proposal_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Proposal(proposal_id));
+}
+
+pub fn set_proposal_vote(env: &Env, proposal_id: u64, voter: &Address, approve: bool) {
+    let key = DataKey::ProposalVote(proposal_id, voter.clone());
+    env.storage().persistent().set(&key, &approve);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn has_proposal_vote(env: &Env, proposal_id: u64, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::ProposalVote(proposal_id, voter.clone()))
 }
 
 pub fn set_voters(env: &Env, voters: &Vec<Address>) {

--- a/contracts/niffyinsure/tests/admin.rs
+++ b/contracts/niffyinsure/tests/admin.rs
@@ -18,7 +18,7 @@
 use niffyinsure::NiffyInsureClient;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, Env,
+    Address, Env, String,
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -34,12 +34,24 @@ fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
     (env, client, admin, token)
 }
 
+fn events_debug(env: &Env) -> std::string::String {
+    soroban_sdk::testutils::arbitrary::std::format!("{:?}", env.events().all())
+}
+
+fn assert_admin_action_emitted(env: &Env, action_type: &str) {
+    let debug = events_debug(env);
+    assert!(
+        debug.contains("admin_action") && debug.contains(action_type),
+        "expected AdminAction audit event for {action_type}, got {debug}"
+    );
+}
+
 // ── initialize ────────────────────────────────────────────────────────────────
 
 #[test]
 fn initialize_succeeds_once() {
-    let (_env, _client, _admin, _token) = setup();
-    // If we get here without panic, initialize worked.
+    let (env, _client, _admin, _token) = setup();
+    assert_admin_action_emitted(&env, "initialize");
 }
 
 #[test]
@@ -169,7 +181,7 @@ fn set_token_emits_audit_event() {
     let (env, client, _, _) = setup();
     let new_token = Address::generate(&env);
     client.set_token(&new_token);
-    assert!(env.events().all().events().len() > 0);
+    assert_admin_action_emitted(&env, "set_token");
 }
 
 #[test]
@@ -213,7 +225,106 @@ fn admin_can_pause_and_unpause() {
 fn pause_emits_event() {
     let (env, client, admin, _) = setup();
     client.pause(&admin, &0u32);
-    assert!(env.events().all().events().len() > 0);
+    assert_admin_action_emitted(&env, "pause");
+}
+
+#[test]
+fn admin_entrypoints_emit_admin_action_audit_events() {
+    let (env, client, admin, _token) = setup();
+    let asset = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let new_token = Address::generate(&env);
+    client.set_token(&new_token);
+    assert_admin_action_emitted(&env, "set_token");
+
+    let new_treasury = Address::generate(&env);
+    client.set_treasury(&new_treasury);
+    assert_admin_action_emitted(&env, "set_treasury");
+
+    client.set_allowed_asset(&asset, &true, &String::from_str(&env, "USDC"), &7u32);
+    assert_admin_action_emitted(&env, "set_allowed_asset");
+
+    client.admin_set_vote_duration_ledgers(&120u32);
+    assert_admin_action_emitted(&env, "admin_set_vote_duration_ledgers");
+
+    client.admin_set_quorum_bps(&5_000u32);
+    assert_admin_action_emitted(&env, "admin_set_quorum_bps");
+
+    client.set_grace_period_ledgers(&1_000u32);
+    assert_admin_action_emitted(&env, "set_grace_period_ledgers");
+
+    let calculator = Address::generate(&env);
+    client.set_calculator(&calculator);
+    assert_admin_action_emitted(&env, "set_calculator");
+    client.clear_calculator();
+    assert_admin_action_emitted(&env, "clear_calculator");
+
+    let pending = Address::generate(&env);
+    client.propose_admin(&pending);
+    assert_admin_action_emitted(&env, "propose_admin");
+    client.cancel_admin();
+    assert_admin_action_emitted(&env, "cancel_admin");
+
+    client.set_sweep_cap(&Some(1_000_000i128));
+    assert_admin_action_emitted(&env, "set_sweep_cap");
+    client.set_sweep_notice_period(&0u32);
+    assert_admin_action_emitted(&env, "set_sweep_notice_period");
+
+    client.admin_set_max_evidence_count(&5u32);
+    assert_admin_action_emitted(&env, "admin_set_max_evidence_count");
+    client.admin_set_gateway_allowlist(&soroban_sdk::vec![&env, String::from_str(&env, "ipfs://")]);
+    assert_admin_action_emitted(&env, "admin_set_gateway_allowlist");
+
+    client.pause(&admin, &0u32);
+    assert_admin_action_emitted(&env, "pause");
+    client.unpause(&admin, &0u32);
+    assert_admin_action_emitted(&env, "unpause");
+    client.pause_bind(&admin, &0u32);
+    assert_admin_action_emitted(&env, "pause_bind");
+    client.pause_claims(&admin, &0u32);
+    assert_admin_action_emitted(&env, "pause_claims");
+
+    client.set_rolling_claim_cap(&1_000_000i128);
+    assert_admin_action_emitted(&env, "set_rolling_claim_cap");
+    client.set_rolling_claim_window_ledgers(&1_000u32);
+    assert_admin_action_emitted(&env, "set_rolling_claim_window_ledgers");
+    client.set_ttl_alert_threshold(&500_000u32);
+    assert_admin_action_emitted(&env, "set_ttl_alert_threshold");
+}
+
+#[test]
+fn failed_non_admin_call_does_not_emit_admin_action() {
+    let env = Env::default();
+    let cid = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let rando = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin, &token);
+    let before = env.events().all().events().len();
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &rando,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &cid,
+            fn_name: "set_token",
+            args: soroban_sdk::vec![
+                &env,
+                soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&token, &env)
+            ],
+            sub_invokes: &[],
+        },
+    }]);
+
+    assert!(client.try_set_token(&token).is_err());
+    assert_eq!(
+        env.events().all().events().len(),
+        before,
+        "unauthorized call must not emit AdminAction"
+    );
 }
 
 // ── Two-step admin action: propose / confirm / cancel / expiry ────────────────

--- a/contracts/niffyinsure/tests/governance_proposals.rs
+++ b/contracts/niffyinsure/tests/governance_proposals.rs
@@ -1,0 +1,92 @@
+#![cfg(test)]
+
+use niffyinsure::NiffyInsureClient;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+    client.test_seed_policy(&holder_a, &1u32, &1_000_000i128, &500_000u32);
+    client.test_seed_policy(&holder_b, &1u32, &1_000_000i128, &500_000u32);
+    (env, client, holder_a, holder_b, admin)
+}
+
+#[test]
+fn token_holder_can_create_proposal() {
+    let (env, client, holder, _, _) = setup();
+    let id = client.create_proposal(&holder, &String::from_str(&env, "quorum_bps"), &6_000u32);
+    let proposal = client.get_proposal(&id).expect("proposal stored");
+
+    assert_eq!(proposal.param_key, String::from_str(&env, "quorum_bps"));
+    assert_eq!(proposal.proposed_value, 6_000u32);
+    assert_eq!(proposal.approve_votes, 0);
+    assert_eq!(proposal.reject_votes, 0);
+}
+
+#[test]
+fn quorum_applies_parameter_change() {
+    let (env, client, holder_a, holder_b, _) = setup();
+    let id = client.create_proposal(
+        &holder_a,
+        &String::from_str(&env, "quorum_bps"),
+        &7_000u32,
+    );
+
+    client.vote_proposal(&holder_a, &id, &true);
+    assert_eq!(client.get_quorum_bps(), 5_000u32);
+    client.vote_proposal(&holder_b, &id, &true);
+
+    assert_eq!(client.get_quorum_bps(), 7_000u32);
+    assert!(client.get_proposal(&id).expect("proposal retained").applied);
+}
+
+#[test]
+fn rejected_proposal_is_discarded_without_applying() {
+    let (env, client, holder_a, holder_b, _) = setup();
+    let before = client.get_vote_duration_ledgers();
+    let id = client.create_proposal(
+        &holder_a,
+        &String::from_str(&env, "voting_duration_ledgers"),
+        &10_000u32,
+    );
+
+    client.vote_proposal(&holder_a, &id, &false);
+    client.vote_proposal(&holder_b, &id, &false);
+
+    assert_eq!(client.get_vote_duration_ledgers(), before);
+    assert!(client.get_proposal(&id).is_none());
+}
+
+#[test]
+fn non_token_holder_cannot_create_proposal() {
+    let (env, client, _, _, _) = setup();
+    let outsider = Address::generate(&env);
+
+    assert!(client
+        .try_create_proposal(
+            &outsider,
+            &String::from_str(&env, "quorum_bps"),
+            &6_000u32,
+        )
+        .is_err());
+}
+
+#[test]
+fn duplicate_votes_are_rejected() {
+    let (env, client, holder_a, _, _) = setup();
+    let id = client.create_proposal(&holder_a, &String::from_str(&env, "quorum_bps"), &6_000u32);
+
+    client.vote_proposal(&holder_a, &id, &true);
+    assert!(client.try_vote_proposal(&holder_a, &id, &true).is_err());
+}

--- a/docs/EVENT_DICTIONARY.md
+++ b/docs/EVENT_DICTIONARY.md
@@ -34,6 +34,34 @@ The indexer discriminates events by `${topic[0]}:${topic[1]}`.
 
 ---
 
+## Admin Audit Event (`namespace = "niffyinsure"`)
+
+### `admin_action` — immutable admin audit trail
+
+Emitted after every successful admin-authenticated entrypoint. Failed or unauthorized calls do not emit this event.
+
+**Topics:** `("niffyinsure", "admin_action")`
+
+```json
+{
+  "actor": "G...",
+  "action_type": "set_token",
+  "params": {}
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actor` | string (G...) | Authenticated account that authorized the admin operation |
+| `action_type` | string | Stable machine-readable action name |
+| `params` | object | String-keyed parameter map; currently emitted as `{}` to preserve the schema while avoiding address/string encoding ambiguity |
+
+Stable `action_type` values:
+
+`initialize`, `update_multiplier_table`, `admin_set_premium_multiplier`, `set_allowed_asset`, `admin_set_vote_duration_ledgers`, `admin_set_quorum_bps`, `set_grace_period_ledgers`, `process_claim`, `set_calculator`, `clear_calculator`, `admin_terminate_policy`, `propose_admin`, `accept_admin`, `cancel_admin`, `propose_admin_action`, `confirm_admin_action`, `cancel_admin_action`, `set_token`, `set_treasury`, `drain`, `sweep_token`, `set_sweep_cap`, `set_sweep_notice_period`, `admin_set_max_evidence_count`, `admin_set_gateway_allowlist`, `admin_set_asset_premium_table`, `pause`, `unpause`, `pause_bind`, `pause_claims`, `set_rolling_claim_cap`, `set_rolling_claim_window_ledgers`, `set_ttl_alert_threshold`, `gov_set_token_runtime_enabled`, `gov_set_token_address_stub`, `admin_set_open_claim_count`.
+
+---
+
 ## Claim events  (`namespace = "niffyins"`)
 
 ### `clm_filed` — claim filed


### PR DESCRIPTION
closes #608 
closes #607 
closes #609 
closes #602 

190e8de - Admin audit events
Added admin_action audit events for admin-authenticated contract entrypoints, documented action_type values in EVENT_DICTIONARY.md, and added tests checking emission plus non-admin failure behavior.

b19f6a9 - Claim summary cache
Added ClaimSummaryCacheService with configurable Redis TTL, wired claims board list reads through it, invalidated cache from the indexer on claim file/vote/payout changes, and exposed Prometheus hit/miss metrics.

3363a0a - Governance proposals
Added on-chain governance proposals with Proposal storage, holder-gated create_proposal, vote_proposal, quorum-triggered application for supported params, rejection cleanup, and proposal tests.

1a5afa6 - Vote subscriptions
Wired indexer vote ingestion to publish through VotePubSubService, enforced wallet JWT authentication during GraphQL WebSocket handshake, added tests for publishing/auth helpers, and documented voteAdded(claimId) subscription behavior.