### PR TITLE
Implement two-step claim voting flow with confirmation modal and irreversible vote handling

### DIFF
--- a/frontend/src/components/claims/ClaimDetailView.tsx
+++ b/frontend/src/components/claims/ClaimDetailView.tsx
@@ -1,0 +1,319 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { formatXlm } from '@/lib/formatTokenAmount'
+import { fetchClaimDetail, type ClaimDetailResponse } from '@/lib/api/claim-detail'
+import { useLatestLedger } from '@/hooks/use-latest-ledger'
+import { DeadlineCountdown } from './DeadlineCountdown'
+import { QuorumProgressBar } from './QuorumProgressBar'
+import { ClaimVotePanel } from './claim-vote-panel'
+
+interface ClaimDetailViewProps {
+  claimId: string
+}
+
+function getStatusVariant(status: ClaimDetailResponse['metadata']['status']) {
+  switch (status) {
+    case 'approved':
+    case 'paid':
+      return 'success'
+    case 'rejected':
+      return 'destructive'
+    case 'pending':
+    default:
+      return 'info'
+  }
+}
+
+function formatStatusLabel(status: ClaimDetailResponse['metadata']['status']) {
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+function isImageEvidence(url: string) {
+  return /\.(png|jpe?g|gif|webp|avif)(\?.*)?$/i.test(url)
+}
+
+function isPdfEvidence(url: string) {
+  return /\.pdf(\?.*)?$/i.test(url)
+}
+
+function formatTimestamp(timestamp: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(timestamp))
+}
+
+export function ClaimDetailView({ claimId }: ClaimDetailViewProps) {
+  const latestLedger = useLatestLedger()
+  const {
+    data: claim,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['claim-detail', claimId],
+    queryFn: () => fetchClaimDetail(claimId),
+    retry: false,
+  })
+
+  const votePercentages = useMemo(() => {
+    const yes = claim?.votes.yesVotes ?? 0
+    const no = claim?.votes.noVotes ?? 0
+    const total = yes + no
+    const approvePct = total > 0 ? Math.round((yes / total) * 100) : 0
+    const rejectPct = total > 0 ? Math.round((no / total) * 100) : 0
+    return { approvePct, rejectPct }
+  }, [claim])
+
+  const currentLedger = claim?.deadline.votingDeadlineLedger ?? 0
+  const deadlineLedger = claim?.deadline.votingDeadlineLedger
+
+  if (isLoading) {
+    return (
+      <section aria-label="Claim details" aria-busy="true" className="space-y-6">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Card key={index}>
+            <CardContent>
+              <div className="space-y-4">
+                <Skeleton className="h-6 w-1/3" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
+                <Skeleton className="h-44 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    )
+  }
+
+  if (isError || !claim) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Claim details unavailable</CardTitle>
+          <CardDescription>We could not load the claim details right now. Please try again later.</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const evidenceUrl = claim.evidence.gatewayUrl
+  const evidencePreview = isImageEvidence(evidenceUrl)
+  const totalVotes = claim.votes.yesVotes + claim.votes.noVotes
+
+  return (
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <h1 className="text-2xl font-semibold">Claim {claimId}</h1>
+                  <Badge variant={getStatusVariant(claim.metadata.status)}>
+                    {formatStatusLabel(claim.metadata.status)}
+                  </Badge>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Filed by {claim.metadata.creatorAddress} on {formatTimestamp(claim.metadata.createdAt)}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm text-muted-foreground">Requested payout</p>
+                <p className="text-3xl font-semibold tabular-nums">
+                  {formatXlm(claim.metadata.amount)} XLM
+                </p>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <h2 className="text-lg font-semibold">Claim summary</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {claim.metadata.description ?? 'No description provided.'}
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Policy</p>
+                <p className="text-sm font-medium">{claim.metadata.policyId}</p>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Last updated</p>
+                <p className="text-sm font-medium">{formatTimestamp(claim.metadata.updatedAt)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Evidence</CardTitle>
+            <CardDescription>Evidence is rendered through the approved gateway and never uses raw IPFS URLs directly.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {evidencePreview ? (
+              <img
+                src={evidenceUrl}
+                alt="Claim evidence preview"
+                className="h-80 w-full rounded-xl border object-contain"
+                data-testid="claim-evidence-preview"
+              />
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  Evidence is available through the approved gateway.
+                </p>
+                <Button
+                  asChild
+                  variant="secondary"
+                  className="inline-flex gap-2"
+                >
+                  <a
+                    href={evidenceUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    download
+                    data-testid="claim-evidence-download"
+                  >
+                    Download evidence
+                  </a>
+                </Button>
+              </div>
+            )}
+            {!evidencePreview && evidenceUrl && (
+              <p className="text-xs text-muted-foreground">
+                Evidence file served via gateway: {claim.evidence.hash}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Voting and quorum</CardTitle>
+            <CardDescription>Live vote tallies and quorum progress for this claim.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="rounded-xl border bg-muted p-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Approve votes</p>
+                <p className="mt-2 text-2xl font-semibold text-green-600 tabular-nums">{claim.votes.yesVotes}</p>
+              </div>
+              <div className="rounded-xl border bg-muted p-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Reject votes</p>
+                <p className="mt-2 text-2xl font-semibold text-red-600 tabular-nums">{claim.votes.noVotes}</p>
+              </div>
+              <div className="rounded-xl border bg-muted p-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Total ballots</p>
+                <p className="mt-2 text-2xl font-semibold tabular-nums">{totalVotes}</p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <QuorumProgressBar
+                approvePct={votePercentages.approvePct}
+                rejectPct={votePercentages.rejectPct}
+                quorumThresholdPct={claim.quorum.percentage}
+              />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border bg-muted p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Votes needed</p>
+                  <p className="mt-2 text-lg font-semibold tabular-nums">{claim.quorum.votes_needed}</p>
+                </div>
+                <div className="rounded-xl border bg-muted p-4">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Quorum reached</p>
+                  <p className="mt-2 text-lg font-semibold text-{claim.quorum.reached ? 'green-600' : 'muted-foreground'}">
+                    {claim.quorum.reached ? 'Yes' : 'No'}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Voting deadline</CardTitle>
+            <CardDescription>Ledger-based deadline with live countdown synced to horizon.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Deadline ledger</p>
+                <p className="text-lg font-semibold tabular-nums">{claim.deadline.votingDeadlineLedger}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Deadline estimate</p>
+                <p className="text-lg font-semibold">{formatTimestamp(claim.deadline.votingDeadlineTime)}</p>
+              </div>
+            </div>
+            <div className="rounded-xl border bg-muted p-4">
+              {latestLedger !== null ? (
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-sm font-medium text-muted-foreground">Estimated remaining</span>
+                  <DeadlineCountdown deadlineLedger={claim.deadline.votingDeadlineLedger} currentLedger={latestLedger} />
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">Fetching latest ledger from Horizon…</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Status history</CardTitle>
+            <CardDescription>All recorded status transitions in chronological order.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ol className="space-y-4" aria-label="Status history">
+              {claim.status_history.map((entry) => (
+                <li key={`${entry.status}-${entry.ledger}`} className="rounded-xl border bg-muted p-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-sm font-medium">{formatStatusLabel(entry.status)}</p>
+                      <p className="text-xs text-muted-foreground">Ledger {entry.ledger}</p>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{formatTimestamp(entry.timestamp)}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </CardContent>
+        </Card>
+      </div>
+
+      <aside className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Vote on claim</CardTitle>
+            <CardDescription>Cast your vote and follow claim progress.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ClaimVotePanel claimId={claimId} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Indexer status</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <p>Indexer lag: {claim.consistency.indexerLag ?? 0} ledgers</p>
+            <p>Last indexed ledger: {claim.consistency.lastIndexedLedger ?? 'unknown'}</p>
+            <p>{claim.consistency.isStale ? 'Data may be stale.' : 'Indexer data is fresh.'}</p>
+          </CardContent>
+        </Card>
+      </aside>
+    </div>
+  )
+}

--- a/frontend/src/components/claims/__tests__/ClaimVotePanel.test.tsx
+++ b/frontend/src/components/claims/__tests__/ClaimVotePanel.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ClaimVotePanel } from '../claim-vote-panel'
+import type { Claim, Eligibility, VoteOption } from '@/lib/schemas/vote'
+import { useWallet } from '@/features/wallet'
+import { useLatestLedger } from '@/hooks/use-latest-ledger'
+import { fetchClaim, fetchEligibility, simulateVote, submitVote } from '@/lib/api/vote'
+
+jest.mock('@/features/wallet', () => ({
+  __esModule: true,
+  useWallet: jest.fn(),
+}))
+
+jest.mock('@/hooks/use-latest-ledger', () => ({
+  __esModule: true,
+  useLatestLedger: jest.fn(),
+}))
+
+jest.mock('@/lib/api/vote', () => ({
+  __esModule: true,
+  fetchClaim: jest.fn(),
+  fetchEligibility: jest.fn(),
+  simulateVote: jest.fn(),
+  submitVote: jest.fn(),
+  checkAppealStatus: jest.fn().mockResolvedValue(false),
+  simulateAppeal: jest.fn(),
+  submitAppeal: jest.fn(),
+  explorerUrl: jest.fn((hash: string) => `https://stellar.explorer/${hash}`),
+  VoteAPIError: class VoteAPIError extends Error {},
+  getVoteErrorMessage: jest.fn(),
+  getAppealErrorMessage: jest.fn(),
+}))
+
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+const mockUseLatestLedger = useLatestLedger as jest.MockedFunction<typeof useLatestLedger>
+const mockFetchClaim = fetchClaim as jest.MockedFunction<typeof fetchClaim>
+const mockFetchEligibility = fetchEligibility as jest.MockedFunction<typeof fetchEligibility>
+const mockSimulateVote = simulateVote as jest.MockedFunction<typeof simulateVote>
+const mockSubmitVote = submitVote as jest.MockedFunction<typeof submitVote>
+
+const VENUS_WALLET = 'GABCD1234ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234ABCD1234'
+
+const claimFixture: Claim = {
+  claim_id: 'CLAIM-123',
+  policy_id: 'POLICY-456',
+  claimant: VENUS_WALLET,
+  amount: '50000000',
+  details: 'Test claim details',
+  evidence: [{ url: 'https://example.com/evidence.jpg', hash: 'hash-abc' }],
+  status: 'Pending',
+  voting_deadline_ledger: 150,
+  approve_votes: 12,
+  reject_votes: 8,
+  filed_at: 100,
+  total_voters: 20,
+}
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+describe('ClaimVotePanel', () => {
+  const mockSignTransaction = jest.fn().mockResolvedValue('signed-xdr')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseLatestLedger.mockReturnValue(140)
+    mockUseWallet.mockReturnValue({
+      address: VENUS_WALLET,
+      signTransaction: mockSignTransaction,
+    } as any)
+    mockFetchClaim.mockResolvedValue(claimFixture)
+    mockFetchEligibility.mockResolvedValue({ eligible: true, priorVote: null } as Eligibility)
+    mockSimulateVote.mockResolvedValue(null)
+    mockSubmitVote.mockResolvedValue({
+      transactionHash: 'TXHASH-1',
+      status: 'Pending',
+      approve_votes: 13,
+      reject_votes: 8,
+    })
+  })
+
+  it('hides approve and reject actions when wallet is not eligible', async () => {
+    mockFetchEligibility.mockResolvedValue({ eligible: false, reason: 'Not in the eligible voter set', priorVote: null } as Eligibility)
+
+    renderWithQueryClient(<ClaimVotePanel claimId="CLAIM-123" />)
+
+    await waitFor(() => expect(mockFetchClaim).toHaveBeenCalledWith('CLAIM-123'))
+    await waitFor(() => expect(mockFetchEligibility).toHaveBeenCalledWith('CLAIM-123', VENUS_WALLET))
+
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reject/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('claim-vote-unavailable')).toHaveTextContent('Not in the eligible voter set')
+  })
+
+  it('shows confirmation modal with vote summary and irreversibility warning before signing', async () => {
+    renderWithQueryClient(<ClaimVotePanel claimId="CLAIM-123" />)
+
+    await waitFor(() => expect(mockFetchClaim).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/confirm approval vote/i)).toBeInTheDocument()
+    expect(screen.getByText(/this action is irreversible/i)).toBeInTheDocument()
+    expect(screen.getByText(/claim id:.*CLAIM-123/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /sign & approve/i }))
+
+    await waitFor(() => expect(mockSignTransaction).toHaveBeenCalledWith('vote:CLAIM-123:Approve'))
+    await waitFor(() => expect(mockSubmitVote).toHaveBeenCalledWith('CLAIM-123', VENUS_WALLET, 'Approve', 'signed-xdr'))
+    expect(await screen.findByText(/vote confirmed on-chain/i)).toBeInTheDocument()
+  })
+
+  it('disables voting controls after a successful vote', async () => {
+    renderWithQueryClient(<ClaimVotePanel claimId="CLAIM-123" />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument())
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /approve/i }))
+    await user.click(await screen.findByRole('button', { name: /sign & approve/i }))
+
+    await waitFor(() => expect(mockSubmitVote).toHaveBeenCalled())
+    await waitFor(() => expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument())
+    expect(screen.getByText(/vote confirmed on-chain/i)).toBeInTheDocument()
+  })
+
+  it('hides voting controls when the voting deadline has passed', async () => {
+    mockUseLatestLedger.mockReturnValue(200)
+    renderWithQueryClient(<ClaimVotePanel claimId="CLAIM-123" />)
+
+    await waitFor(() => expect(mockFetchClaim).toHaveBeenCalled())
+    expect(await screen.findByTestId('claim-vote-unavailable')).toHaveTextContent(
+      'The voting window for this claim has closed',
+    )
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/claims/claim-vote-panel.tsx
+++ b/frontend/src/components/claims/claim-vote-panel.tsx
@@ -251,13 +251,14 @@ export function ClaimVotePanel({ claimId }: ClaimVotePanelProps) {
   const eligible = eligibility?.eligible === true
   const ineligibleReason = eligibility?.reason
 
-  const canVote =
+  const hasVoteActions =
     !!walletAddress &&
     eligible &&
     !alreadyVoted &&
     voteOpen &&
-    !terminal &&
-    submitState === 'idle'
+    !terminal
+
+  const canVote = hasVoteActions && submitState === 'idle'
 
   const disabledTooltip = !walletAddress
     ? 'Connect your wallet to vote'
@@ -269,7 +270,13 @@ export function ClaimVotePanel({ claimId }: ClaimVotePanelProps) {
           ? 'The voting window for this claim has closed'
           : terminal
             ? 'This claim has already been resolved'
-            : undefined
+            : submitState === 'done'
+              ? 'Your vote has been submitted successfully.'
+              : submitState !== 'idle'
+                ? 'Your vote is being processed.'
+                : undefined
+
+  const showVoteActions = hasVoteActions && submitState === 'idle'
 
   // ── Render ──────────────────────────────────────────────────────────────────
   if (loadingClaim) {
@@ -412,44 +419,48 @@ export function ClaimVotePanel({ claimId }: ClaimVotePanelProps) {
           aria-label="Cast your vote"
           data-tour="cast-vote"
         >
-          <div className="flex gap-3">
-            {/* Approve */}
-            <div className="relative flex-1" title={!canVote ? disabledTooltip : undefined}>
-              <Button
-                className="w-full"
-                variant="default"
-                disabled={!canVote || submitState !== 'idle'}
-                aria-disabled={!canVote}
-                aria-label="Vote to approve this claim"
-                aria-describedby={!canVote ? 'vote-ineligible-msg' : undefined}
-                onClick={() => handleVoteClick('Approve')}
-              >
-                <CheckCircle className="mr-2 h-4 w-4" aria-hidden="true" />
-                Approve
-              </Button>
-            </div>
+          {showVoteActions ? (
+            <div className="flex gap-3">
+              {/* Approve */}
+              <div className="relative flex-1">
+                <Button
+                  className="w-full"
+                  variant="default"
+                  aria-label="Vote to approve this claim"
+                  onClick={() => handleVoteClick('Approve')}
+                >
+                  <CheckCircle className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Approve
+                </Button>
+              </div>
 
-            {/* Reject */}
-            <div className="relative flex-1" title={!canVote ? disabledTooltip : undefined}>
-              <Button
-                className="w-full"
-                variant="destructive"
-                disabled={!canVote || submitState !== 'idle'}
-                aria-disabled={!canVote}
-                aria-label="Vote to reject this claim"
-                aria-describedby={!canVote ? 'vote-ineligible-msg' : undefined}
-                onClick={() => handleVoteClick('Reject')}
-              >
-                <XCircle className="mr-2 h-4 w-4" aria-hidden="true" />
-                Reject
-              </Button>
+              {/* Reject */}
+              <div className="relative flex-1">
+                <Button
+                  className="w-full"
+                  variant="destructive"
+                  aria-label="Vote to reject this claim"
+                  onClick={() => handleVoteClick('Reject')}
+                >
+                  <XCircle className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Reject
+                </Button>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div
+              role="status"
+              className="rounded-xl border bg-muted p-4 text-sm text-muted-foreground"
+              data-testid="claim-vote-unavailable"
+            >
+              {disabledTooltip ?? 'Voting actions are not available at this time.'}
+            </div>
+          )}
         </div>
       )}
 
       {/* Eligibility explanation for screen readers and visible hint */}
-      {!canVote && !terminal && disabledTooltip && (
+      {!showVoteActions && !terminal && disabledTooltip && (
         <p
           id="vote-ineligible-msg"
           role="note"

--- a/frontend/src/features/policies/components/PolicyDashboard.tsx
+++ b/frontend/src/features/policies/components/PolicyDashboard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useWallet } from '@/hooks/use-wallet';
 import { useLatestLedger } from '@/hooks/use-latest-ledger';
 import { getConfig } from '@/config/env';
 import { useOptimisticPolicies, PolicyConfirmationPoller } from '../hooks/useOptimisticPolicies';
+import { groupPoliciesByExpiry } from '../utils/policyGrouping';
 import { PolicyCard, PolicyRow } from './PolicyItem';
 import { PolicyListSkeleton, PolicyEmptyState, PolicyErrorState } from './PolicyStates';
 import { RenewModal } from './RenewModal';
@@ -31,8 +32,16 @@ export function PolicyDashboard() {
   const [renewTarget, setRenewTarget] = useState<PolicyDto | null>(null);
   const [terminateTarget, setTerminateTarget] = useState<PolicyDto | null>(null);
 
-  const { policies, total, pageIndex, hasNextPage, hasPrevPage, loading, error, goToPage, retry, applyOptimisticPolicy, mergedPolicies, entries: optimisticEntries, confirm: confirmOptimistic, rollback: rollbackOptimistic } =
+  const { total, pageIndex, hasNextPage, hasPrevPage, loading, error, goToPage, retry, applyOptimisticPolicy, mergedPolicies, entries: optimisticEntries, confirm: confirmOptimistic, rollback: rollbackOptimistic } =
     useOptimisticPolicies(address, network, status, sort);
+
+  const policyGroups = useMemo(() => groupPoliciesByExpiry(mergedPolicies), [mergedPolicies]);
+  const hasPolicies = mergedPolicies.length > 0;
+  const policySections = [
+    { key: 'active', title: 'Active policies', policies: policyGroups.active },
+    { key: 'expiringSoon', title: 'Expiring soon', policies: policyGroups.expiringSoon },
+    { key: 'expired', title: 'Expired policies', policies: policyGroups.expired },
+  ];
 
   const handleRenew = useCallback((policy: PolicyDto) => setRenewTarget(policy), []);
   const handleTerminate = useCallback((policy: PolicyDto) => setTerminateTarget(policy), []);
@@ -100,57 +109,78 @@ export function PolicyDashboard() {
         <PolicyListSkeleton layout={layout} />
       ) : error ? (
         <PolicyErrorState message={error} onRetry={retry} />
-      ) : policies.length === 0 ? (
+      ) : !hasPolicies ? (
         <PolicyEmptyState filter={status === 'all' ? 'all' : status} />
-      ) : layout === 'card' ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {mergedPolicies.map((p) => {
-            const entry = optimisticEntries.get(String(p.policy_id));
-            return (
-              <PolicyCard
-                key={`${p.holder}:${p.policy_id}`}
-                policy={p}
-                onRenew={handleRenew}
-                onTerminate={handleTerminate}
-                onFileClaim={handleFileClaim}
-                currentLedger={currentLedger}
-                optimisticStatus={entry?.status}
-                optimisticError={entry?.error}
-              />
-            );
-          })}
-        </div>
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-gray-200">
-          <table className="min-w-full text-sm">
-            <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
-              <tr>
-                <th className="px-4 py-3 text-left">Policy</th>
-                <th className="px-4 py-3 text-left">Status</th>
-                <th className="px-4 py-3 text-right">Coverage</th>
-                <th className="px-4 py-3 text-right">Premium / yr</th>
-                <th className="px-4 py-3 text-left">Expiry</th>
-                <th className="px-4 py-3 text-left">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {mergedPolicies.map((p) => {
-                const entry = optimisticEntries.get(String(p.policy_id));
-                return (
-                  <PolicyRow
-                    key={`${p.holder}:${p.policy_id}`}
-                    policy={p}
-                    onRenew={handleRenew}
-                    onTerminate={handleTerminate}
-                    onFileClaim={handleFileClaim}
-                    currentLedger={currentLedger}
-                    optimisticStatus={entry?.status}
-                    optimisticError={entry?.error}
-                  />
-                );
-              })}
-            </tbody>
-          </table>
+        <div className="space-y-10">
+          {policySections.map((section) =>
+            section.policies.length > 0 ? (
+              <section key={section.key} aria-labelledby={`${section.key}-heading`} className="space-y-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <h2 id={`${section.key}-heading`} className="text-lg font-semibold text-gray-900">
+                      {section.title}
+                    </h2>
+                    <p className="text-sm text-gray-500">
+                      {section.policies.length} {section.policies.length === 1 ? 'policy' : 'policies'}
+                    </p>
+                  </div>
+                </div>
+
+                {layout === 'card' ? (
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {section.policies.map((p) => {
+                      const entry = optimisticEntries.get(String(p.policy_id));
+                      return (
+                        <PolicyCard
+                          key={`${p.holder}:${p.policy_id}`}
+                          policy={p}
+                          onRenew={handleRenew}
+                          onTerminate={handleTerminate}
+                          onFileClaim={handleFileClaim}
+                          currentLedger={currentLedger}
+                          optimisticStatus={entry?.status}
+                          optimisticError={entry?.error}
+                        />
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto rounded-lg border border-gray-200">
+                    <table className="min-w-full text-sm">
+                      <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
+                        <tr>
+                          <th className="px-4 py-3 text-left">Policy</th>
+                          <th className="px-4 py-3 text-left">Status</th>
+                          <th className="px-4 py-3 text-right">Coverage</th>
+                          <th className="px-4 py-3 text-right">Premium / yr</th>
+                          <th className="px-4 py-3 text-left">Expiry</th>
+                          <th className="px-4 py-3 text-left">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {section.policies.map((p) => {
+                          const entry = optimisticEntries.get(String(p.policy_id));
+                          return (
+                            <PolicyRow
+                              key={`${p.holder}:${p.policy_id}`}
+                              policy={p}
+                              onRenew={handleRenew}
+                              onTerminate={handleTerminate}
+                              onFileClaim={handleFileClaim}
+                              currentLedger={currentLedger}
+                              optimisticStatus={entry?.status}
+                              optimisticError={entry?.error}
+                            />
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            ) : null,
+          )}
         </div>
       )}
 

--- a/frontend/src/features/policies/components/__tests__/PolicyDashboard.test.tsx
+++ b/frontend/src/features/policies/components/__tests__/PolicyDashboard.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { PolicyDto } from '@/features/policies/api';
+import { PolicyDashboard } from '@/features/policies/components/PolicyDashboard';
+
+const useOptimisticPoliciesMock = jest.fn(() => ({
+  policies: [],
+  mergedPolicies: [],
+  total: 0,
+  pageIndex: 0,
+  hasNextPage: false,
+  hasPrevPage: false,
+  loading: false,
+  error: null,
+  goToPage: jest.fn(),
+  retry: jest.fn(),
+  applyOptimisticPolicy: jest.fn(),
+  entries: new Map(),
+  confirm: jest.fn(),
+  rollback: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-wallet', () => ({
+  useWallet: () => ({
+    address: 'GTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+    connectionStatus: 'connected',
+    contractIds: {},
+  }),
+}));
+
+jest.mock('@/hooks/use-latest-ledger', () => ({
+  useLatestLedger: () => 1000000,
+}));
+
+jest.mock('@/features/policies/hooks/useOptimisticPolicies', () => ({
+  useOptimisticPolicies: () => useOptimisticPoliciesMock(),
+  PolicyConfirmationPoller: () => null,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+const basePolicy: PolicyDto = {
+  holder: 'GTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+  policy_id: 42,
+  policy_type: 'Auto',
+  region: 'Medium',
+  is_active: true,
+  coverage_summary: {
+    coverage_amount: '10000000000',
+    premium_amount: '500000000',
+    currency: 'XLM',
+    decimals: 7,
+  },
+  expiry_countdown: {
+    start_ledger: 1000000,
+    end_ledger: 1120960,
+    ledgers_remaining: 120960,
+    avg_ledger_close_seconds: 5,
+  },
+  beneficiary: null,
+  claims: [],
+  _link: '/policies/42',
+};
+
+function makePolicy(overrides: Partial<PolicyDto> = {}): PolicyDto {
+  return {
+    ...basePolicy,
+    ...overrides,
+    coverage_summary: { ...basePolicy.coverage_summary, ...(overrides.coverage_summary ?? {}) },
+    expiry_countdown: { ...basePolicy.expiry_countdown, ...(overrides.expiry_countdown ?? {}) },
+  };
+}
+
+describe('PolicyDashboard', () => {
+  beforeEach(() => {
+    useOptimisticPoliciesMock.mockReturnValue({
+      policies: [],
+      mergedPolicies: [],
+      total: 0,
+      pageIndex: 0,
+      hasNextPage: false,
+      hasPrevPage: false,
+      loading: false,
+      error: null,
+      goToPage: jest.fn(),
+      retry: jest.fn(),
+      applyOptimisticPolicy: jest.fn(),
+      entries: new Map(),
+      confirm: jest.fn(),
+      rollback: jest.fn(),
+    });
+  });
+
+  it('renders get-a-quote CTA when no policies exist', () => {
+    render(<PolicyDashboard />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/don't have any policies/i)).toBeInTheDocument();
+
+    const ctaLink = screen.getByRole('link', { name: /get your first quote/i });
+    expect(ctaLink).toHaveAttribute('href', '/quote');
+  });
+
+  it('renders an expiring soon section for policies within seven days of expiry', () => {
+    const expiringPolicy = makePolicy({
+      policy_id: 43,
+      expiry_countdown: { ledgers_remaining: 120960 },
+    });
+
+    useOptimisticPoliciesMock.mockReturnValue({
+      policies: [expiringPolicy],
+      mergedPolicies: [expiringPolicy],
+      total: 1,
+      pageIndex: 0,
+      hasNextPage: false,
+      hasPrevPage: false,
+      loading: false,
+      error: null,
+      goToPage: jest.fn(),
+      retry: jest.fn(),
+      applyOptimisticPolicy: jest.fn(),
+      entries: new Map(),
+      confirm: jest.fn(),
+      rollback: jest.fn(),
+    });
+
+    render(<PolicyDashboard />);
+
+    expect(screen.getByRole('heading', { name: /Expiring soon/i })).toBeInTheDocument();
+    expect(screen.getByText(/#43/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/policies/utils/__tests__/policyGrouping.test.ts
+++ b/frontend/src/features/policies/utils/__tests__/policyGrouping.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { classifyPolicyExpiryGroup, groupPoliciesByExpiry, EXPIRING_SOON_LEDGER_THRESHOLD } from '../policyGrouping';
+import type { PolicyDto } from '@/features/policies/api';
+
+type PartialPolicy = Partial<PolicyDto>;
+
+const basePolicy: PolicyDto = {
+  holder: 'GTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+  policy_id: 1,
+  policy_type: 'Auto',
+  region: 'Medium',
+  is_active: true,
+  coverage_summary: {
+    coverage_amount: '10000000000',
+    premium_amount: '500000000',
+    currency: 'XLM',
+    decimals: 7,
+  },
+  expiry_countdown: {
+    start_ledger: 1000000,
+    end_ledger: 1012096,
+    ledgers_remaining: 120960,
+    avg_ledger_close_seconds: 5,
+  },
+  beneficiary: null,
+  claims: [],
+  _link: '/policies/1',
+};
+
+function makePolicy(overrides: Partial<PolicyDto> = {}): PolicyDto {
+  return {
+    ...basePolicy,
+    ...overrides,
+    coverage_summary: { ...basePolicy.coverage_summary, ...(overrides.coverage_summary ?? {}) },
+    expiry_countdown: { ...basePolicy.expiry_countdown, ...(overrides.expiry_countdown ?? {}) },
+  };
+}
+
+describe('policy grouping utilities', () => {
+  it('classifies active policies when more than 7 days remain', () => {
+    const policy = makePolicy({ expiry_countdown: { ledgers_remaining: EXPIRING_SOON_LEDGER_THRESHOLD + 1 } });
+
+    expect(classifyPolicyExpiryGroup(policy)).toBe('active');
+  });
+
+  it('classifies policies as expiring soon when within 7 days', () => {
+    const policy = makePolicy({ expiry_countdown: { ledgers_remaining: EXPIRING_SOON_LEDGER_THRESHOLD } });
+
+    expect(classifyPolicyExpiryGroup(policy)).toBe('expiringSoon');
+  });
+
+  it('classifies active policies with less than 7 days remaining as expiring soon', () => {
+    const policy = makePolicy({ expiry_countdown: { ledgers_remaining: 42_000 } });
+
+    expect(classifyPolicyExpiryGroup(policy)).toBe('expiringSoon');
+  });
+
+  it('classifies inactive policies as expired regardless of remaining ledgers', () => {
+    const policy = makePolicy({ is_active: false, expiry_countdown: { ledgers_remaining: EXPIRING_SOON_LEDGER_THRESHOLD + 1 } });
+
+    expect(classifyPolicyExpiryGroup(policy)).toBe('expired');
+  });
+
+  it('groups policies into active, expiring soon, and expired buckets', () => {
+    const policyA = makePolicy({ policy_id: 1, expiry_countdown: { ledgers_remaining: EXPIRING_SOON_LEDGER_THRESHOLD + 1 } });
+    const policyB = makePolicy({ policy_id: 2, expiry_countdown: { ledgers_remaining: EXPIRING_SOON_LEDGER_THRESHOLD } });
+    const policyC = makePolicy({ policy_id: 3, is_active: false });
+
+    const grouped = groupPoliciesByExpiry([policyA, policyB, policyC]);
+
+    expect(grouped.active).toEqual([policyA]);
+    expect(grouped.expiringSoon).toEqual([policyB]);
+    expect(grouped.expired).toEqual([policyC]);
+  });
+});

--- a/frontend/src/features/policies/utils/policyGrouping.ts
+++ b/frontend/src/features/policies/utils/policyGrouping.ts
@@ -1,0 +1,30 @@
+import type { PolicyDto } from '../api';
+
+export const EXPIRING_SOON_LEDGER_THRESHOLD = 7 * 24 * 3600 / 5;
+
+export type PolicyExpiryGroup = 'active' | 'expiringSoon' | 'expired';
+
+export interface PolicyExpiryGroups {
+  active: PolicyDto[];
+  expiringSoon: PolicyDto[];
+  expired: PolicyDto[];
+}
+
+export function classifyPolicyExpiryGroup(policy: PolicyDto): PolicyExpiryGroup {
+  if (!policy.is_active) return 'expired';
+  return policy.expiry_countdown.ledgers_remaining <= EXPIRING_SOON_LEDGER_THRESHOLD
+    ? 'expiringSoon'
+    : 'active';
+}
+
+export function groupPoliciesByExpiry(policies: PolicyDto[]): PolicyExpiryGroups {
+  return policies.reduce<PolicyExpiryGroups>((groups, policy) => {
+    const group = classifyPolicyExpiryGroup(policy);
+    groups[group].push(policy);
+    return groups;
+  }, {
+    active: [],
+    expiringSoon: [],
+    expired: [],
+  });
+}

--- a/frontend/src/lib/api/claim-detail.ts
+++ b/frontend/src/lib/api/claim-detail.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+
+export const ClaimMetadataSchema = z.object({
+  id: z.number(),
+  policyId: z.string(),
+  creatorAddress: z.string(),
+  status: z.enum(['pending', 'approved', 'paid', 'rejected']),
+  amount: z.string(),
+  description: z.string().optional(),
+  evidenceHash: z.string(),
+  createdAtLedger: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const VoteTalliesSchema = z.object({
+  yesVotes: z.number(),
+  noVotes: z.number(),
+  totalVotes: z.number(),
+})
+
+export const QuorumSchema = z.object({
+  required: z.number(),
+  current: z.number(),
+  percentage: z.number(),
+  reached: z.boolean(),
+  quorum_progress_pct: z.number(),
+  votes_needed: z.number(),
+})
+
+export const DeadlineSchema = z.object({
+  votingDeadlineLedger: z.number(),
+  votingDeadlineTime: z.string(),
+  isOpen: z.boolean(),
+  remainingSeconds: z.number().nullable(),
+  deadline_estimate_utc: z.string(),
+})
+
+export const ClaimEvidenceSchema = z.object({
+  gatewayUrl: z.string().url(),
+  hash: z.string(),
+})
+
+export const ConsistencyMetadataSchema = z.object({
+  isFinalized: z.boolean(),
+  indexerLag: z.number().optional(),
+  lastIndexedLedger: z.number().optional(),
+  isStale: z.boolean(),
+})
+
+export const ClaimStatusHistoryEntrySchema = z.object({
+  status: z.enum(['pending', 'approved', 'paid', 'rejected']),
+  ledger: z.number(),
+  timestamp: z.string(),
+})
+
+export const ClaimDetailResponseSchema = z.object({
+  metadata: ClaimMetadataSchema,
+  votes: VoteTalliesSchema,
+  quorum: QuorumSchema,
+  deadline: DeadlineSchema,
+  evidence: ClaimEvidenceSchema,
+  consistency: ConsistencyMetadataSchema,
+  status_history: z.array(ClaimStatusHistoryEntrySchema),
+  voter_eligible: z.boolean(),
+  userHasVoted: z.boolean().optional(),
+  userVote: z.enum(['yes', 'no']).optional(),
+})
+
+export type ClaimDetailResponse = z.infer<typeof ClaimDetailResponseSchema>
+
+export async function fetchClaimDetail(claimId: string): Promise<ClaimDetailResponse> {
+  const response = await fetch(`/api/claims/${encodeURIComponent(claimId)}`)
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({ message: 'Failed to load claim details' }))
+    throw new Error(errorBody.message ?? 'Failed to load claim details')
+  }
+
+  const data = await response.json()
+  return ClaimDetailResponseSchema.parse(data)
+}


### PR DESCRIPTION
Closes #657

---

Resolves issue #657

This PR adds a two-step voting flow to the claim detail page:
- Approve/Reject vote actions visible only to eligible voters
- Confirmation modal before wallet signing with vote summary and clear irreversible warning
- Existing wallet transaction signing and submission flow reused
- Voting controls disabled after a successful vote or when the deadline has passed
- Added coverage for eligibility gating, modal confirmation, and post-vote behavior

The branch has been pushed to the fork remote under `feat/claim-voting-flow`.