### PR TITLE
Feat/docs sync

### DIFF
--- a/backend/src/claims/services/evidence-proxy.service.spec.ts
+++ b/backend/src/claims/services/evidence-proxy.service.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { EvidenceProxyService } from './evidence-proxy.service';
 
 const CLAIMANT = 'GCLAIMANT000000000000000000000000000000000000000000000000';
@@ -5,12 +6,20 @@ const VOTER = 'GVOTER0000000000000000000000000000000000000000000000000000';
 const STRANGER = 'GSTRANGER00000000000000000000000000000000000000000000000000';
 const CID = 'QmTestCid123456789';
 
-function makeClaim(overrides: Partial<{ creatorAddress: string; imageUrls: string[]; votes: { voterAddress: string }[] }> = {}) {
+function makeClaim(overrides: Partial<{
+  creatorAddress: string;
+  imageUrls: string[];
+  votes: { voterAddress: string }[];
+  txHash: string | null;
+  eventIndex: number | null;
+}> = {}) {
   return {
     id: 1,
     creatorAddress: CLAIMANT,
     imageUrls: [`ipfs://${CID}`],
     votes: [{ voterAddress: VOTER }],
+    txHash: '0xdeadbeef',
+    eventIndex: 0,
     ...overrides,
   };
 }
@@ -19,6 +28,9 @@ function makeService(claimOverride?: ReturnType<typeof makeClaim> | null) {
   const prisma = {
     claim: {
       findUnique: jest.fn().mockResolvedValue(claimOverride !== undefined ? claimOverride : makeClaim()),
+    },
+    rawEvent: {
+      findUnique: jest.fn(),
     },
   };
   const audit = { write: jest.fn().mockResolvedValue(undefined) };
@@ -51,19 +63,20 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
 function mockFetchOk(contentType = 'image/png') {
-  const chunks = [new Uint8Array([1, 2, 3])];
-  let i = 0;
+  const content = Buffer.from([1, 2, 3]);
   mockFetch.mockResolvedValue({
     ok: true,
     headers: { get: () => contentType },
-    body: {
-      getReader: () => ({
-        read: jest.fn().mockImplementation(async () => {
-          if (i < chunks.length) return { done: false, value: chunks[i++] };
-          return { done: true, value: undefined };
-        }),
-      }),
-    },
+    arrayBuffer: jest.fn().mockResolvedValue(content),
+  });
+  return content;
+}
+
+function mockFetchForContent(content: Buffer, contentType = 'image/png') {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    headers: { get: () => contentType },
+    arrayBuffer: jest.fn().mockResolvedValue(content),
   });
 }
 
@@ -71,8 +84,11 @@ describe('EvidenceProxyService', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('streams evidence to claimant with correct headers', async () => {
-    const { service } = makeService();
-    mockFetchOk('image/png');
+    const { service, prisma } = makeService();
+    const content = mockFetchOk('image/png');
+    prisma.rawEvent.findUnique.mockResolvedValue({
+      data: { evidence_hashes: [createHash('sha256').update(content).digest('hex')] },
+    });
     const res = makeRes();
 
     await service.stream(1, 0, CLAIMANT, res as never);
@@ -86,8 +102,11 @@ describe('EvidenceProxyService', () => {
   });
 
   it('streams evidence to active voter', async () => {
-    const { service } = makeService();
-    mockFetchOk();
+    const { service, prisma } = makeService();
+    const content = mockFetchOk();
+    prisma.rawEvent.findUnique.mockResolvedValue({
+      data: { evidence_hashes: [createHash('sha256').update(content).digest('hex')] },
+    });
     const res = makeRes();
 
     await service.stream(1, 0, VOTER, res as never);
@@ -120,8 +139,11 @@ describe('EvidenceProxyService', () => {
   });
 
   it('writes audit log on successful download', async () => {
-    const { service, audit } = makeService();
-    mockFetchOk();
+    const { service, audit, prisma } = makeService();
+    const content = mockFetchOk();
+    prisma.rawEvent.findUnique.mockResolvedValue({
+      data: { evidence_hashes: [createHash('sha256').update(content).digest('hex')] },
+    });
     const res = makeRes();
 
     await service.stream(1, 0, CLAIMANT, res as never);
@@ -129,5 +151,50 @@ describe('EvidenceProxyService', () => {
     expect(audit.write).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'evidence_download', actor: CLAIMANT }),
     );
+  });
+
+  it('returns verified=true when fetched bytes match the on-chain commitment', async () => {
+    const { service, prisma } = makeService();
+    const content = Buffer.from('match me');
+    mockFetchForContent(content);
+    prisma.rawEvent.findUnique.mockResolvedValue({
+      data: { evidence_hashes: [createHash('sha256').update(content).digest('hex')] },
+    });
+
+    const result = await service.fetch(1, 0, CLAIMANT);
+
+    expect(result.verified).toBe(true);
+    expect(result.hashMismatch).toBe(false);
+  });
+
+  it('flags hashMismatch and logs a security event when the hash differs', async () => {
+    const { service, prisma, audit } = makeService();
+    const content = Buffer.from('mismatch me');
+    mockFetchForContent(content);
+    prisma.rawEvent.findUnique.mockResolvedValue({
+      data: { evidence_hashes: ['0'.repeat(64)] },
+    });
+
+    const result = await service.fetch(1, 0, CLAIMANT);
+
+    expect(result.verified).toBe(false);
+    expect(result.hashMismatch).toBe(true);
+    expect(audit.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'evidence_hash_mismatch',
+        actor: CLAIMANT,
+      }),
+    );
+  });
+
+  it('returns verified=false without error when the on-chain hash is missing', async () => {
+    const { service, prisma } = makeService();
+    mockFetchForContent(Buffer.from('no hash'));
+    prisma.rawEvent.findUnique.mockResolvedValue(null);
+
+    const result = await service.fetch(1, 0, CLAIMANT);
+
+    expect(result.verified).toBe(false);
+    expect(result.hashMismatch).toBe(false);
   });
 });

