### PR TITLE
feat/solvency-claim-protocol-fee

### DIFF
--- a/backend/src/chain/chain.constants.ts
+++ b/backend/src/chain/chain.constants.ts
@@ -3,3 +3,9 @@
  * Keep in sync when changing the on-chain batch cap.
  */
 export const POLICY_BATCH_GET_MAX = 20;
+
+/**
+ * Must match `CLAIM_BATCH_GET_MAX` / `PAGE_SIZE_MAX` in contracts/niffyinsure.
+ * Keep in sync when changing the on-chain batch cap.
+ */
+export const CLAIM_BATCH_GET_MAX = 20;

--- a/backend/src/chain/chain.controller.ts
+++ b/backend/src/chain/chain.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, HttpCode, Post, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { SorobanService } from '../rpc/soroban.service';
 import { GetPoliciesBatchDto } from './dto/get-policies-batch.dto';
+import { GetClaimsBatchDto } from './dto/get-claims-batch.dto';
 
 @ApiTags('chain')
 @Controller('chain')
@@ -20,6 +21,23 @@ export class ChainController {
   ): Promise<{ results: (Record<string, unknown> | null)[] }> {
     const results = await this.soroban.simulateGetPoliciesBatch({
       keys: dto.keys.map((k) => ({ holder: k.holder, policy_id: k.policy_id })),
+      sourceAccount: dto.source_account,
+    });
+    return { results };
+  }
+
+  @Post('claims/batch')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Batch-read claims via Soroban simulation',
+    description:
+      'Invokes get_claims_batch in a single simulated transaction. Missing claims appear as null in the same positions as the request IDs. Over 20 IDs returns 400.',
+  })
+  async getClaimsBatch(
+    @Body() dto: GetClaimsBatchDto,
+  ): Promise<{ results: (Record<string, unknown> | null)[] }> {
+    const results = await this.soroban.simulateGetClaimsBatch({
+      ids: dto.ids,
       sourceAccount: dto.source_account,
     });
     return { results };

--- a/backend/src/chain/dto/get-claims-batch.dto.ts
+++ b/backend/src/chain/dto/get-claims-batch.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ArrayMaxSize, IsArray, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { CLAIM_BATCH_GET_MAX } from '../chain.constants';
+
+export class GetClaimsBatchDto {
+  @ApiProperty({
+    type: [Number],
+    maxItems: CLAIM_BATCH_GET_MAX,
+    description: `Up to ${CLAIM_BATCH_GET_MAX} claim IDs; order is preserved and missing claims return null.`,
+  })
+  @IsArray()
+  @ArrayMaxSize(CLAIM_BATCH_GET_MAX, {
+    message: `ids must contain at most ${CLAIM_BATCH_GET_MAX} entries (on-chain CLAIM_BATCH_GET_MAX)`,
+  })
+  @IsInt({ each: true })
+  @Min(1, { each: true })
+  ids!: number[];
+
+  @ApiPropertyOptional({
+    description: 'Account used as the Soroban transaction source for simulation.',
+  })
+  @IsOptional()
+  @IsString()
+  source_account?: string;
+}

--- a/backend/src/rpc/soroban.service.ts
+++ b/backend/src/rpc/soroban.service.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '@nestjs/config';
 import CircuitBreaker from 'opossum';
 import { MetricsService } from '../metrics/metrics.service';
 import { getNetworkConfig } from '../config/network.config';
-import { POLICY_BATCH_GET_MAX } from '../chain/chain.constants';
+import { CLAIM_BATCH_GET_MAX, POLICY_BATCH_GET_MAX } from '../chain/chain.constants';
 import {
   Account,
   BASE_FEE,
@@ -266,6 +266,16 @@ export class SorobanService implements OnModuleInit, OnModuleDestroy {
       e.includes('policy_batch') ||
       // ContractError tag 50 = PolicyBatchTooLarge
       /\b50\b/.test(error)
+    );
+  }
+
+  private isClaimBatchTooLargeSimulation(error: string): boolean {
+    const e = error.toLowerCase();
+    return (
+      e.includes('claimbatch') ||
+      e.includes('claim_batch') ||
+      // ContractError tag 60 = ClaimBatchTooLarge
+      /\b60\b/.test(error)
     );
   }
 
@@ -783,6 +793,99 @@ export class SorobanService implements OnModuleInit, OnModuleDestroy {
       throw new BadRequestException({
         code: 'SIMULATION_DECODE_FAILED',
         message: 'get_policies_batch: unexpected return shape from simulation.',
+      });
+    }
+
+    return native.map((entry: unknown) => {
+      if (entry === null || entry === undefined) {
+        return null;
+      }
+      if (typeof entry === 'object' && entry !== null) {
+        return entry as Record<string, unknown>;
+      }
+      return null;
+    });
+  }
+
+  /**
+   * Simulate `get_claims_batch(Vec<u64>)` -> `Vec<Option<Claim>>`.
+   * One RPC round-trip for claims-board bulk dashboard loads; order matches `ids`.
+   */
+  async simulateGetClaimsBatch(args: {
+    ids: number[];
+    sourceAccount?: string;
+  }): Promise<(Record<string, unknown> | null)[]> {
+    return this.trackRpc('simulate_get_claims_batch', () =>
+      this._simulateGetClaimsBatch(args),
+    );
+  }
+
+  private async _simulateGetClaimsBatch(args: {
+    ids: number[];
+    sourceAccount?: string;
+  }): Promise<(Record<string, unknown> | null)[]> {
+    if (!this.contractId) {
+      throw new BadRequestException({
+        code: 'CONTRACT_NOT_INITIALIZED',
+        message:
+          'CONTRACT_ID is not configured on the server; cannot simulate get_claims_batch.',
+      });
+    }
+    if (args.ids.length > CLAIM_BATCH_GET_MAX) {
+      throw new BadRequestException({
+        code: 'CLAIM_BATCH_TOO_LARGE',
+        message: `At most ${CLAIM_BATCH_GET_MAX} claim IDs per batch (on-chain CLAIM_BATCH_GET_MAX).`,
+      });
+    }
+    if (args.ids.length === 0) {
+      return [];
+    }
+    if (!args.sourceAccount) {
+      throw new BadRequestException({
+        code: 'SOURCE_ACCOUNT_REQUIRED',
+        message: 'source_account is required when simulating a non-empty claim batch.',
+      });
+    }
+
+    const server = this.makeServer();
+    const account = await this.loadAccount(server, args.sourceAccount);
+    const contract = new Contract(this.contractId);
+    const idsScVal = xdr.ScVal.scvVec(
+      args.ids.map((id) => nativeToScVal(id, { type: 'u64' })),
+    );
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call('get_claims_batch', idsScVal))
+      .setTimeout(30)
+      .build();
+
+    const simulation = await server.simulateTransaction(tx);
+    if (Api.isSimulationError(simulation)) {
+      const err = simulation as SorobanRpc.Api.SimulateTransactionErrorResponse;
+      if (this.isClaimBatchTooLargeSimulation(err.error)) {
+        throw new BadRequestException({
+          code: 'CLAIM_BATCH_TOO_LARGE',
+          message: `At most ${CLAIM_BATCH_GET_MAX} claim IDs per batch (on-chain CLAIM_BATCH_GET_MAX).`,
+        });
+      }
+      this.mapSimulationError(err.error);
+    }
+
+    const success =
+      simulation as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+    const retval = success.result?.retval;
+    if (!retval) {
+      return [];
+    }
+
+    const native = scValToNative(retval) as unknown;
+    if (!Array.isArray(native)) {
+      throw new BadRequestException({
+        code: 'SIMULATION_DECODE_FAILED',
+        message: 'get_claims_batch: unexpected return shape from simulation.',
       });
     }
 