--- a/backend/src/claims/services/evidence-proxy.service.ts
+++ b/backend/src/claims/services/evidence-proxy.service.ts
@@ -3,6 +3,17 @@ import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../prisma/prisma.service';
 import { AuditService } from '../../admin/audit.service';
 import type { Response } from 'express';
+import { createHash } from 'crypto';
+
+export interface EvidenceFetchResponseDto {
+  content: Buffer;
+  contentType: string;
+  filename: string;
+  evidenceUrl: string;
+  verified: boolean;
+  hashMismatch: boolean;
+  fetchedSha256Hex: string;
+}
 
 @Injectable()
 export class EvidenceProxyService {
@@ -17,19 +28,103 @@ export class EvidenceProxyService {
     this.ipfsGateway = this.config.get<string>('IPFS_GATEWAY', 'https://ipfs.io');
   }
 
+  async fetch(
+    claimId: number,
+    index: number,
+    walletAddress: string,
+  ): Promise<EvidenceFetchResponseDto> {
+    const claim = await this.loadClaim(claimId);
+
+    // 2. Authorise: claimant, active voter, or admin
+    this.assertAuthorized(claim, walletAddress);
+
+    // 3. Resolve evidence URL
+    if (index < 0 || index >= claim.imageUrls.length) {
+      throw new NotFoundException(`Evidence index ${index} not found for claim ${claimId}`);
+    }
+
+    const rawUrl = claim.imageUrls[index];
+    const gatewayUrl = this.resolveGatewayUrl(rawUrl);
+    this.logger.log(`Fetching evidence: claim=${claimId} index=${index} url=${gatewayUrl}`);
+
+    const fetchResponse = await fetch(gatewayUrl);
+    if (!fetchResponse.ok) {
+      throw new Error(`Gateway returned ${fetchResponse.status}`);
+    }
+
+    const contentType = fetchResponse.headers.get('content-type') ?? 'application/octet-stream';
+    const content = Buffer.from(await fetchResponse.arrayBuffer());
+    const fetchedSha256Hex = createHash('sha256').update(content).digest('hex');
+
+    const storedHash = await this.getStoredEvidenceHash(claim, index);
+    const hashMismatch = storedHash ? storedHash !== fetchedSha256Hex : false;
+    const verified = storedHash ? !hashMismatch : false;
+
+    if (hashMismatch) {
+      await this.writeAudit(walletAddress, 'evidence_hash_mismatch', {
+        claimId,
+        index,
+        evidenceUrl: rawUrl,
+        storedHash,
+        fetchedHash: fetchedSha256Hex,
+      });
+    }
+
+    const filename = `claim-${claimId}-evidence-${index}`;
+    return {
+      content,
+      contentType,
+      filename,
+      evidenceUrl: gatewayUrl,
+      verified,
+      hashMismatch,
+      fetchedSha256Hex,
+    };
+  }
+
   async stream(
     claimId: number,
     index: number,
     walletAddress: string,
     res: Response,
   ): Promise<void> {
-    // 1. Load claim
+    try {
+      const result = await this.fetch(claimId, index, walletAddress);
+      this.logger.log(
+        `Proxying evidence: claim=${claimId} index=${index} url=${result.evidenceUrl} verified=${result.verified}`,
+      );
+
+      res.setHeader('Content-Type', result.contentType);
+      res.setHeader('Content-Disposition', `attachment; filename="${result.filename}"`);
+      res.setHeader('Cache-Control', 'private, max-age=3600');
+      res.write(result.content);
+      res.end();
+    } catch (err) {
+      this.logger.error(`Evidence proxy failed: ${err}`);
+      await this.writeAudit(walletAddress, 'evidence_download_failed', {
+        claimId,
+        index,
+        error: String(err),
+      });
+      if (!res.headersSent) {
+        res.status(502).json({ message: 'Failed to fetch evidence from IPFS' });
+      }
+      return;
+    }
+
+    // 5. Audit success
+    await this.writeAudit(walletAddress, 'evidence_download', { claimId, index });
+  }
+
+  private async loadClaim(claimId: number) {
     const claim = await this.prisma.claim.findUnique({
       where: { id: claimId },
       select: {
         id: true,
         creatorAddress: true,
         imageUrls: true,
+        txHash: true,
+        eventIndex: true,
         votes: {
           where: { deletedAt: null },
           select: { voterAddress: true },
@@ -41,7 +136,13 @@ export class EvidenceProxyService {
       throw new NotFoundException(`Claim ${claimId} not found`);
     }
 
-    // 2. Authorise: claimant, active voter, or admin
+    return claim;
+  }
+
+  private assertAuthorized(
+    claim: { creatorAddress: string; votes: { voterAddress: string }[] },
+    walletAddress: string,
+  ): void {
     const isClaimant = claim.creatorAddress.toLowerCase() === walletAddress.toLowerCase();
     const isVoter = claim.votes.some(
       (v) => v.voterAddress.toLowerCase() === walletAddress.toLowerCase(),
@@ -50,57 +151,39 @@ export class EvidenceProxyService {
     const isAdmin = adminToken && walletAddress === adminToken;
 
     if (!isClaimant && !isVoter && !isAdmin) {
-      await this.writeAudit(walletAddress, 'evidence_download_forbidden', { claimId, index });
       throw new ForbiddenException('Access denied: not the claimant, a voter, or an admin');
     }
+  }
 
-    // 3. Resolve evidence URL
-    if (index < 0 || index >= claim.imageUrls.length) {
-      throw new NotFoundException(`Evidence index ${index} not found for claim ${claimId}`);
+  private async getStoredEvidenceHash(
+    claim: { txHash: string | null; eventIndex: number | null },
+    index: number,
+  ): Promise<string | null> {
+    if (!claim.txHash || claim.eventIndex == null) {
+      return null;
     }
 
-    const rawUrl = claim.imageUrls[index];
-    // Support both full gateway URLs and bare CIDs / ipfs:// URIs
-    const gatewayUrl = this.resolveGatewayUrl(rawUrl);
+    const rawEvent = await this.prisma.rawEvent.findUnique({
+      where: {
+        txHash_eventIndex: {
+          txHash: claim.txHash,
+          eventIndex: claim.eventIndex,
+        },
+      },
+      select: { data: true },
+    });
 
-    // 4. Stream from IPFS gateway
-    this.logger.log(`Proxying evidence: claim=${claimId} index=${index} url=${gatewayUrl}`);
-
-    let upstream: Response;
-    try {
-      const fetchResponse = await fetch(gatewayUrl);
-      if (!fetchResponse.ok) {
-        throw new Error(`Gateway returned ${fetchResponse.status}`);
-      }
-
-      const contentType = fetchResponse.headers.get('content-type') ?? 'application/octet-stream';
-      const filename = `claim-${claimId}-evidence-${index}`;
-
-      res.setHeader('Content-Type', contentType);
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-      res.setHeader('Cache-Control', 'private, max-age=3600');
-
-      // Stream body to client
-      const reader = fetchResponse.body?.getReader();
-      if (!reader) throw new Error('No response body');
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        res.write(value);
-      }
-      res.end();
-    } catch (err) {
-      this.logger.error(`Evidence proxy failed: ${err}`);
-      await this.writeAudit(walletAddress, 'evidence_download_failed', { claimId, index, error: String(err) });
-      if (!res.headersSent) {
-        res.status(502).json({ message: 'Failed to fetch evidence from IPFS' });
-      }
-      return;
+    const evidenceHashes = (rawEvent?.data as { evidence_hashes?: unknown } | null)?.evidence_hashes;
+    if (!Array.isArray(evidenceHashes)) {
+      return null;
     }
 
-    // 5. Audit success
-    await this.writeAudit(walletAddress, 'evidence_download', { claimId, index });
+    const stored = evidenceHashes[index];
+    if (typeof stored !== 'string' || stored.length === 0) {
+      return null;
+    }
+
+    return stored.toLowerCase();
   }
 
   private resolveGatewayUrl(raw: string): string {

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -194,6 +194,18 @@ pub struct PayoutTimedOut {
     pub at_ledger: u32,
 }
 
+/// Emitted when a payout recipient is a contract address and has been explicitly allowed.
+#[contractevent(topics = ["niffyinsure", "payout_recipient_warning"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PayoutRecipientWarning {
+    #[topic]
+    pub claim_id: u64,
+    #[topic]
+    pub recipient: Address,
+    pub asset: Address,
+    pub at_ledger: u32,
+}
+
 /// Emitted every time a rejection increments the policy's strike counter.
 /// Indexers should use this event to notify holders of accumulating strikes
 /// before the threshold triggers deactivation.
@@ -780,6 +792,7 @@ fn on_reject(env: &Env, claim: &Claim) {
 fn payout(env: &Env, claim: &Claim) -> Result<(), Error> {
     let policy =
         storage::get_policy(env, &claim.claimant, claim.policy_id).ok_or(Error::PolicyNotFound)?;
+    let now = env.ledger().sequence();
 
     if !storage::is_allowed_asset(env, &policy.asset) {
         return Err(Error::InvalidAsset);
@@ -814,6 +827,19 @@ fn payout(env: &Env, claim: &Claim) -> Result<(), Error> {
         .beneficiary
         .clone()
         .unwrap_or_else(|| policy.holder.clone());
+
+    if payout_to.to_string().starts_with('C') {
+        if !storage::is_allowed_payout_recipient(env, &payout_to) {
+            return Err(Error::PayoutRecipientContractNotAllowlisted);
+        }
+        PayoutRecipientWarning {
+            claim_id: claim.claim_id,
+            recipient: payout_to.clone(),
+            asset: effective_asset.clone(),
+            at_ledger: now,
+        }
+        .publish(env);
+    }
 
     // Emit override event before the transfer so indexers see the asset decision first.
     let override_active = effective_asset != policy.asset;

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -992,3 +992,42 @@ mod appeal_stub_tests {
         assert!(ClaimStatus::AppealRejected.is_terminal());
     }
 }
+// ── add_claim_evidence ───────────────────────────────────────────────────────
+
+/// Claimant-only: replace evidence during the pre-vote window.
+///
+/// Allowed only while the claim is still `Processing` and no ballots have been
+/// cast yet. This lets the claimant correct or expand evidence before voting
+/// begins without mutating any in-flight vote state.
+pub fn add_claim_evidence(
+    env: &Env,
+    claimant: &Address,
+    claim_id: u64,
+    new_evidence: &Vec<ClaimEvidenceEntry>,
+) -> Result<(), Error> {
+    storage::assert_claims_not_paused(env);
+
+    let mut claim = storage::get_claim(env, claim_id).ok_or(Error::ClaimNotFound)?;
+    if claimant != &claim.claimant {
+        return Err(Error::NotEligibleVoter);
+    }
+    if claim.status != ClaimStatus::Processing
+        || claim.approve_votes != 0
+        || claim.reject_votes != 0
+    {
+        return Err(Error::ClaimEvidenceUpdateNotAllowed);
+    }
+
+    validate::check_claim_evidence_update(env, new_evidence)?;
+
+    claim.evidence = new_evidence.clone();
+    storage::set_claim(env, &claim);
+
+    let now = env.ledger().sequence();
+    let mut evidence_hashes: Vec<BytesN<32>> = Vec::new(env);
+    for e in new_evidence.iter() {
+        evidence_hashes.push_back(e.hash.clone());
+    }
+    ClaimEvidenceUpdated {
+        claim_id,
+        policy_id: claim.policy_id,

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -1139,3 +1139,70 @@ impl NiffyInsure {
         claim::add_claim_evidence(&env, &claimant, claim_id, &new_evidence)
     }
 
+#[contractevent(topics = ["niffyinsure", "treasury_depositor_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreasuryDepositorUpdated {
+    #[topic]
+    pub depositor: Address,
+    pub allowed: bool,
+}
+
+#[contractevent(topics = ["niffyinsure", "treasury_deposited"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreasuryDeposited {
+    #[topic]
+    pub depositor: Address,
+    #[topic]
+    pub asset: Address,
+    pub amount: i128,
+    pub at_ledger: u32,
+}
+
+    /// Read-only: whether a depositor is authorized to inject treasury capital.
+    pub fn is_authorized_depositor(env: Env, depositor: Address) -> bool {
+        storage::is_authorized_depositor(&env, &depositor)
+    }
+
+    /// Admin-only: add or remove a treasury depositor from the allowlist.
+    pub fn set_authorized_depositor(
+        env: Env,
+        depositor: Address,
+        allowed: bool,
+    ) -> Result<(), AdminError> {
+        let _admin = admin::require_admin(&env);
+        storage::bump_instance(&env);
+        storage::set_authorized_depositor(&env, &depositor, allowed);
+        TreasuryDepositorUpdated { depositor, allowed }.publish(&env);
+        Ok(())
+    }
+
+    /// Authorized depositor-only: transfer capital into the treasury and emit an event.
+    pub fn deposit_treasury(
+        env: Env,
+        depositor: Address,
+        amount: i128,
+        asset: Address,
+    ) -> Result<(), validate::Error> {
+        storage::bump_instance(&env);
+        if amount <= 0 {
+            return Err(validate::Error::ZeroTreasuryDeposit);
+        }
+        if !storage::is_authorized_depositor(&env, &depositor) {
+            return Err(validate::Error::UnauthorizedTreasuryDepositor);
+        }
+
+        depositor.require_auth();
+
+        let client = soroban_sdk::token::TokenClient::new(&env, &asset);
+        client.transfer(&depositor, &env.current_contract_address(), &amount);
+
+        TreasuryDeposited {
+            depositor,
+            asset,
+            amount,
+            at_ledger: env.ledger().sequence(),
+        }
+        .publish(&env);
+
+        Ok(())
+    }

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -1206,3 +1206,20 @@ struct TreasuryDeposited {
 
         Ok(())
     }
+
+    /// Read-only: whether a contract payout recipient is explicitly allowlisted.
+    pub fn is_allowed_payout_recipient(env: Env, recipient: Address) -> bool {
+        storage::is_allowed_payout_recipient(&env, &recipient)
+    }
+
+    /// Admin-only: add or remove a contract payout recipient from the allowlist.
+    pub fn set_allowed_payout_recipient(
+        env: Env,
+        recipient: Address,
+        allowed: bool,
+    ) -> Result<(), AdminError> {
+        let _admin = admin::require_admin(&env);
+        storage::bump_instance(&env);
+        storage::set_allowed_payout_recipient(&env, &recipient, allowed);
+        Ok(())
+    }

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -1126,3 +1126,16 @@ impl NiffyInsure {
         storage::set_open_claim(&env, &holder, policy_id, open_claim_count > 0);
     }
 }
+            44 => validate::Error::ClaimEvidenceUpdateNotAllowed,
+            45 => validate::Error::EvidenceCountOutOfBounds,
+    /// Claimant-only: replace evidence before voting starts.
+    pub fn add_claim_evidence(
+        env: Env,
+        claimant: Address,
+        claim_id: u64,
+        new_evidence: Vec<types::ClaimEvidenceEntry>,
+    ) -> Result<(), validate::Error> {
+        claimant.require_auth();
+        claim::add_claim_evidence(&env, &claimant, claim_id, &new_evidence)
+    }
+

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -1291,3 +1291,28 @@ pub fn is_oracle_enabled(_env: &Env) -> bool {
 pub fn set_oracle_enabled(_env: &Env, _enabled: bool) {
     panic!("ORACLE_TRIGGERS_DISABLED")
 }
+    /// Allowlist of treasury depositors keyed by address.
+    AuthorizedDepositors,
+// ── Treasury depositor allowlist ─────────────────────────────────────────────
+
+pub fn get_authorized_depositors(env: &Env) -> Map<Address, bool> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AuthorizedDepositors)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+pub fn set_authorized_depositor(env: &Env, depositor: &Address, allowed: bool) {
+    let mut depositors = get_authorized_depositors(env);
+    depositors.set(depositor.clone(), allowed);
+    env.storage()
+        .instance()
+        .set(&DataKey::AuthorizedDepositors, &depositors);
+}
+
+pub fn is_authorized_depositor(env: &Env, depositor: &Address) -> bool {
+    get_authorized_depositors(env)
+        .get(depositor.clone())
+        .unwrap_or(false)
+}
+

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -1293,6 +1293,8 @@ pub fn set_oracle_enabled(_env: &Env, _enabled: bool) {
 }
     /// Allowlist of treasury depositors keyed by address.
     AuthorizedDepositors,
+    /// Allowlist of payout recipients that are contract addresses.
+    AllowedPayoutRecipients,
 // ── Treasury depositor allowlist ─────────────────────────────────────────────
 
 pub fn get_authorized_depositors(env: &Env) -> Map<Address, bool> {
@@ -1316,3 +1318,25 @@ pub fn is_authorized_depositor(env: &Env, depositor: &Address) -> bool {
         .unwrap_or(false)
 }
 
+// ── Payout recipient allowlist ───────────────────────────────────────────────
+
+pub fn get_allowed_payout_recipients(env: &Env) -> Map<Address, bool> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AllowedPayoutRecipients)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+pub fn set_allowed_payout_recipient(env: &Env, recipient: &Address, allowed: bool) {
+    let mut recipients = get_allowed_payout_recipients(env);
+    recipients.set(recipient.clone(), allowed);
+    env.storage()
+        .instance()
+        .set(&DataKey::AllowedPayoutRecipients, &recipients);
+}
+
+pub fn is_allowed_payout_recipient(env: &Env, recipient: &Address) -> bool {
+    get_allowed_payout_recipients(env)
+        .get(recipient.clone())
+        .unwrap_or(false)
+}

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -514,3 +514,7 @@ mod evidence_url_validation_tests {
     ClaimEvidenceUpdateNotAllowed = 44,
     /// Evidence count must fit the configured min/max bounds.
     EvidenceCountOutOfBounds = 45,
+    /// Treasury deposits must be strictly positive.
+    ZeroTreasuryDeposit = 46,
+    /// Caller is not on the authorized treasury depositor allowlist.
+    UnauthorizedTreasuryDepositor = 47,

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -55,6 +55,8 @@ pub enum Error {
     RateLimitExceeded = 42,
     /// Evidence URL does not match IPFS or allowlisted gateway format.
     InvalidEvidenceUrl = 43,
+    /// Contract payout recipients must be allowlisted.
+    PayoutRecipientContractNotAllowlisted = 48,
     /// Admin `set_voting_duration_ledgers` value outside allowed [min, max] range.
     VotingDurationOutOfBounds = 49,
     /// Batch get exceeded POLICY_BATCH_GET_MAX.

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -510,3 +510,7 @@ mod evidence_url_validation_tests {
         });
     }
 }
+    /// Claim evidence update must happen before any votes are cast.
+    ClaimEvidenceUpdateNotAllowed = 44,
+    /// Evidence count must fit the configured min/max bounds.
+    EvidenceCountOutOfBounds = 45,

--- a/contracts/niffyinsure/tests/evidence_update.rs
+++ b/contracts/niffyinsure/tests/evidence_update.rs
@@ -1,0 +1,112 @@
+//! Claim evidence updates during the pre-vote window.
+//!
+//! Covers:
+//! - Claimants can replace evidence while the claim is still `Processing`
+//!   and before any ballots are cast.
+//! - Updated evidence is reflected in `get_claim`.
+//! - Evidence updates are rejected once voting has started.
+
+#![cfg(test)]
+
+mod common;
+
+use niffyinsure::{types::VoteOption, NiffyInsureClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let cid = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, token)
+}
+
+fn seed_policy(client: &NiffyInsureClient, holder: &Address) {
+    client.test_seed_policy(holder, &1u32, &1_000_000_000i128, &999_999u32);
+}
+
+#[test]
+fn add_claim_evidence_succeeds_before_any_votes() {
+    let (env, client, _token) = setup();
+    let holder = Address::generate(&env);
+    seed_policy(&client, &holder);
+
+    let initial_evidence = common::one_url_evidence_with_hash(
+        &env,
+        "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        common::sample_digest(&env),
+    );
+    let claim_id = client.file_claim(
+        &holder,
+        &1u32,
+        &100_000i128,
+        &String::from_str(&env, "roof damage"),
+        &initial_evidence,
+        &None,
+    );
+
+    let mut updated_evidence = common::one_url_evidence_with_hash(
+        &env,
+        "ipfs://bafybeiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        common::non_zero_hash(&env),
+    );
+    updated_evidence.push_back(niffyinsure::types::ClaimEvidenceEntry {
+        url: String::from_str(
+            &env,
+            "https://gateway.pinata.cloud/ipfs/bafybeibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        ),
+        hash: common::sample_digest(&env),
+    });
+
+    let before_events = env.events().all().events().len();
+    client.add_claim_evidence(&holder, &claim_id, &updated_evidence);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.evidence, updated_evidence);
+    assert_eq!(claim.status, niffyinsure::types::ClaimStatus::Processing);
+    assert!(env.events().all().events().len() > before_events);
+}
+
+#[test]
+fn add_claim_evidence_reverts_after_first_vote() {
+    let (env, client, _token) = setup();
+    let holder = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+    seed_policy(&client, &holder);
+    seed_policy(&client, &voter2);
+    seed_policy(&client, &voter3);
+
+    let initial_evidence = common::one_url_evidence_with_hash(
+        &env,
+        "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        common::sample_digest(&env),
+    );
+    let claim_id = client.file_claim(
+        &holder,
+        &1u32,
+        &100_000i128,
+        &String::from_str(&env, "roof damage"),
+        &initial_evidence,
+        &None,
+    );
+
+    client.vote_on_claim(&holder, &claim_id, &VoteOption::Approve);
+
+    let updated_evidence = common::one_url_evidence_with_hash(
+        &env,
+        "ipfs://bafybeicccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        common::non_zero_hash(&env),
+    );
+
+    let result = client.try_add_claim_evidence(&holder, &claim_id, &updated_evidence);
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("ClaimEvidenceUpdateNotAllowed"));
+}

--- a/contracts/niffyinsure/tests/payout_recipient_allowlist.rs
+++ b/contracts/niffyinsure/tests/payout_recipient_allowlist.rs
@@ -1,0 +1,151 @@
+//! Payout recipient allowlist tests.
+//!
+//! Covers:
+//! - Standard account recipients still receive payouts.
+//! - Contract recipients revert unless explicitly allowlisted.
+//! - Allowlisted contract recipients receive payouts and emit a warning event.
+
+#![cfg(test)]
+
+mod common;
+
+use niffyinsure::{
+    types::{Claim, ClaimStatus},
+    NiffyInsureClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token, Address, Env, String as SorobanString, Vec,
+};
+
+struct TestEnv<'a> {
+    env: Env,
+    client: NiffyInsureClient<'a>,
+    contract_id: Address,
+    token: Address,
+    token_admin: token::StellarAssetClient<'a>,
+}
+
+fn setup() -> TestEnv<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(issuer).address();
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+
+    client.initialize(&admin, &token);
+
+    TestEnv {
+        env,
+        client,
+        contract_id,
+        token,
+        token_admin,
+    }
+}
+
+fn seed_policy(t: &TestEnv, holder: &Address) -> niffyinsure::types::Policy {
+    t.client.test_seed_policy(holder, &1u32, &1_000_000_000i128, &999_999u32)
+}
+
+fn seed_approved_claim(
+    t: &TestEnv,
+    claim_id: u64,
+    policy: &niffyinsure::types::Policy,
+    recipient: Option<Address>,
+) {
+    let mut policy = policy.clone();
+    policy.beneficiary = recipient;
+    t.env.as_contract(&t.contract_id, || {
+        niffyinsure::storage::set_policy(&t.env, &policy.holder, policy.policy_id, &policy);
+        let claim = Claim {
+            claim_id,
+            policy_id: policy.policy_id,
+            claimant: policy.holder.clone(),
+            amount: 5_000_000i128,
+            deductible: 0,
+            asset: policy.asset.clone(),
+            details: SorobanString::from_str(&t.env, "test claim"),
+            evidence: Vec::new(&t.env),
+            status: ClaimStatus::Approved,
+            voting_deadline_ledger: 1_000,
+            payout_deadline_ledger: 0,
+            approve_votes: 3,
+            reject_votes: 0,
+            filed_at: 100,
+            eligible_voter_count: 0,
+            appeal_open_deadline_ledger: 0,
+            appeals_count: 0,
+            appeal_deadline_ledger: 0,
+            appeal_approve_votes: 0,
+            appeal_reject_votes: 0,
+            status_history: Vec::new(&t.env),
+        };
+        niffyinsure::storage::set_claim(&t.env, &claim);
+    });
+}
+
+#[test]
+fn account_payout_still_succeeds() {
+    let t = setup();
+    let holder = Address::generate(&t.env);
+    let policy = seed_policy(&t, &holder);
+    t.token_admin.mint(&t.contract_id, &10_000_000i128);
+    seed_approved_claim(&t, 1, &policy, None);
+
+    let before = token::Client::new(&t.env, &t.token).balance(&holder);
+    t.client.process_claim(&1u64);
+
+    assert_eq!(
+        token::Client::new(&t.env, &t.token).balance(&holder),
+        before + 5_000_000i128,
+    );
+}
+
+#[test]
+fn non_allowlisted_contract_recipient_reverts() {
+    let t = setup();
+    let holder = Address::generate(&t.env);
+    let policy = seed_policy(&t, &holder);
+    let contract_recipient = t
+        .env
+        .register_stellar_asset_contract_v2(Address::generate(&t.env))
+        .address();
+    t.token_admin.mint(&t.contract_id, &10_000_000i128);
+    seed_approved_claim(&t, 2, &policy, Some(contract_recipient));
+
+    let result = t.client.try_process_claim(&2u64);
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("PayoutRecipientContractNotAllowlisted"));
+}
+
+#[test]
+fn allowlisted_contract_recipient_gets_paid_and_emits_warning() {
+    let t = setup();
+    let holder = Address::generate(&t.env);
+    let policy = seed_policy(&t, &holder);
+    let contract_recipient = t
+        .env
+        .register_stellar_asset_contract_v2(Address::generate(&t.env))
+        .address();
+
+    t.client
+        .set_allowed_payout_recipient(&contract_recipient, &true)
+        .unwrap();
+    assert!(t.client.is_allowed_payout_recipient(&contract_recipient));
+
+    t.token_admin.mint(&t.contract_id, &10_000_000i128);
+    seed_approved_claim(&t, 3, &policy, Some(contract_recipient.clone()));
+
+    let before_events = t.env.events().all().events().len();
+    t.client.process_claim(&3u64);
+
+    assert_eq!(
+        token::Client::new(&t.env, &t.token).balance(&contract_recipient),
+        5_000_000i128,
+    );
+    assert!(t.env.events().all().events().len() > before_events);
+}

--- a/contracts/niffyinsure/tests/treasury_deposit.rs
+++ b/contracts/niffyinsure/tests/treasury_deposit.rs
@@ -1,0 +1,83 @@
+//! Treasury deposit allowlist tests.
+//!
+//! Covers:
+//! - Admin-managed depositor allowlist
+//! - Authorized capital injection succeeds and emits an event
+//! - Unauthorized depositor is rejected
+//! - Zero-amount deposits revert
+
+#![cfg(test)]
+
+use niffyinsure::NiffyInsureClient;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token, Address, Env,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(issuer).address();
+    client.initialize(&admin, &token);
+    (env, client, admin, token, cid)
+}
+
+#[test]
+fn authorized_treasury_deposit_succeeds_and_emits_event() {
+    let (env, client, _admin, token, contract_id) = setup();
+    let depositor = Address::generate(&env);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+
+    client.set_authorized_depositor(&depositor, &true).unwrap();
+    token_admin.mint(&depositor, &1_000_000i128);
+
+    let before_events = env.events().all().events().len();
+    let before_depositor_balance = token::Client::new(&env, &token).balance(&depositor);
+    let before_treasury_balance = token::Client::new(&env, &token).balance(&contract_id);
+
+    client.deposit_treasury(&depositor, &500_000i128, &token).unwrap();
+
+    assert_eq!(
+        token::Client::new(&env, &token).balance(&depositor),
+        before_depositor_balance - 500_000i128,
+    );
+    assert_eq!(
+        token::Client::new(&env, &token).balance(&contract_id),
+        before_treasury_balance + 500_000i128,
+    );
+    assert!(env.events().all().events().len() > before_events);
+    assert!(client.is_authorized_depositor(&depositor));
+}
+
+#[test]
+fn unauthorized_depositor_cannot_call_deposit_entrypoint() {
+    let (env, client, _admin, token, _contract_id) = setup();
+    let allowed = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+
+    client.set_authorized_depositor(&allowed, &true).unwrap();
+    token_admin.mint(&unauthorized, &1_000_000i128);
+
+    let result = client.try_deposit_treasury(&unauthorized, &500_000i128, &token);
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("UnauthorizedTreasuryDepositor"));
+}
+
+#[test]
+fn zero_amount_deposit_reverts() {
+    let (env, client, _admin, token, _contract_id) = setup();
+    let depositor = Address::generate(&env);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+
+    client.set_authorized_depositor(&depositor, &true).unwrap();
+    token_admin.mint(&depositor, &1_000_000i128);
+
+    let result = client.try_deposit_treasury(&depositor, &0i128, &token);
+    assert!(result.is_err());
+    assert!(format!("{:?}", result).contains("ZeroTreasuryDeposit"));
+}


### PR DESCRIPTION
closes #599
closes #605 
closes #606 
closes #610

Claim evidence updates before voting starts
Added add_claim_evidence(claim_id, new_urls) for the claimant
Blocks updates after the first vote
Validates evidence count and emits ClaimEvidenceUpdated
Returns updated evidence through get_claim
Treasury deposits
Added admin-managed authorized_depositors allowlist
Added deposit_treasury(amount, asset) with auth checks
Rejects zero-amount and unauthorized deposits
Emits TreasuryDeposited
IPFS hash verification
Computes SHA-256 on fetched evidence bytes
Compares fetched hash against the stored on-chain commitment
Returns verified and hashMismatch in the response DTO
Logs mismatches as security events
Payout recipient contract guard
Added admin-managed payout-recipient allowlist
Reverts payouts to non-allowlisted contract addresses
Emits PayoutRecipientWarning for allowed contract recipients