--- a/contracts/niffyinsure/src/claim.rs
+++ b/contracts/niffyinsure/src/claim.rs
@@ -451,6 +451,11 @@ pub fn vote_on_claim(
         return Err(Error::NotEligibleVoter);
     }
 
+    let resolved_target = storage::resolve_vote_delegation_target(env, voter, now)?;
+    if resolved_target != *voter {
+        return Err(Error::VoteDelegated);
+    }
+
     // Duplicate vote check — before any write.
     if storage::get_vote(env, claim_id, voter).is_some() {
         return Err(Error::DuplicateVote);
@@ -459,10 +464,11 @@ pub fn vote_on_claim(
     storage::set_vote(env, claim_id, voter, vote);
 
     let status_before = claim.status.clone();
+    let vote_weight = storage::delegated_vote_weight(env, claim_id, voter, now)?;
 
     match vote {
-        VoteOption::Approve => claim.approve_votes += 1,
-        VoteOption::Reject => claim.reject_votes += 1,
+        VoteOption::Approve => claim.approve_votes += vote_weight,
+        VoteOption::Reject => claim.reject_votes += vote_weight,
     }
 
     let eligible = claim.eligible_voter_count;

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -250,6 +250,7 @@ impl NiffyInsure {
             57 => validate::Error::CircularDelegation,
             58 => validate::Error::ProtocolFeeOutOfBounds,
             59 => validate::Error::SolvencyRatioOutOfBounds,
+            60 => validate::Error::ClaimBatchTooLarge,
             _ => validate::Error::ClaimNotApproved,
         };
         policy::map_quote_error(&env, err)
@@ -539,6 +540,21 @@ impl NiffyInsure {
 
     pub fn get_claim(env: Env, claim_id: u64) -> Result<types::Claim, validate::Error> {
         claim::get_claim(&env, claim_id)
+    }
+
+    /// Batch-read claims in one simulation/RPC round-trip.
+    ///
+    /// Returns positions aligned with `ids`, using `None` for missing claim IDs.
+    /// More than `CLAIM_BATCH_GET_MAX` IDs reverts before any storage reads.
+    pub fn get_claims_batch(env: Env, ids: Vec<u64>) -> Vec<Option<types::Claim>> {
+        if ids.len() > types::CLAIM_BATCH_GET_MAX {
+            panic_with_error!(&env, validate::Error::ClaimBatchTooLarge);
+        }
+        let mut out: Vec<Option<types::Claim>> = Vec::new(&env);
+        for id in ids.iter() {
+            out.push_back(storage::get_claim(&env, id));
+        }
+        out
     }
 
     pub fn get_claim_counter(env: Env) -> u64 {

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -60,6 +60,20 @@ struct QuorumUpdated {
     pub new_bps: u32,
 }
 
+#[contractevent(topics = ["niffyinsure", "protocol_fee_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ProtocolFeeUpdated {
+    pub old_bps: u32,
+    pub new_bps: u32,
+}
+
+#[contractevent(topics = ["niffyinsure", "fee_recipient_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FeeRecipientUpdated {
+    pub old_recipient: Address,
+    pub new_recipient: Address,
+}
+
 #[contractevent(topics = ["niffyinsure", "pause_toggled"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PauseToggled {
@@ -85,6 +99,8 @@ impl NiffyInsure {
         storage::set_token(&env, &token);
         storage::set_multiplier_table(&env, &premium::default_multiplier_table(&env));
         storage::set_allowed_asset(&env, &token, true);
+        storage::set_protocol_fee_bps(&env, 0);
+        storage::set_fee_recipient(&env, &env.current_contract_address());
         storage::set_voting_duration_ledgers(&env, ledger::VOTE_WINDOW_LEDGERS);
         storage::set_quorum_bps(&env, types::DEFAULT_QUORUM_BPS);
         Ok(())
@@ -111,6 +127,14 @@ impl NiffyInsure {
     pub fn get_treasury_balance(env: Env) -> i128 {
         let token_addr = storage::get_token(&env);
         crate::token::get_treasury_balance(&env, &token_addr)
+    }
+
+    pub fn get_protocol_fee_bps(env: Env) -> u32 {
+        storage::get_protocol_fee_bps(&env)
+    }
+
+    pub fn get_fee_recipient(env: Env) -> Address {
+        storage::get_fee_recipient(&env)
     }
 
     /// Pure quote path: reads config and computes premium only.
@@ -207,6 +231,7 @@ impl NiffyInsure {
             55 => validate::Error::PayoutDeadlineNotReached,
             56 => validate::Error::VoteDelegated,
             57 => validate::Error::CircularDelegation,
+            58 => validate::Error::ProtocolFeeOutOfBounds,
             _ => validate::Error::ClaimNotApproved,
         };
         policy::map_quote_error(&env, err)
@@ -423,6 +448,35 @@ impl NiffyInsure {
         QuorumUpdated {
             old_bps: old,
             new_bps: quorum_bps,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn admin_set_protocol_fee_bps(env: Env, fee_bps: u32) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        storage::bump_instance(&env);
+        validate::validate_protocol_fee_bps(fee_bps)?;
+        let old = storage::get_protocol_fee_bps(&env);
+        storage::set_protocol_fee_bps(&env, fee_bps);
+        ProtocolFeeUpdated {
+            old_bps: old,
+            new_bps: fee_bps,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn admin_set_fee_recipient(env: Env, recipient: Address) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        storage::bump_instance(&env);
+        let old = storage::get_fee_recipient(&env);
+        storage::set_fee_recipient(&env, &recipient);
+        FeeRecipientUpdated {
+            old_recipient: old,
+            new_recipient: recipient,
         }
         .publish(&env);
         Ok(())

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -205,6 +205,8 @@ impl NiffyInsure {
             53 => validate::Error::ClaimNotProcessing,
             54 => validate::Error::RollingClaimCapExceeded,
             55 => validate::Error::PayoutDeadlineNotReached,
+            56 => validate::Error::VoteDelegated,
+            57 => validate::Error::CircularDelegation,
             _ => validate::Error::ClaimNotApproved,
         };
         policy::map_quote_error(&env, err)
@@ -315,6 +317,45 @@ impl NiffyInsure {
     ) -> Result<types::ClaimStatus, validate::Error> {
         voter.require_auth();
         claim::vote_on_claim(&env, &voter, claim_id, &vote)
+    }
+
+    /// Holder-authenticated delegation of vote weight to another address.
+    ///
+    /// Delegations are checked against the current ledger and expire at
+    /// `expiry_ledger` inclusively.
+    pub fn delegate_vote(
+        env: Env,
+        delegator: Address,
+        delegate: Address,
+        expiry_ledger: u32,
+    ) -> Result<(), validate::Error> {
+        delegator.require_auth();
+        storage::bump_instance(&env);
+
+        if delegator == delegate {
+            return Err(validate::Error::CircularDelegation);
+        }
+
+        let now = env.ledger().sequence();
+        let resolved_target = storage::resolve_vote_delegation_target(&env, &delegate, now)?;
+        if resolved_target == delegator {
+            return Err(validate::Error::CircularDelegation);
+        }
+
+        storage::set_vote_delegation(
+            &env,
+            &delegator,
+            &types::VoteDelegation {
+                delegate,
+                expiry_ledger,
+            },
+        );
+        Ok(())
+    }
+
+    /// Read-only: current delegation binding for a holder, if any.
+    pub fn get_vote_delegation(env: Env, delegator: Address) -> Option<types::VoteDelegation> {
+        storage::get_vote_delegation(&env, &delegator)
     }
 
     /// Permissionless keeper hook: bump persistent TTL for the claim voter snapshot.

--- a/contracts/niffyinsure/src/lib.rs
+++ b/contracts/niffyinsure/src/lib.rs
@@ -74,6 +74,13 @@ struct FeeRecipientUpdated {
     pub new_recipient: Address,
 }
 
+#[contractevent(topics = ["niffyinsure", "min_solvency_ratio_updated"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MinSolvencyRatioUpdated {
+    pub old_bps: u32,
+    pub new_bps: u32,
+}
+
 #[contractevent(topics = ["niffyinsure", "pause_toggled"])]
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PauseToggled {
@@ -101,6 +108,7 @@ impl NiffyInsure {
         storage::set_allowed_asset(&env, &token, true);
         storage::set_protocol_fee_bps(&env, 0);
         storage::set_fee_recipient(&env, &env.current_contract_address());
+        storage::set_min_solvency_ratio_bps(&env, 0);
         storage::set_voting_duration_ledgers(&env, ledger::VOTE_WINDOW_LEDGERS);
         storage::set_quorum_bps(&env, types::DEFAULT_QUORUM_BPS);
         Ok(())
@@ -135,6 +143,15 @@ impl NiffyInsure {
 
     pub fn get_fee_recipient(env: Env) -> Address {
         storage::get_fee_recipient(&env)
+    }
+
+    pub fn get_min_solvency_ratio_bps(env: Env) -> u32 {
+        storage::get_min_solvency_ratio_bps(&env)
+    }
+
+    pub fn check_solvency_ratio(env: Env, new_coverage: i128) -> bool {
+        let token_addr = storage::get_token(&env);
+        policy::check_solvency_ratio(&env, &token_addr, new_coverage)
     }
 
     /// Pure quote path: reads config and computes premium only.
@@ -232,6 +249,7 @@ impl NiffyInsure {
             56 => validate::Error::VoteDelegated,
             57 => validate::Error::CircularDelegation,
             58 => validate::Error::ProtocolFeeOutOfBounds,
+            59 => validate::Error::SolvencyRatioOutOfBounds,
             _ => validate::Error::ClaimNotApproved,
         };
         policy::map_quote_error(&env, err)
@@ -477,6 +495,24 @@ impl NiffyInsure {
         FeeRecipientUpdated {
             old_recipient: old,
             new_recipient: recipient,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn admin_set_min_solvency_ratio_bps(
+        env: Env,
+        ratio_bps: u32,
+    ) -> Result<(), validate::Error> {
+        let admin = storage::get_admin(&env);
+        admin.require_auth();
+        storage::bump_instance(&env);
+        validate::validate_min_solvency_ratio_bps(ratio_bps)?;
+        let old = storage::get_min_solvency_ratio_bps(&env);
+        storage::set_min_solvency_ratio_bps(&env, ratio_bps);
+        MinSolvencyRatioUpdated {
+            old_bps: old,
+            new_bps: ratio_bps,
         }
         .publish(&env);
         Ok(())

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -271,6 +271,7 @@ pub fn map_quote_error(env: &Env, err: Error) -> QuoteFailure {
         Error::SolvencyRatioOutOfBounds => {
             "minimum solvency ratio basis points outside documented bounds"
         },
+        Error::ClaimBatchTooLarge => "claim batch exceeds maximum allowed IDs per call",
     };
     QuoteFailure {
         code: err as u32,

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -250,6 +250,8 @@ pub fn map_quote_error(env: &Env, err: Error) -> QuoteFailure {
         Error::PayoutDeadlineNotReached => {
             "payout timeout is not yet due: the approved claim must wait for its deadline to pass"
         },
+        Error::VoteDelegated => "direct vote rejected because the caller has an active delegation",
+        Error::CircularDelegation => "delegation would create a cycle",
     };
     QuoteFailure {
         code: err as u32,

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -86,6 +86,17 @@ pub struct PolicyInitiated {
     pub end_ledger: u32,
 }
 
+/// Emitted when a protocol fee is collected from a premium payment.
+#[contractevent(topics = ["niffyinsure", "protocol_fee_collected"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolFeeCollected {
+    #[topic]
+    pub policy_id: u32,
+    pub version: u32,
+    pub fee_amount: i128,
+    pub recipient: Address,
+}
+
 /// Emitted when the payout beneficiary is set or changed (including at policy initiation when non-empty).
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -252,6 +263,9 @@ pub fn map_quote_error(env: &Env, err: Error) -> QuoteFailure {
         },
         Error::VoteDelegated => "direct vote rejected because the caller has an active delegation",
         Error::CircularDelegation => "delegation would create a cycle",
+        Error::ProtocolFeeOutOfBounds => {
+            "protocol fee basis points exceed the configured maximum"
+        },
     };
     QuoteFailure {
         code: err as u32,
@@ -332,6 +346,20 @@ pub fn initiate_policy(
         return Err(PolicyError::InvalidPremium);
     }
 
+    let fee_bps = storage::get_protocol_fee_bps(env);
+    let fee_recipient = storage::get_fee_recipient(env);
+    let fee_amount = if fee_bps == 0 {
+        0
+    } else {
+        premium_amount
+            .checked_mul(fee_bps as i128)
+            .ok_or(PolicyError::PremiumOverflow)?
+            / 10_000
+    };
+    let treasury_amount = premium_amount
+        .checked_sub(fee_amount)
+        .ok_or(PolicyError::PremiumOverflow)?;
+
     // Allocate unique per-holder policy_id.
     let policy_id = storage::next_policy_id(env, &holder);
 
@@ -339,9 +367,16 @@ pub fn initiate_policy(
         return Err(PolicyError::DuplicatePolicyId);
     }
 
-    // Premium transfer: holder -> treasury using the policy's bound asset.
+    // Premium transfer: holder -> treasury and fee recipient using the policy's bound asset.
     // Done BEFORE any durable writes so failure leaves no partial state.
-    token::collect_premium(env, &holder, &asset, premium_amount);
+    token::collect_premium_with_fee(
+        env,
+        &holder,
+        &asset,
+        treasury_amount,
+        &fee_recipient,
+        fee_amount,
+    );
 
     let current_ledger = env.ledger().sequence();
     let end_ledger = current_ledger
@@ -371,6 +406,16 @@ pub fn initiate_policy(
 
     storage::set_policy(env, &holder, policy_id, &policy);
     storage::add_voter(env, &holder);
+
+    if fee_amount > 0 {
+        ProtocolFeeCollected {
+            policy_id,
+            version: POLICY_EVENT_VERSION,
+            fee_amount,
+            recipient: fee_recipient.clone(),
+        }
+        .publish(env);
+    }
 
     PolicyInitiated {
         version: POLICY_EVENT_VERSION,

--- a/contracts/niffyinsure/src/policy.rs
+++ b/contracts/niffyinsure/src/policy.rs
@@ -58,6 +58,8 @@ pub enum PolicyError {
     Expired = 118,
     /// Supplied `expected_nonce` does not match the holder's current on-chain nonce.
     NonceMismatch = 119,
+    /// Treasury solvency ratio is below the admin-configured threshold.
+    InsufficientSolvency = 121,
 }
 
 #[contracttype]
@@ -266,11 +268,42 @@ pub fn map_quote_error(env: &Env, err: Error) -> QuoteFailure {
         Error::ProtocolFeeOutOfBounds => {
             "protocol fee basis points exceed the configured maximum"
         },
+        Error::SolvencyRatioOutOfBounds => {
+            "minimum solvency ratio basis points outside documented bounds"
+        },
     };
     QuoteFailure {
         code: err as u32,
         message: String::from_str(env, message),
     }
+}
+
+/// Returns true when treasury balance covers approved obligations plus `new_coverage`
+/// at or above the configured minimum solvency ratio.
+pub fn check_solvency_ratio(env: &Env, asset: &Address, new_coverage: i128) -> bool {
+    let min_ratio_bps = storage::get_min_solvency_ratio_bps(env);
+    if min_ratio_bps == 0 {
+        return true;
+    }
+    if new_coverage < 0 {
+        return false;
+    }
+
+    let obligations = storage::outstanding_approved_claim_obligations(env, asset)
+        .saturating_add(new_coverage);
+    if obligations <= 0 {
+        return true;
+    }
+
+    let balance = token::get_treasury_balance(env, asset);
+    if balance < 0 {
+        return false;
+    }
+
+    let Some(numerator) = balance.checked_mul(10_000) else {
+        return true;
+    };
+    numerator / obligations >= min_ratio_bps as i128
 }
 
 /// Turns an accepted quote into an enforceable on-chain policy.
@@ -320,6 +353,9 @@ pub fn initiate_policy(
     }
     if base_amount <= 0 {
         return Err(PolicyError::InvalidCoverage);
+    }
+    if !check_solvency_ratio(env, &asset, base_amount) {
+        return Err(PolicyError::InsufficientSolvency);
     }
 
     let deductible_stored = match deductible {

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -72,6 +72,10 @@ pub enum DataKey {
     Token,
     /// Address where collected premiums are sent.
     Treasury,
+    /// Basis-point protocol fee deducted from each premium payment.
+    ProtocolFeeBps,
+    /// Address receiving the protocol fee portion of premiums.
+    FeeRecipient,
     PremiumTable,
     CalcAddress,
     /// Boolean allowlist flag per asset contract address.
@@ -291,6 +295,30 @@ pub fn get_treasury(env: &Env) -> Address {
     env.storage()
         .instance()
         .get(&DataKey::Treasury)
+        .unwrap_or_else(|| env.current_contract_address())
+}
+
+// ── Protocol fee config (instance) ───────────────────────────────────────────
+
+pub fn set_protocol_fee_bps(env: &Env, bps: u32) {
+    env.storage().instance().set(&DataKey::ProtocolFeeBps, &bps);
+}
+
+pub fn get_protocol_fee_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProtocolFeeBps)
+        .unwrap_or(0)
+}
+
+pub fn set_fee_recipient(env: &Env, recipient: &Address) {
+    env.storage().instance().set(&DataKey::FeeRecipient, recipient);
+}
+
+pub fn get_fee_recipient(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::FeeRecipient)
         .unwrap_or_else(|| env.current_contract_address())
 }
 

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -1,7 +1,9 @@
-use soroban_sdk::{contracttype, Address, Env, Vec};
+use soroban_sdk::{contracttype, Address, Env, Map, Vec};
 
 use crate::ledger;
-use crate::types::{Claim, MultiplierTable, Policy, RollingClaimWindowState, VoteOption};
+use crate::types::{
+    Claim, MultiplierTable, Policy, RollingClaimWindowState, VoteDelegation, VoteOption,
+};
 
 // ── TTL constants ─────────────────────────────────────────────────────────────
 ///
@@ -114,6 +116,8 @@ pub enum DataKey {
     OpenClaim(Address, u32),
     /// (claim_id, voter_address) -> VoteOption; immutable after first write
     Vote(u64, Address),
+    /// Delegator -> active vote delegation binding.
+    VoteDelegations,
     /// Snapshot of eligible voters captured at claim-filing time.
     ClaimVoters(u64),
     /// Last ledger at which `holder` filed a claim (rate-limit anchor).
@@ -651,6 +655,87 @@ pub fn get_vote(env: &Env, claim_id: u64, voter: &Address) -> Option<VoteOption>
     env.storage()
         .persistent()
         .get(&DataKey::Vote(claim_id, voter.clone()))
+}
+
+// ── Vote delegations (instance) ───────────────────────────────────────────────
+
+pub fn get_vote_delegations(env: &Env) -> Map<Address, VoteDelegation> {
+    env.storage()
+        .instance()
+        .get(&DataKey::VoteDelegations)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+pub fn set_vote_delegations(env: &Env, delegations: &Map<Address, VoteDelegation>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::VoteDelegations, delegations);
+}
+
+pub fn get_vote_delegation(env: &Env, delegator: &Address) -> Option<VoteDelegation> {
+    get_vote_delegations(env).get(delegator.clone())
+}
+
+pub fn set_vote_delegation(env: &Env, delegator: &Address, delegation: &VoteDelegation) {
+    let mut delegations = get_vote_delegations(env);
+    delegations.set(delegator.clone(), delegation.clone());
+    set_vote_delegations(env, &delegations);
+}
+
+pub fn remove_vote_delegation(env: &Env, delegator: &Address) {
+    let mut delegations = get_vote_delegations(env);
+    if delegations.remove(delegator.clone()).is_some() {
+        set_vote_delegations(env, &delegations);
+    }
+}
+
+pub fn has_active_vote_delegation(env: &Env, delegator: &Address, now: u32) -> bool {
+    get_vote_delegation(env, delegator)
+        .map(|delegation| delegation.expiry_ledger >= now)
+        .unwrap_or(false)
+}
+
+pub fn resolve_vote_delegation_target(
+    env: &Env,
+    start: &Address,
+    now: u32,
+) -> Result<Address, crate::validate::Error> {
+    let mut current = start.clone();
+    let mut seen: Vec<Address> = Vec::new(env);
+
+    loop {
+        if seen.iter().any(|addr| addr == current) {
+            return Err(crate::validate::Error::CircularDelegation);
+        }
+        seen.push_back(current.clone());
+
+        let Some(delegation) = get_vote_delegation(env, &current) else {
+            return Ok(current);
+        };
+
+        if delegation.expiry_ledger < now {
+            return Ok(current);
+        }
+
+        current = delegation.delegate;
+    }
+}
+
+pub fn delegated_vote_weight(
+    env: &Env,
+    claim_id: u64,
+    target: &Address,
+    now: u32,
+) -> Result<u32, crate::validate::Error> {
+    let voters = get_claim_voters(env, claim_id);
+    let mut total: u32 = 0;
+    for voter in voters.iter() {
+        let resolved = resolve_vote_delegation_target(env, &voter, now)?;
+        if resolved == *target {
+            total = total.saturating_add(get_active_policy_count(env, &voter));
+        }
+    }
+    Ok(total)
 }
 
 // ── Claim voters snapshot (persistent) ───────────────────────────────────────

--- a/contracts/niffyinsure/src/storage.rs
+++ b/contracts/niffyinsure/src/storage.rs
@@ -76,6 +76,8 @@ pub enum DataKey {
     ProtocolFeeBps,
     /// Address receiving the protocol fee portion of premiums.
     FeeRecipient,
+    /// Minimum treasury solvency ratio required before binding new policies.
+    MinSolvencyRatioBps,
     PremiumTable,
     CalcAddress,
     /// Boolean allowlist flag per asset contract address.
@@ -320,6 +322,39 @@ pub fn get_fee_recipient(env: &Env) -> Address {
         .instance()
         .get(&DataKey::FeeRecipient)
         .unwrap_or_else(|| env.current_contract_address())
+}
+
+// ── Solvency config (instance) ───────────────────────────────────────────────
+
+pub fn set_min_solvency_ratio_bps(env: &Env, bps: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MinSolvencyRatioBps, &bps);
+}
+
+pub fn get_min_solvency_ratio_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinSolvencyRatioBps)
+        .unwrap_or(0)
+}
+
+pub fn outstanding_approved_claim_obligations(env: &Env, asset: &Address) -> i128 {
+    let claim_counter = get_claim_counter(env);
+    let mut total: i128 = 0;
+
+    for claim_id in 1..=claim_counter {
+        if let Some(claim) = get_claim(env, claim_id) {
+            if claim.status == crate::types::ClaimStatus::Approved && claim.asset == *asset {
+                let net = claim.amount.saturating_sub(claim.deductible);
+                if net > 0 {
+                    total = total.saturating_add(net);
+                }
+            }
+        }
+    }
+
+    total
 }
 
 // ── Governance: claim voting duration (instance) ─────────────────────────────

--- a/contracts/niffyinsure/src/token.rs
+++ b/contracts/niffyinsure/src/token.rs
@@ -18,6 +18,26 @@ pub fn collect_premium(env: &Env, from: &Address, asset: &Address, amount: i128)
     client.transfer_from(&env.current_contract_address(), from, &treasury, &amount);
 }
 
+/// Collect a premium and split it between treasury and protocol fee recipient.
+pub fn collect_premium_with_fee(
+    env: &Env,
+    from: &Address,
+    asset: &Address,
+    treasury_amount: i128,
+    fee_recipient: &Address,
+    fee_amount: i128,
+) {
+    let client = token::TokenClient::new(env, asset);
+    let spender = &env.current_contract_address();
+    let treasury = storage::get_treasury(env);
+    if treasury_amount > 0 {
+        client.transfer_from(spender, from, &treasury, &treasury_amount);
+    }
+    if fee_amount > 0 {
+        client.transfer_from(spender, from, fee_recipient, &fee_amount);
+    }
+}
+
 /// Transfer `amount` of the contract's default treasury token from this contract to `to`.
 /// Used for admin drain operations.
 pub fn transfer_from_contract(env: &Env, to: &Address, amount: i128) {

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -71,6 +71,9 @@ pub const QUORUM_BPS_MAX: u32 = 10_000;
 /// One full turn-out / 100% weight in bps (used in the quorum formula below).
 pub const QUORUM_BPS_DENOMINATOR: u32 = 10_000;
 
+/// Absolute maximum protocol fee in basis points.
+pub const PROTOCOL_FEE_BPS_MAX: u32 = 1_000;
+
 // ── Enums ─────────────────────────────────────────────────────────────────────
 
 #[contracttype]

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -314,6 +314,12 @@ pub const PAGE_SIZE_MAX: u32 = 20;
 /// `limit`), an over-cap batch **reverts** so callers chunk explicitly.
 pub const POLICY_BATCH_GET_MAX: u32 = PAGE_SIZE_MAX;
 
+/// Maximum claim IDs in a single `get_claims_batch` call.
+///
+/// This intentionally matches [`PAGE_SIZE_MAX`] so dashboard simulations can
+/// bulk-load claims without unbounded metered storage reads.
+pub const CLAIM_BATCH_GET_MAX: u32 = PAGE_SIZE_MAX;
+
 /// Key for batched policy reads (`get_policies_batch`).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -240,6 +240,14 @@ pub enum VoteOption {
     Reject,
 }
 
+/// Active vote delegation binding for a holder.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VoteDelegation {
+    pub delegate: Address,
+    pub expiry_ledger: u32,
+}
+
 /// Reason for policy termination.
 ///
 /// GOVERNANCE NOTE: `ExcessiveRejections` is set by the claims engine

--- a/contracts/niffyinsure/src/types.rs
+++ b/contracts/niffyinsure/src/types.rs
@@ -74,6 +74,10 @@ pub const QUORUM_BPS_DENOMINATOR: u32 = 10_000;
 /// Absolute maximum protocol fee in basis points.
 pub const PROTOCOL_FEE_BPS_MAX: u32 = 1_000;
 
+/// Solvency threshold bounds in basis points. `100_000` = 1,000%.
+pub const MIN_SOLVENCY_RATIO_BPS_MIN: u32 = 0;
+pub const MIN_SOLVENCY_RATIO_BPS_MAX: u32 = 100_000;
+
 // ── Enums ─────────────────────────────────────────────────────────────────────
 
 #[contracttype]

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -75,6 +75,8 @@ pub enum Error {
     VoteDelegated = 56,
     /// Delegation would create a cycle in the vote-delegation graph.
     CircularDelegation = 57,
+    /// Protocol fee basis points exceed the configured absolute maximum.
+    ProtocolFeeOutOfBounds = 58,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {
@@ -82,6 +84,14 @@ pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {
     if !(QUORUM_BPS_MIN..=QUORUM_BPS_MAX).contains(&bps) {
         // Reuse bounded-config error code (Soroban `contracterror` caps variant count).
         return Err(Error::VotingDurationOutOfBounds);
+    }
+    Ok(())
+}
+
+pub fn validate_protocol_fee_bps(bps: u32) -> Result<(), Error> {
+    use crate::types::PROTOCOL_FEE_BPS_MAX;
+    if bps > PROTOCOL_FEE_BPS_MAX {
+        return Err(Error::ProtocolFeeOutOfBounds);
     }
     Ok(())
 }

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -71,6 +71,10 @@ pub enum Error {
     RollingClaimCapExceeded = 54,
     /// Keeper `process_payout_timeout` called before the approved payout deadline elapsed.
     PayoutDeadlineNotReached = 55,
+    /// Caller attempted to vote directly while an active delegation is in force.
+    VoteDelegated = 56,
+    /// Delegation would create a cycle in the vote-delegation graph.
+    CircularDelegation = 57,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -79,6 +79,8 @@ pub enum Error {
     ProtocolFeeOutOfBounds = 58,
     /// Minimum solvency ratio basis points outside documented bounds.
     SolvencyRatioOutOfBounds = 59,
+    /// Batch get exceeded CLAIM_BATCH_GET_MAX.
+    ClaimBatchTooLarge = 60,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {

--- a/contracts/niffyinsure/src/validate.rs
+++ b/contracts/niffyinsure/src/validate.rs
@@ -77,6 +77,8 @@ pub enum Error {
     CircularDelegation = 57,
     /// Protocol fee basis points exceed the configured absolute maximum.
     ProtocolFeeOutOfBounds = 58,
+    /// Minimum solvency ratio basis points outside documented bounds.
+    SolvencyRatioOutOfBounds = 59,
 }
 
 pub fn validate_quorum_bps(bps: u32) -> Result<(), Error> {
@@ -92,6 +94,14 @@ pub fn validate_protocol_fee_bps(bps: u32) -> Result<(), Error> {
     use crate::types::PROTOCOL_FEE_BPS_MAX;
     if bps > PROTOCOL_FEE_BPS_MAX {
         return Err(Error::ProtocolFeeOutOfBounds);
+    }
+    Ok(())
+}
+
+pub fn validate_min_solvency_ratio_bps(bps: u32) -> Result<(), Error> {
+    use crate::types::{MIN_SOLVENCY_RATIO_BPS_MAX, MIN_SOLVENCY_RATIO_BPS_MIN};
+    if !(MIN_SOLVENCY_RATIO_BPS_MIN..=MIN_SOLVENCY_RATIO_BPS_MAX).contains(&bps) {
+        return Err(Error::SolvencyRatioOutOfBounds);
     }
     Ok(())
 }

--- a/contracts/niffyinsure/tests/delegation.rs
+++ b/contracts/niffyinsure/tests/delegation.rs
@@ -1,0 +1,121 @@
+//! Vote delegation integration tests.
+
+#![cfg(test)]
+
+mod common;
+
+use niffyinsure::{
+    types::{ClaimStatus, VoteOption, VOTE_WINDOW_LEDGERS},
+    validate::Error as ValidateError,
+    NiffyInsureClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+fn seed(client: &NiffyInsureClient, holder: &Address, coverage: i128, end_ledger: u32) {
+    client.test_seed_policy(holder, &1u32, &coverage, &end_ledger);
+}
+
+fn file(client: &NiffyInsureClient, holder: &Address, amount: i128, env: &Env) -> u64 {
+    let details = String::from_str(env, "delegation test");
+    let ev = common::empty_evidence(env);
+    client.file_claim(holder, &1u32, &amount, &details, &ev, &None)
+}
+
+#[test]
+fn delegated_vote_carries_combined_weight() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+
+    seed(&client, &claimant, 1_000_000, 10_000);
+    seed(&client, &delegator, 1_000_000, 10_000);
+    seed(&client, &delegate, 1_000_000, 10_000);
+
+    let claim_id = file(&client, &claimant, 100_000, &env);
+    client.delegate_vote(&delegator, &delegate, &200);
+
+    client.vote_on_claim(&delegate, &claim_id, &VoteOption::Approve);
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.approve_votes, 2);
+    assert_eq!(claim.status, ClaimStatus::Approved);
+}
+
+#[test]
+fn direct_vote_while_delegated_reverts() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+
+    seed(&client, &claimant, 1_000_000, 10_000);
+    seed(&client, &delegator, 1_000_000, 10_000);
+    seed(&client, &delegate, 1_000_000, 10_000);
+
+    let claim_id = file(&client, &claimant, 100_000, &env);
+    client.delegate_vote(&delegator, &delegate, &200);
+
+    let err = client
+        .try_vote_on_claim(&delegator, &claim_id, &VoteOption::Approve)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, ValidateError::VoteDelegated.into());
+}
+
+#[test]
+fn circular_delegation_attempt_reverts() {
+    let (env, client, _, _) = setup();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    seed(&client, &a, 1_000_000, 10_000);
+    seed(&client, &b, 1_000_000, 10_000);
+
+    client.delegate_vote(&a, &b, &200);
+    let err = client.try_delegate_vote(&b, &a, &200).err().unwrap().unwrap();
+    assert_eq!(err, ValidateError::CircularDelegation.into());
+}
+
+#[test]
+fn delegation_expires_and_direct_vote_resumes() {
+    let (env, client, _, _) = setup();
+    let claimant = Address::generate(&env);
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+
+    seed(&client, &claimant, 1_000_000, 10_000);
+    seed(&client, &delegator, 1_000_000, 10_000);
+    seed(&client, &delegate, 1_000_000, 10_000);
+
+    let claim_id = file(&client, &claimant, 100_000, &env);
+    let expiry = env.ledger().sequence() + 1;
+    client.delegate_vote(&delegator, &delegate, &expiry);
+
+    env.ledger().with_mut(|l| l.sequence_number = expiry + 1);
+    client.vote_on_claim(&delegator, &claim_id, &VoteOption::Approve);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.approve_votes, 1);
+    assert_eq!(claim.status, ClaimStatus::Processing);
+
+    env.ledger()
+        .with_mut(|l| l.sequence_number += VOTE_WINDOW_LEDGERS + 1);
+    client.finalize_claim(&claim_id);
+    assert_eq!(client.get_claim(&claim_id).status, ClaimStatus::Approved);
+}

--- a/contracts/niffyinsure/tests/get_claims_batch.rs
+++ b/contracts/niffyinsure/tests/get_claims_batch.rs
@@ -1,0 +1,113 @@
+#![cfg(test)]
+
+mod common;
+
+use niffyinsure::{
+    storage,
+    types::{
+        Claim, ClaimStatus, ClaimStatusHistoryEntry, CLAIM_BATCH_GET_MAX,
+    },
+    validate::Error as ValidateError,
+    NiffyInsureClient,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, client, token)
+}
+
+fn seed_claim(env: &Env, client: &NiffyInsureClient<'_>, token: &Address, claim_id: u64) {
+    let claimant = Address::generate(env);
+    let claim = Claim {
+        claim_id,
+        policy_id: 1,
+        claimant,
+        amount: 100_000,
+        deductible: 0,
+        asset: token.clone(),
+        details: String::from_str(env, "batch claim"),
+        evidence: common::empty_evidence(env),
+        status: ClaimStatus::Processing,
+        voting_deadline_ledger: 10_000,
+        payout_deadline_ledger: 0,
+        approve_votes: 0,
+        reject_votes: 0,
+        filed_at: 1,
+        eligible_voter_count: 0,
+        appeal_open_deadline_ledger: 0,
+        appeals_count: 0,
+        appeal_deadline_ledger: 0,
+        appeal_approve_votes: 0,
+        appeal_reject_votes: 0,
+        status_history: Vec::<ClaimStatusHistoryEntry>::new(env),
+    };
+
+    env.as_contract(&client.address, || {
+        storage::set_claim(env, &claim);
+    });
+}
+
+#[test]
+fn get_claims_batch_empty_input() {
+    let (env, client, _) = setup();
+    let ids = Vec::new(&env);
+    let out = client.get_claims_batch(&ids);
+    assert_eq!(out.len(), 0u32);
+}
+
+#[test]
+fn get_claims_batch_full_batch_all_hits() {
+    let (env, client, token) = setup();
+    for id in 1..=CLAIM_BATCH_GET_MAX {
+        seed_claim(&env, &client, &token, id as u64);
+    }
+
+    let mut ids = Vec::new(&env);
+    for id in 1..=CLAIM_BATCH_GET_MAX {
+        ids.push_back(id as u64);
+    }
+
+    let out = client.get_claims_batch(&ids);
+    assert_eq!(out.len(), CLAIM_BATCH_GET_MAX);
+    for i in 0..CLAIM_BATCH_GET_MAX {
+        let claim = out.get(i).unwrap().unwrap();
+        assert_eq!(claim.claim_id, (i + 1) as u64);
+    }
+}
+
+#[test]
+fn get_claims_batch_partial_hits_keep_none_positions() {
+    let (env, client, token) = setup();
+    seed_claim(&env, &client, &token, 1);
+    seed_claim(&env, &client, &token, 3);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(1u64);
+    ids.push_back(2u64);
+    ids.push_back(3u64);
+
+    let out = client.get_claims_batch(&ids);
+    assert_eq!(out.len(), 3u32);
+    assert_eq!(out.get(0).unwrap().unwrap().claim_id, 1);
+    assert!(out.get(1).unwrap().is_none());
+    assert_eq!(out.get(2).unwrap().unwrap().claim_id, 3);
+}
+
+#[test]
+fn get_claims_batch_over_cap_reverts() {
+    let (env, client, _) = setup();
+    let mut ids = Vec::new(&env);
+    for id in 0..=CLAIM_BATCH_GET_MAX {
+        ids.push_back(id as u64);
+    }
+
+    let err = client.try_get_claims_batch(&ids).err().unwrap().unwrap();
+    assert_eq!(err, ValidateError::ClaimBatchTooLarge.into());
+}

--- a/contracts/niffyinsure/tests/protocol_fee.rs
+++ b/contracts/niffyinsure/tests/protocol_fee.rs
@@ -1,0 +1,202 @@
+//! Protocol fee configuration and premium split tests.
+
+#![cfg(test)]
+
+use niffyinsure::{
+    types::{AgeBand, CoverageTier, PolicyType, PROTOCOL_FEE_BPS_MAX, RegionTier},
+    validate::Error as ValidateError,
+    NiffyInsureClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+fn setup() -> (Env, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(issuer).address();
+    client.initialize(&admin, &token);
+    (env, client, admin, token)
+}
+
+fn fund_holder(env: &Env, client: &NiffyInsureClient<'_>, token: &Address, holder: &Address) {
+    let amount = 100_000_000i128;
+    token::StellarAssetClient::new(env, token).mint(holder, &amount);
+    token::Client::new(env, token).approve(
+        holder,
+        &client.address,
+        &amount,
+        &(env.ledger().sequence() + 10_000),
+    );
+}
+
+fn initiate_policy(
+    client: &NiffyInsureClient,
+    holder: &Address,
+    token: &Address,
+) -> niffyinsure::types::Policy {
+    client.initiate_policy(
+        holder,
+        &PolicyType::Auto,
+        &RegionTier::Medium,
+        &AgeBand::Adult,
+        &CoverageTier::Standard,
+        &80,
+        &1_000_000,
+        token,
+        &niffyinsure::types::InitiatePolicyOptions {
+            beneficiary: None,
+            deductible: None,
+            expected_nonce: None,
+        },
+    )
+}
+
+#[test]
+fn zero_fee_sends_full_premium_to_treasury() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+
+    client.admin_set_fee_recipient(&recipient);
+    client.admin_set_protocol_fee_bps(&0u32);
+
+    let quote = client
+        .generate_premium_for_asset(
+        &niffyinsure::types::RiskInput {
+            region: RegionTier::Medium,
+            age_band: AgeBand::Adult,
+            coverage: CoverageTier::Standard,
+            safety_score: 80,
+        },
+        &1_000_000,
+        &false,
+        token.clone(),
+    )
+    .unwrap();
+    let premium = quote.total_premium;
+
+    initiate_policy(&client, &holder, &token);
+
+    assert_eq!(client.get_protocol_fee_bps(), 0);
+    assert_eq!(client.get_fee_recipient(), recipient);
+    assert_eq!(client.get_treasury_balance(), premium);
+    assert_eq!(token::StellarAssetClient::new(&env, &token).balance(&recipient), 0);
+}
+
+#[test]
+fn non_zero_fee_splits_premium_between_treasury_and_recipient() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+
+    client.admin_set_fee_recipient(&recipient);
+    client.admin_set_protocol_fee_bps(&250u32);
+
+    let premium = client
+        .generate_premium_for_asset(
+            &niffyinsure::types::RiskInput {
+                region: RegionTier::Medium,
+                age_band: AgeBand::Adult,
+                coverage: CoverageTier::Standard,
+                safety_score: 80,
+            },
+            &1_000_000,
+            &false,
+            token.clone(),
+        )
+        .unwrap()
+        .total_premium;
+    let fee = premium * 250 / 10_000;
+
+    initiate_policy(&client, &holder, &token);
+
+    assert_eq!(token::StellarAssetClient::new(&env, &token).balance(&recipient), fee);
+    assert_eq!(client.get_treasury_balance(), premium - fee);
+}
+
+#[test]
+fn max_fee_is_allowed_and_calculated_correctly() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+
+    client.admin_set_fee_recipient(&recipient);
+    client.admin_set_protocol_fee_bps(&PROTOCOL_FEE_BPS_MAX);
+
+    let premium = client
+        .generate_premium_for_asset(
+            &niffyinsure::types::RiskInput {
+                region: RegionTier::Medium,
+                age_band: AgeBand::Adult,
+                coverage: CoverageTier::Standard,
+                safety_score: 80,
+            },
+            &1_000_000,
+            &false,
+            token.clone(),
+        )
+        .unwrap()
+        .total_premium;
+    let fee = premium * (PROTOCOL_FEE_BPS_MAX as i128) / 10_000;
+
+    initiate_policy(&client, &holder, &token);
+
+    assert_eq!(token::StellarAssetClient::new(&env, &token).balance(&recipient), fee);
+    assert_eq!(client.get_treasury_balance(), premium - fee);
+}
+
+#[test]
+fn fee_recipient_update_is_used_for_subsequent_premiums() {
+    let (env, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    let first_recipient = Address::generate(&env);
+    let second_recipient = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+
+    client.admin_set_fee_recipient(&first_recipient);
+    client.admin_set_fee_recipient(&second_recipient);
+    client.admin_set_protocol_fee_bps(&500u32);
+
+    let premium = client
+        .generate_premium_for_asset(
+            &niffyinsure::types::RiskInput {
+                region: RegionTier::Medium,
+                age_band: AgeBand::Adult,
+                coverage: CoverageTier::Standard,
+                safety_score: 80,
+            },
+            &1_000_000,
+            &false,
+            token.clone(),
+        )
+        .unwrap()
+        .total_premium;
+    let fee = premium * 500 / 10_000;
+
+    initiate_policy(&client, &holder, &token);
+
+    assert_eq!(client.get_fee_recipient(), second_recipient);
+    assert_eq!(token::StellarAssetClient::new(&env, &token).balance(&first_recipient), 0);
+    assert_eq!(token::StellarAssetClient::new(&env, &token).balance(&second_recipient), fee);
+}
+
+#[test]
+fn protocol_fee_above_max_reverts() {
+    let (env, client, _, _) = setup();
+    let err = client
+        .try_admin_set_protocol_fee_bps(&(PROTOCOL_FEE_BPS_MAX + 1))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, ValidateError::ProtocolFeeOutOfBounds.into());
+}

--- a/contracts/niffyinsure/tests/protocol_fee.rs
+++ b/contracts/niffyinsure/tests/protocol_fee.rs
@@ -79,8 +79,7 @@ fn zero_fee_sends_full_premium_to_treasury() {
         &1_000_000,
         &false,
         token.clone(),
-    )
-    .unwrap();
+    );
     let premium = quote.total_premium;
 
     initiate_policy(&client, &holder, &token);
@@ -113,7 +112,6 @@ fn non_zero_fee_splits_premium_between_treasury_and_recipient() {
             &false,
             token.clone(),
         )
-        .unwrap()
         .total_premium;
     let fee = premium * 250 / 10_000;
 
@@ -145,7 +143,6 @@ fn max_fee_is_allowed_and_calculated_correctly() {
             &false,
             token.clone(),
         )
-        .unwrap()
         .total_premium;
     let fee = premium * (PROTOCOL_FEE_BPS_MAX as i128) / 10_000;
 
@@ -179,7 +176,6 @@ fn fee_recipient_update_is_used_for_subsequent_premiums() {
             &false,
             token.clone(),
         )
-        .unwrap()
         .total_premium;
     let fee = premium * 500 / 10_000;
 

--- a/contracts/niffyinsure/tests/solvency.rs
+++ b/contracts/niffyinsure/tests/solvency.rs
@@ -1,0 +1,127 @@
+//! Solvency-ratio gate tests for policy initiation.
+
+#![cfg(test)]
+
+use niffyinsure::{
+    types::{
+        AgeBand, CoverageTier, MIN_SOLVENCY_RATIO_BPS_MAX, PolicyType, RegionTier,
+    },
+    validate::Error as ValidateError,
+    NiffyInsureClient, PolicyError,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+fn setup() -> (Env, Address, NiffyInsureClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let contract_id = env.register(niffyinsure::NiffyInsure, ());
+    let client = NiffyInsureClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(issuer).address();
+    client.initialize(&admin, &token);
+    (env, contract_id, client, admin, token)
+}
+
+fn fund_holder(env: &Env, client: &NiffyInsureClient<'_>, token: &Address, holder: &Address) {
+    let amount = 100_000_000i128;
+    token::StellarAssetClient::new(env, token).mint(holder, &amount);
+    token::Client::new(env, token).approve(
+        holder,
+        &client.address,
+        &amount,
+        &(env.ledger().sequence() + 10_000),
+    );
+}
+
+fn initiate(
+    client: &NiffyInsureClient,
+    holder: &Address,
+    token: &Address,
+    coverage: i128,
+) -> Result<niffyinsure::types::Policy, Result<PolicyError, soroban_sdk::InvokeError>> {
+    client.try_initiate_policy(
+        holder,
+        &PolicyType::Auto,
+        &RegionTier::Medium,
+        &AgeBand::Adult,
+        &CoverageTier::Standard,
+        &80,
+        &coverage,
+        token,
+        &niffyinsure::types::InitiatePolicyOptions {
+            beneficiary: None,
+            deductible: None,
+            expected_nonce: None,
+        },
+    )
+}
+
+#[test]
+fn solvent_state_allows_policy_initiation() {
+    let (env, contract_id, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+    token::StellarAssetClient::new(&env, &token).mint(&contract_id, &2_000_000i128);
+
+    client.admin_set_min_solvency_ratio_bps(&10_000u32);
+
+    let policy = initiate(&client, &holder, &token, 1_000_000)
+        .expect("2:1 treasury coverage satisfies 100% solvency");
+    assert!(policy.is_active);
+}
+
+#[test]
+fn insolvent_state_reverts_policy_initiation() {
+    let (env, contract_id, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+    token::StellarAssetClient::new(&env, &token).mint(&contract_id, &499_999i128);
+
+    client.admin_set_min_solvency_ratio_bps(&5_000u32);
+
+    let err = initiate(&client, &holder, &token, 1_000_000)
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, PolicyError::InsufficientSolvency);
+}
+
+#[test]
+fn threshold_boundary_is_inclusive() {
+    let (env, contract_id, client, _, token) = setup();
+    let holder = Address::generate(&env);
+    fund_holder(&env, &client, &token, &holder);
+    token::StellarAssetClient::new(&env, &token).mint(&contract_id, &500_000i128);
+
+    client.admin_set_min_solvency_ratio_bps(&5_000u32);
+
+    let policy = initiate(&client, &holder, &token, 1_000_000)
+        .expect("exactly 50% ratio should satisfy a 5_000 bps threshold");
+    assert!(policy.is_active);
+}
+
+#[test]
+fn admin_can_update_threshold_within_bounds() {
+    let (_env, _contract_id, client, _, _) = setup();
+    client.admin_set_min_solvency_ratio_bps(&MIN_SOLVENCY_RATIO_BPS_MAX);
+    assert_eq!(
+        client.get_min_solvency_ratio_bps(),
+        MIN_SOLVENCY_RATIO_BPS_MAX
+    );
+}
+
+#[test]
+fn admin_cannot_update_threshold_above_bounds() {
+    let (_env, _contract_id, client, _, _) = setup();
+    let err = client
+        .try_admin_set_min_solvency_ratio_bps(&(MIN_SOLVENCY_RATIO_BPS_MAX + 1))
+        .err()
+        .unwrap()
+        .unwrap();
+    assert_eq!(err, ValidateError::SolvencyRatioOutOfBounds.into());
+}


### PR DESCRIPTION
closes #601
closes #600
closes #595
closes #594

209d177 Add vote delegation support
Added vote delegation storage, delegation entrypoint, active delegation checks, circular delegation rejection, delegated vote weight aggregation, and delegation tests.

008bddb Add protocol fee collection
Added configurable protocol_fee_bps and fee_recipient, admin setters with events, premium fee splitting at policy initiation, ProtocolFeeCollected event, and protocol fee tests.

5d1a5dc Add solvency ratio gate
Added min_solvency_ratio_bps, admin setter with event, check_solvency_ratio(new_coverage), policy initiation solvency rejection via InsufficientSolvency, and solvency boundary tests.

371dbc9 Add claims batch query
Added get_claims_batch(Vec<u64>) -> Vec<Option<Claim>> with cap enforcement, missing-ID None behavior, tests, and backend /chain/claims/batch simulation support.